### PR TITLE
Fix non unicode export/import of ø and Ø.

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -173,13 +173,13 @@ var mappingTable = {
 	"\u00C6":"{\\AE}", // LATIN CAPITAL LETTER AE
 	"\u00D0":"{\\DH}", // LATIN CAPITAL LETTER ETH
 	"\u00D7":"{\\texttimes}", // MULTIPLICATION SIGN
-	"\U00D8":"{\\O}", // LATIN CAPITAL LETTER O WITH STROKE
+	"\u00D8":"{\\O}", // LATIN CAPITAL LETTER O WITH STROKE
 	"\u00DE":"{\\TH}", // LATIN CAPITAL LETTER THORN
 	"\u00DF":"{\\ss}", // LATIN SMALL LETTER SHARP S
 	"\u00E6":"{\\ae}", // LATIN SMALL LETTER AE
 	"\u00F0":"{\\dh}", // LATIN SMALL LETTER ETH
 	"\u00F7":"{\\textdiv}", // DIVISION SIGN
-	"\U00F8":"{\\o}", // LATIN SMALL LETTER O WITH STROKE
+	"\u00F8":"{\\o}", // LATIN SMALL LETTER O WITH STROKE
 	"\u00FE":"{\\th}", // LATIN SMALL LETTER THORN
 	"\u0131":"{\\i}", // LATIN SMALL LETTER DOTLESS I
 	"\u0132":"IJ", // LATIN CAPITAL LIGATURE IJ
@@ -1098,13 +1098,13 @@ var reversemappingTable = {
 	"{\\AE}"                          : "\u00C6", // LATIN CAPITAL LETTER AE
 	"{\\DH}"                          : "\u00D0", // LATIN CAPITAL LETTER ETH
 	"{\\texttimes}"                   : "\u00D7", // MULTIPLICATION SIGN
-	"{\\O}"                          : "\U00D8", // LATIN SMALL LETTER O WITH STROKE
+	"{\\O}"                          : "\u00D8", // LATIN SMALL LETTER O WITH STROKE
 	"{\\TH}"                          : "\u00DE", // LATIN CAPITAL LETTER THORN
 	"{\\ss}"                          : "\u00DF", // LATIN SMALL LETTER SHARP S
 	"{\\ae}"                          : "\u00E6", // LATIN SMALL LETTER AE
 	"{\\dh}"                          : "\u00F0", // LATIN SMALL LETTER ETH
 	"{\\textdiv}"                     : "\u00F7", // DIVISION SIGN
-	"{\\o}"                          : "\U00F8", // LATIN SMALL LETTER O WITH STROKE
+	"{\\o}"                          : "\u00F8", // LATIN SMALL LETTER O WITH STROKE
 	"{\\th}"                          : "\u00FE", // LATIN SMALL LETTER THORN
 	"{\\i}"                           : "\u0131", // LATIN SMALL LETTER DOTLESS I
 	"'n"                              : "\u0149", // LATIN SMALL LETTER N PRECEDED BY APOSTROPHE


### PR DESCRIPTION
There seems to be a bug in the mappingtables where the u in the unicode
characters for ø and Ø  ie \o and \O are written as a big U and thus does not work. 
This should fix that problem. 
