### PR TITLE
[PubMed Central] Add PubMed Central url to the URL field

### DIFF
--- a/PubMed Central.js
+++ b/PubMed Central.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-05-16 23:35:57"
+	"lastUpdated": "2012-06-25 22:24:30"
 }
 
 function detectWeb(doc, url) {
@@ -134,6 +134,7 @@ function lookupPMCIDs(ids, doc, pdfLink) {
 			}
 
 			var linkurl = "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC" + ids[i] + "/";
+			newItem.url = linkurl;
 			newItem.attachments = [{
 				url: linkurl,
 				title: "PubMed Central Link",
@@ -276,17 +277,19 @@ var testCases = [
 					}
 				],
 				"journalAbbreviation": "Respir Res",
+				"publicationTitle": "Respiratory Research",
 				"ISSN": "1465-9921",
 				"abstractNote": "Background\nThe patient population receiving long-term oxygen therapy has increased with the rising morbidity of COPD. Although high-dose oxygen induces pulmonary edema and interstitial fibrosis, potential lung injury caused by long-term exposure to low-dose oxygen has not been fully analyzed. This study was designed to clarify the effects of long-term low-dose oxygen inhalation on pulmonary epithelial function, edema formation, collagen metabolism, and alveolar fibrosis.\n\nMethods\nGuinea pigs (n = 159) were exposed to either 21% or 40% oxygen for a maximum of 16 weeks, and to 90% oxygen for a maximum of 120 hours. Clearance of inhaled technetium-labeled diethylene triamine pentaacetate (Tc-DTPA) and bronchoalveolar lavage fluid-to-serum ratio (BAL/Serum) of albumin (ALB) were used as markers of epithelial permeability. Lung wet-to-dry weight ratio (W/D) was measured to evaluate pulmonary edema, and types I and III collagenolytic activities and hydroxyproline content in the lung were analyzed as indices of collagen metabolism. Pulmonary fibrotic state was evaluated by histological quantification of fibrous tissue area stained with aniline blue.\n\nResults\nThe clearance of Tc-DTPA was higher with 2 week exposure to 40% oxygen, while BAL/Serum Alb and W/D did not differ between the 40% and 21% groups. In the 40% oxygen group, type I collagenolytic activities at 2 and 4 weeks and type III collagenolytic activity at 2 weeks were increased. Hydroxyproline and fibrous tissue area were also increased at 2 weeks. No discernible injury was histologically observed in the 40% group, while progressive alveolar damage was observed in the 90% group.\n\nConclusion\nThese results indicate that epithelial function is damaged, collagen metabolism is affected, and both breakdown of collagen fibrils and fibrogenesis are transiently induced even with low-dose 40% oxygen exposure. However, these changes are successfully compensated even with continuous exposure to low-dose oxygen. We conclude that long-term low-dose oxygen exposure does not significantly induce permanent lung injury in guinea pigs.",
 				"DOI": "10.1186/1465-9921-9-37",
 				"extra": "PMID: 18439301\nPMCID: PMC2377243",
-				"issue": "1",
-				"libraryCatalog": "PubMed Central",
-				"publicationTitle": "Respiratory Research",
 				"title": "Effects of long-term low-dose oxygen supplementation on the epithelial function, collagen metabolism and interstitial fibrogenesis in the guinea pig lung",
 				"volume": "9",
+				"issue": "1",
 				"pages": "37",
-				"date": "2008"
+				"date": "2008",
+				"url": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2377243/",
+				"libraryCatalog": "PubMed Central",
+				"accessDate": "CURRENT_TIMESTAMP"
 			}
 		]
 	},


### PR DESCRIPTION
Was there a reason why we didn't do this in the first place? I know a link is included as an attachment and I can see how it could be useful if the article is published both on the publisher's website and pubmed central. However, if the article is imported from pubmed central, I think we should store the URL as item.url.
