### PR TITLE
MS Academic Search

### DIFF
--- a/Microsoft Academic Search.js
+++ b/Microsoft Academic Search.js
@@ -12,6 +12,24 @@
 	"lastUpdated": "2012-04-11 00:40:43"
 }
 
+/**
+	Copyright (c) 2012 Aurimas Vinckevicius
+	
+	This program is free software: you can redistribute it and/or
+	modify it under the terms of the GNU Affero General Public License
+	as published by the Free Software Foundation, either version 3 of
+	the License, or (at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+	Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public
+	License along with this program. If not, see
+	<http://www.gnu.org/licenses/>.
+*/
+
 function getSearchResults(doc) {
 	if(!getSearchResults.results) {
 		getSearchResults.results = ZU.xpath(doc,


### PR DESCRIPTION
Initial commit for MS Academic Search

Feature request at #258

This does not use the API since it offers little advantage for the web translator. From my experimentation, the only thing that API offers over BibTeX export is journal abbreviation.

Couple issues:

All articles are assumed to be journal articles, but occasionally there will be a conference paper, which I couldn't find how to identify before fetching the BibTeX file. E.g. http://academic.research.microsoft.com/Publication/13294478/tools-at-hand-and-learning-in-multi-session-collaborative-search There are probably other items like books, but I haven't explored MAS enough to figure out how to identify those.

Another problem right now is that I was trying to add attachments linked on the MAS results page, but a lot of the results have tons of links which are more or less useless. E.g. http://academic.research.microsoft.com/Publication/5500326/defrosting-the-digital-library-bibliographic-tools-for-the-next-generation-web So I'm not sure how to resolve this. Should we just not try to attach items, attach them all, or attach first link of each type (snapshot, pdf, etc.) and only link to the rest?

Lastly, from the search results page, the translator requests the item page, then requests BibTeX. We could avoid the intermediate item page, but that would prevent us from getting tags and attachments.

TODO: maybe tighten up the target regex
