### PR TITLE
embed metadata - add abstract. RePec - disable

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -47,7 +47,8 @@ var HIGHWIRE_MAPPINGS = {
 	"citation_technical_report_institution":"institution",
 	"citation_technical_report_number":"number",
 	"citation_issn":"ISSN",
-	"citation_isbn":"ISBN"
+	"citation_isbn":"ISBN",
+	"citation_abstract":"abstractNote"
 };
 
 // Maps actual prefix in use to URI

--- a/RePEc.js
+++ b/RePEc.js
@@ -27,7 +27,7 @@ function detectWeb(doc, url) {
 		if(doc.evaluate(multXpath, doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent.indexOf("Search")!=-1)
 			return "multiple";
 	} else if(doc.evaluate(singXpath, doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext()) {
-		return "report";
+		return false;
 	}
 }
 


### PR DESCRIPTION
add abstract to metadata translator. Disable RePEc, which works better with metadata
