### PR TITLE
EIDR search translator initial commit

### DIFF
--- a/EIDR.js
+++ b/EIDR.js
@@ -5,7 +5,7 @@
 	"target": "",
 	"minVersion": "1.0",
 	"maxVersion": "",
-	"priority": 100,
+	"priority": 80,
 	"inRepository": true,
 	"translatorType": 8,
 	"browserSupport": "gcsi",
@@ -111,9 +111,9 @@ function  doSearch(searchItem) {
 		//running time
 		var time = getValue(base,'ApproximateLength')
 					.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/i);
-		item.runningTime = (time[1] || 0) * 3600 +
+		item.runningTime = ((time[1] || 0) * 3600 +
 							(time[2] || 0) * 60 +
-							(time[3] || 0);
+							(time[3] || 0)) + 's';
 
 		//creators
 		var creators = base.getElementsByTagName('Credits')[0];


### PR DESCRIPTION
Sample EIDR
10.5240/6F7E-EF59-329B-1F0A-8440-2
10.5240/C19F-7450-5481-F620-4C25-W

Not sure what's the best way to handle detectSearch. This translator should capture DOIs that begin with 10.5237, 10.5238, and 10.5240, but we only retrieve DOIs that begin with 10.5240, because the other two return some types that we can't store in Zotero, like producers. My approach was to return true for detection, but then throw an error inside doSearch.

EDIT: EIDR database can be searched via https://sandboxui.eidr.org/search

EDIT2: Tagging #286
