### PR TITLE
856 subfield u When Marc 245 subfield h is Present

### DIFF
--- a/MARC.js
+++ b/MARC.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcsn",
-	"lastUpdated": "2011-11-30 23:29:49"
+	"lastUpdated": "2012-04-11 14:15:49"
 }
 
 function detectImport() {


### PR DESCRIPTION
Hi,

This patch pulls in the URL stored in the 856 field subfield u when the Marc 245 subfield h has been defined as "electronic resource". This common cataloging practice is a fairly reliable way to determine if the urls in the 856 field are for the actual resource rather than something like a table of contents or publisher's summary. It would be good to include this in the general MARC.js translator. 
