### PR TITLE
Emerald

### DIFF
--- a/Emerald Publishing.js
+++ b/Emerald Publishing.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "79f6f9ed-537a-4d4f-8270-c4fbaafdf327",
 	"label": "Emerald Publishing",
-	"creator": "Michael Berkowitz",
+	"creator": "Sebastian Karcher",
 	"target": "^https?://(www\\.)?emeraldinsight\\.com",
 	"minVersion": "1.0.0b4.r5",
 	"maxVersion": "",


### PR DESCRIPTION
new FW translator for emerald insight, replacing old defunct one. Works for Journal articles and searches, does not work for cases and books (that looks possible, but a lot more work).
Has tests (with proxy removed), GPL and improved regexp.
