### PR TITLE
Revisit xpaths for Google Scholar.

### DIFF
--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -46,7 +46,7 @@ var detectWeb = function (doc, url) {
 		url.indexOf('about=') == -1) {
 			return "case";
 	} else if( ZU.xpath(doc,
-		'//div[@class="gs_r"]//div[@class="gs_fl"]/a[contains(@href,"q=related:")]')
+		'//div[@class="gs_r"]//div[@class="gs_ri"]//a[contains(@href,"q=related:")]')
 		.length ) {
 		return "multiple";
 	}
@@ -130,7 +130,7 @@ function decrementCounter(doc) {
 
 //determine item type from a result node
 function determineType(result) {
-	var titleHref =  ZU.xpathText(result, './h3[@class="gs_rt"]/a[1]/@href');
+	var titleHref =  ZU.xpathText(result, './/h3[@class="gs_rt"]//a[1]/@href');
 
 	if(titleHref) {
 		if(titleHref.indexOf('/scholar_case?') != -1) {
@@ -152,7 +152,7 @@ function determineType(result) {
 	 * 
 	 * This is probably not going to work with google scholar in other languages
 	 */
-	var subTitle = ZU.xpathText(result, './div[@class="gs_a"]');
+	var subTitle = ZU.xpathText(result, './/div[@class="gs_a"]');
 	if(!subTitle) return 'article';
 
 	if(subTitle.match(/\bpatent\s+\d/i)) {
@@ -212,10 +212,9 @@ function scrapeArticleResults(doc, articles) {
 
 						//attach linked page as snapshot if available
 						var snapshotUrl = ZU.xpathText(article.result,
-							'.//h3[@class="gs_rt"]/a/@href');
+							'.//h3[@class="gs_rt"]//a/@href');
 						var linkTitle = ZU.xpathText(article.result,
 							'.//h3[@class="gs_rt"]');
-
 						var attachment;
 						if(linkTitle && snapshotUrl) {
 							//try to get an attachment
@@ -237,8 +236,9 @@ function scrapeArticleResults(doc, articles) {
 
 						//attach files linked on the right
 						var pdf = ZU.xpath(article.result,
-							'./div[contains(@class,"gs_fl")]\
-								/a[.//span[@class="gs_ctg2"]]');
+							'.//div[contains(@class,"gs_rt")]\
+								//a[.//span[@class="gs_ctg2"]]');
+
 						for(var i=0, n=pdf.length; i<n; i++) {
 							var attach = getAttachment(pdf[i].href,
 											pdf[i].childNodes[0].textContent);
@@ -278,11 +278,11 @@ function scrapeArticleResults(doc, articles) {
 
 function scrapeCaseResults(doc, cases) {
 	for(var i=0, n=cases.length; i<n; i++) {
-		var titleString = ZU.xpathText(cases[i].result, './h3[@class="gs_rt"]');
-		var citeletString = ZU.xpathText(cases[i].result, './div[@class="gs_a"]');
+		var titleString = ZU.xpathText(cases[i].result, './/h3[@class="gs_rt"]');
+		var citeletString = ZU.xpathText(cases[i].result, './/div[@class="gs_a"]');
 	
 		var attachmentFrag = ZU.xpathText(cases[i].result,
-								'./h3[@class="gs_rt"]/a/@href');
+								'.//h3[@class="gs_rt"]//a/@href');
 		if (attachmentFrag) {
 			var attachmentLinks = [attachmentFrag];
 		} else {
@@ -387,7 +387,7 @@ function scrapePatentResults(doc, patents) {
 
 					//attach google patents page
 					var patentUrl = ZU.xpathText(result,
-									'./h3[@class="gs_rt"]/a[1]/@href');
+									'.//h3[@class="gs_rt"]//a[1]/@href');
 					if(patentUrl) {
 						item.attachments.push({
 							title: 'Google Patents page',
@@ -409,7 +409,7 @@ function scrapePatentResults(doc, patents) {
 /** Until SOP is "fixed" we'll scrape as much information as we can from the
  * result block instead of using Google Patents translator
 		var patentUrl = ZU.xpathText(patents[i].result,
-									'./h3[@class="gs_rt"]/a[1]/@href');
+									'./h3[@class="gs_ri"]/a[1]/@href');
 
 		if(patentUrl) {
 			(function(doc, url) {
@@ -450,14 +450,14 @@ function doWeb(doc, url) {
 		 */
 		var results = ZU.xpath(doc,
 			'//div[@class="gs_r"]\
-				[.//div[@class="gs_fl"]/a[contains(@href,"q=info:") or contains(@href,"q=related:")]]');
+				[.//div[@class="gs_ri"]//a[contains(@href,"q=info:") or contains(@href,"q=related:")]]');
 
 		var items = new Object();
 		var resultDivs = new Object();
 		var bibtexUrl;
 		for(var i=0, n=results.length; i<n; i++) {
 			bibtexUrl = ZU.xpathText(results[i],
-				'.//div[@class="gs_fl"]/a[contains(@href,"q=info:") or contains(@href,"q=related:")][1]/@href')
+				'.//div[@class="gs_ri"]//a[contains(@href,"q=info:") or contains(@href,"q=related:")][1]/@href')
 				.replace(/\/scholar.*?\?/,'/scholar.bib?')
 				.replace(/=related:/,'=info:')
 				+ '&ct=citation&cd=1&output=citation';


### PR DESCRIPTION
The Google Scholar tag layout seems to have shifted around a little since I filed yesterday's patch. With this further set of adjustments it seems to be working. All it does is loosen the xpath constraints a little, and adjust a div classname that seems to have gone walkies.

As I wrote [on the forums](http://forums.zotero.org/discussion/24326/solved-url-bar-icon-does-not-appear-on-google-scholar/#Comment_130533), I'm not sure whether attachments are fully working, but this does pull in snapshots, at least.
