### PR TITLE
MetaLib - initial commit

### DIFF
--- a/MetaLib.js
+++ b/MetaLib.js
@@ -2,14 +2,14 @@
 	"translatorID": "b06d2609-ebca-4125-ac67-6d7a0dba274e",
 	"label": "MetaLib",
 	"creator": "Aurimas Vinckevicius",
-	"target": "https?://[^/]*metalib4\\.exlibrisgroup\\.com(:\\d+)?/",
+	"target": "https?://[^/]*/V/",
 	"minVersion": "3.0",
 	"maxVersion": "",
-	"priority": 100,
+	"priority": 250,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-04-11 04:41:56"
+	"lastUpdated": "2012-04-11 05:03:56"
 }
 
 /**
@@ -73,6 +73,12 @@ function scrapeExport(basketLinks) {
 }
 
 function detectWeb(doc, url) {
+	if(!ZU.xpath(doc, 
+		'//head/link[substring(@href,string-length(@href)-11)="/metalib.css"]')
+		.length) {
+		return;
+	}
+
 	var baskets = getBasketLinks(doc).length;
 	if(baskets == 1) {
 		return 'journalArticle';


### PR DESCRIPTION
Only tested with Illinois Institute of Technology library. It would be great if anyone else has access to a MetaLib database through another university and can confirm that this works.

The URL says meatlib4, but I'm not sure if this works with other versions as well. It may, we would just need to change the target regex.

MetaLib uses sessions extensively.. though cookies don't seem to matter that much and links for export don't seem to be that unique. I'm quite puzzled as to how they do it. Either way, tests are impossible.

Maybe this should be named like all the other library catalogs (i.e. Library Catalog (MetaLib)), but note that everything happens on ExLibris servers. They just provide a custom skin. So I don't think it qualifies as a library catalog.

They do provide a MARC export format, but it seems to be a little messed up and our MARC translator does not parse it at all (I did not explore why this happens). The RIS is fairly complete though.

No attachments, and all non-multiple pages are journal articles.
