### PR TITLE
PubMed Central ID should include the PMC prefix.

### DIFF
--- a/PubMed Central.js
+++ b/PubMed Central.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-01-30 22:42:15"
+	"lastUpdated": "2012-04-13 19:44:54"
 }
 
 function detectWeb(doc, url) {
@@ -89,7 +89,7 @@ function lookupPMCIDs(ids, doc, pdfLink) {
 			newItem.DOI = ZU.xpathText(article, 'articleid[@pubidtype="doi"]');
 			
 			newItem.extra = "PMID: " + ZU.xpathText(article, 'articleid[@pubidtype="pmid"]') + "\n";
-			newItem.extra = newItem.extra + "PMCID: " + ids[i];
+			newItem.extra = newItem.extra + "PMCID: PMC" + ids[i];
 
 			newItem.title = ZU.trim(ZU.xpathText(article, 'titlegroup/articletitle'));
 			
@@ -266,15 +266,13 @@ var testCases = [
 				"seeAlso": [],
 				"attachments": [
 					{
-						"url": false,
 						"title": "PubMed Central Link",
 						"mimeType": "text/html",
 						"snapshot": false
 					},
 					{
 						"title": "PubMed Central Full Text PDF",
-						"mimeType": "application/pdf",
-						"url": false
+						"mimeType": "application/pdf"
 					}
 				],
 				"journalAbbreviation": "Respir Res",
@@ -282,7 +280,7 @@ var testCases = [
 				"ISSN": "1465-9921",
 				"abstractNote": "Background\nThe patient population receiving long-term oxygen therapy has increased with the rising morbidity of COPD. Although high-dose oxygen induces pulmonary edema and interstitial fibrosis, potential lung injury caused by long-term exposure to low-dose oxygen has not been fully analyzed. This study was designed to clarify the effects of long-term low-dose oxygen inhalation on pulmonary epithelial function, edema formation, collagen metabolism, and alveolar fibrosis.\n\nMethods\nGuinea pigs (n = 159) were exposed to either 21% or 40% oxygen for a maximum of 16 weeks, and to 90% oxygen for a maximum of 120 hours. Clearance of inhaled technetium-labeled diethylene triamine pentaacetate (Tc-DTPA) and bronchoalveolar lavage fluid-to-serum ratio (BAL/Serum) of albumin (ALB) were used as markers of epithelial permeability. Lung wet-to-dry weight ratio (W/D) was measured to evaluate pulmonary edema, and types I and III collagenolytic activities and hydroxyproline content in the lung were analyzed as indices of collagen metabolism. Pulmonary fibrotic state was evaluated by histological quantification of fibrous tissue area stained with aniline blue.\n\nResults\nThe clearance of Tc-DTPA was higher with 2 week exposure to 40% oxygen, while BAL/Serum Alb and W/D did not differ between the 40% and 21% groups. In the 40% oxygen group, type I collagenolytic activities at 2 and 4 weeks and type III collagenolytic activity at 2 weeks were increased. Hydroxyproline and fibrous tissue area were also increased at 2 weeks. No discernible injury was histologically observed in the 40% group, while progressive alveolar damage was observed in the 90% group.\n\nConclusion\nThese results indicate that epithelial function is damaged, collagen metabolism is affected, and both breakdown of collagen fibrils and fibrogenesis are transiently induced even with low-dose 40% oxygen exposure. However, these changes are successfully compensated even with continuous exposure to low-dose oxygen. We conclude that long-term low-dose oxygen exposure does not significantly induce permanent lung injury in guinea pigs.",
 				"DOI": "10.1186/1465-9921-9-37",
-				"extra": "PMID: 18439301\nPMCID: 2377243",
+				"extra": "PMID: 18439301\nPMCID: PMC2377243",
 				"title": "Effects of long-term low-dose oxygen supplementation on the epithelial function, collagen metabolism and interstitial fibrogenesis in the guinea pig lung",
 				"volume": "9",
 				"issue": "1",


### PR DESCRIPTION
Perhaps we shouldn't be excluding the PMC in the first place, since eutils doesn't mind it, but this is unlikely to break anything and I'm feeling lazy.

Bug report at http://forums.zotero.org/discussion/22872/pubmedcentral-id-format/

Citation example where this is used at http://publicaccess.nih.gov/citation_methods.htm
