### PR TITLE
RDF - allow translators to override default namespace prefix URIs

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-04-01 19:01:51"
+	"lastUpdated": "2012-04-13 13:21:35"
 }
 
 /*
@@ -523,6 +523,7 @@ function doWeb(doc, url) {
 			}
 
 			rdf.defaultUnknownType = _itemType;
+			rdf.setNamespacePrefixes(_prefixes);
 			rdf.doImport();
 			if(!_haveItem) {
 				completeItem(doc, new Zotero.Item(_itemType));

--- a/RDF.js
+++ b/RDF.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2012-03-01 08:41:26"
+	"lastUpdated": "2012-04-13 13:21:27"
 }
 
 /*
@@ -69,7 +69,14 @@ var n = {
 	book:"http://ogp.me/ns/book#"
 };
 
-var callNumberTypes = [n.dcterms+"LCC", n.dcterms+"DDC", n.dcterms+"UDC"];
+// allows another translator to override and set the namespaces
+function setNamespacePrefixes(newNS) {
+	for(var i in newNS) {
+		n[i] = newNS[i];
+	}
+}
+
+var callNumberTypes;
 
 // gets the first result set for a property that can be encoded in multiple
 // ontologies
@@ -660,7 +667,10 @@ function doImport() {
 	if(!nodes) {
 		return false;
 	}
-	
+
+	//initialize call numbers
+	callNumberTypes = [n.dcterms+"LCC", n.dcterms+"DDC", n.dcterms+"UDC"];
+
 	// keep track of collections while we're looping through
 	var collections = new Array();
 	
@@ -717,5 +727,6 @@ function doImport() {
  */
 var exports = {
 	"doImport":doImport,
-	"defaultUnknownType":"book"
+	"defaultUnknownType":"book",
+	"setNamespacePrefixes":setNamespacePrefixes
 };


### PR DESCRIPTION
There was an issue where a URI different from that in the default set (e.g. prism: http://prismstandard.org/namespaces/basic/2.0/) was linked to on the web page. All the meta tags were added to RDF translator using the new URI, but the detection of the meta tags was performed with the default set.
