### PR TITLE
Remove E4X from Flickr.js. Still has a problem with saving photos.

### DIFF
--- a/Flickr.js
+++ b/Flickr.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "g",
-	"lastUpdated": "2011-12-02 23:53:49"
+	"lastUpdated": "2011-12-03 00:04:20"
 }
 
 function detectWeb(doc, url) {
@@ -89,7 +89,8 @@ function doWeb(doc, url) {
 		
 		var title;
 		if ((title = ZU.xpathText(doc, '//photo/title'))) {
-			newItem.title = ZU.trimInternal(title);
+			title = ZU.trimInternal(title);
+			newItem.title = title;
 		} else {
 			newItem.title = " ";
 		}


### PR DESCRIPTION
First commit for rewriting flickr.js (more to follow).

I did get stuck with saving attachments, though:

`var last = ZU.xpath(doc, '//size').length - 1;
var attachmentUri = ZU.xpathText(doc, '//size[last]/@source');`
doesn't work, while

`var attachmentUri = ZU.xpathText(doc, '//size[5]/@source');`
does work. I don't get an error for the first case, just nothing gets selected.
