### PR TITLE
Add option to bibtex export to use journal abbrevations.

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -9,7 +9,8 @@
 	"displayOptions": {
 		"exportCharset": "UTF-8",
 		"exportNotes": true,
-		"exportFileData": false
+		"exportFileData": false,
+		"useJournalAbbreviation": false
 	},
 	"inRepository": true,
 	"translatorType": 3,
@@ -2051,6 +2052,8 @@ function doExport() {
 		if(item.publicationTitle) {
 			if(item.itemType == "bookSection" || item.itemType == "conferencePaper") {
 				writeField("booktitle", item.publicationTitle);
+			} else if(Zotero.getOption("useJournalAbbreviation")){
+				writeField("journal", item.journalAbbreviation);
 			} else {
 				writeField("journal", item.publicationTitle);
 			}


### PR DESCRIPTION
In many physics (and other journals?) it is standard to use abbreviated journal titles (i.e. Phys. Rev. Lett. not Physical Review Letters) Since bibtex does not, as far as I know, have a field for this
it is nice with an option in the export to toggle between full and abbreviated journal names. This 
pull request adds that. Note that no fall back to full journal title is made even thou a lot of translators do not write the abbreviated journal titles. This is on purpose to make it easier to spot a missing journal title
as a warning in the bibtex compilation rather than a wrong type. 

In addition the option name should be added to the translations in Zotero itself? 
