### PR TITLE
convert bibtex citekeys to/from zotero tags with a "bibtex:" prefix

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -1785,6 +1785,7 @@ function getFieldValue(read) {
 }
 
 function beginRecord(type, closeChar) {
+	var isCiteKey=false;
 	type = Zotero.Utilities.trimInternal(type.toLowerCase());
 	if(type != "string") {
 		var zoteroType = bibtex2zoteroTypeMap[type];
@@ -1793,6 +1794,7 @@ function beginRecord(type, closeChar) {
 			return;
 		}
 		var item = new Zotero.Item(zoteroType);
+		isCiteKey=true;
 		
 		item.extra = "";
 	}
@@ -1841,6 +1843,10 @@ function beginRecord(type, closeChar) {
 			}
 			field = "";
 		} else if(read == ",") {						// commas reset
+			 if( isCiteKey ) {
+				 item.tags.push('bibtex:'+field);
+				 isCiteKey=false;
+			 }
 			field = "";
 		} else if(read == closeChar) {
 			if(item) {
@@ -1972,6 +1978,11 @@ var citeKeyConversions = {
 
 
 function buildCiteKey (item,citekeys) {
+	for( t in item.tags ) {
+		if( item.tags[t].tag.substr(0,7)=='bibtex:' ) {
+			return item.tags[t].tag.substr(7);
+		}
+	}
 	var basekey = "";
 	var counter = 0;
 	citeKeyFormatRemaining = citeKeyFormat;


### PR DESCRIPTION
Simple change to the BibTeX translator. Creates a single extra tag containing the prefix "bibtex:" followed by the citekey imported. When exporting, it searching for a tag with this prefix to output as the citekey. Using a tag also allows the user to edit the citekey once imported. The prefix ensures that tag collisions are not likely and that it's at least discernable what the tag is for.
