### PR TITLE
[Gmail] Scrape from print pages

### DIFF
--- a/Gmail.js
+++ b/Gmail.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2012-07-15 16:10:24"
+	"lastUpdated": "2012-07-15 16:18:18"
 }
 
 function detectWeb(doc, url) {
@@ -50,7 +50,7 @@ function doWeb(doc, url) {
 	if(item.date) item.date = ZU.trimInternal(item.date);
 
 	//clear the automatic Print popup
-	doc.body.attributes.removeNamedItem('onload');
+	doc.body.removeAttribute('onload');
 	item.attachments.push({
 		title:"Email Snapshot",
 		document: doc


### PR DESCRIPTION
In response to issue #423

Only triggers on "print" pages in gmail. I couldn't find a way to fetch all message IDs for a thread, so I figured this would be the best way to let the user choose which messages in the thread to scrape. I think ideally email threads should be detected as multiple and then the user can choose which messages to fetch. As I said above, I couldn't find message IDs for all messages in the thread, so this is what I'm proposing for now.

The creators are fetched from the first message in the thread. I'm not sure if that is desirable.

To:, CC:, BCC: are all set as recipients

No abstractNote is set. I'm not sure if we want to set it or not.

Couple issues:

1) item.title HAS to be set even though it's not really part of "email" item type. item.subject should probably be sufficient to pass this test.

2) Accessed Date does not get set. I was under the impression that this happens automatically.

3) The print page has a "Print" onload event. This is also saved in the Snapshot. Any reasonable way to remove this?
