### PR TITLE
Some fixes to how author names are handled in WIley Online and Embeded Metadata

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2012-03-22 16:01:47"
+	"lastUpdated": "2012-03-22 22:32:52"
 }
 
 /*
@@ -116,6 +116,16 @@ function getContentText(doc, name) {
 function getContent(doc, name) {
 	return ZU.xpath(doc, '//meta[substring(@name, string-length(@name)-'
 							+ (name.length - 1) + ')="'+ name +'"]/@content');
+}
+
+function fixCase(authorName) {
+	//fix case if all upper or all lower case
+	if(authorName.toUpperCase() === authorName ||
+		authorName.toLowerCase() === authorName) {
+		return ZU.capitalizeTitle(authorName, true);
+	}
+
+	return authorName;
 }
 
 function processFields(doc, item, fieldMap) {
@@ -553,8 +563,8 @@ function addHighwireMetadata(doc, newItem) {
 			author = ZU.cleanAuthor(author, "author", author.indexOf(",") !== -1);
 			if(author.firstName) {
 				//fix case for personal names
-				author.firstName = ZU.capitalizeTitle(author.firstName, true);
-				author.lastName = ZU.capitalizeTitle(author.lastName, true);
+				author.firstName = fixCase(author.firstName);
+				author.lastName = fixCase(author.lastName);
 			}
 			newItem.creators.push(author);
 		}

--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2012-03-22 18:37:56"
+	"lastUpdated": "2012-03-22 22:30:17"
 }
 
 /*
@@ -30,6 +30,15 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+function fixCase(authorName) {
+	if(authorName.toUpperCase() == authorName ||
+		authorName.toLowerCase() == authorName) {
+		return ZU.capitalizeTitle(authorName, true);
+	}
+
+	return authorName;
+}
+
 function addCreators(item, creatorType, creators) {
 	if( typeof(creators) == 'string' ) {
 		creators = [creators];
@@ -38,7 +47,7 @@ function addCreators(item, creatorType, creators) {
 	}
 
 	for(var i=0, n=creators.length; i<n; i++) {
-		item.creators.push(ZU.cleanAuthor(ZU.capitalizeTitle(creators[i],true),
+		item.creators.push(ZU.cleanAuthor(fixCase(creators[i]),
 							creatorType, false));
 	}
 }
@@ -49,7 +58,7 @@ function getAuthorName(text) {
 
 	text = text.replace(/(^|[\s,])(PhD|MA|Prof|Dr)(\.?|(?=\s|$))/gi,'');	//remove salutations
 
-	return ZU.capitalizeTitle(text.trim(), true);
+	return fixCase(text.trim());
 }
 
 function scrape(doc, url, pdfUrl) {


### PR DESCRIPTION
may be easier to compare it to 2a0b9a2a7018e7a6b3822f607ead73f8db3a2a85

@adam3smith - I was working on Wiley, but couldn't finish it at the time. Your fix does have the advantage that it will not capitalize things like von if they start off lower case, but hopefully we can figure out a more universal way to clean up author names soon. We can actually do the same checking that Adam introduced in the last commit, but it gets messy when you try to squeeze that into several places.
