### PR TITLE
Embeded Metadata - Trim keywords before splitting them.

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-03-22 22:32:52"
+	"lastUpdated": "2012-03-26 16:03:25"
 }
 
 /*
@@ -619,6 +619,7 @@ function addHighwireMetadata(doc, newItem) {
 	if (newItem.tags.length) {
 		var tags = [], t;
 		for (var i in newItem.tags) {
+			newItem.tags[i] = newItem.tags[i].trim();
 			t = newItem.tags[i].split(/\s*,\s*/);
 			if (newItem.tags[i].indexOf(';') == -1 && t.length > 2) {
 				tags = tags.concat(t);


### PR DESCRIPTION
Some pages add leading newlines to the keyword @content.

E.g. http://rives.revues.org/4060  `//meta[@name="DC.subject"]/@content`
