### PR TITLE
Bumping timestamps to override accidental merge

### DIFF
--- a/Annual Reviews.js
+++ b/Annual Reviews.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsib",
-	"lastUpdated": "2012-02-20 03:54:19"
+	"lastUpdated": "2012-04-09 21:34:29"
 }
 
 /**

--- a/BibTeX.js
+++ b/BibTeX.js
@@ -14,7 +14,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcs",
-	"lastUpdated": "2012-04-09 04:29:35"
+	"lastUpdated": "2012-04-09 21:35:24"
 }
 
 function detectImport() {

--- a/Scitation.js
+++ b/Scitation.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2012-03-15 05:17:43"
+	"lastUpdated": "2012-04-09 21:34:52"
 }
 
 /**


### PR DESCRIPTION
Apparently the translators that got accidentally merged are being pushed out for update.

EDIT: I think they are producing errors because another BibTeX version was merged in later with a newer timestamp and it's incompatible with modifications made in Scitation and Annual Reviews.
