### PR TITLE
Fix saving PDFs in Wiley Online Library when translation occurs via connectors

### DIFF
--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsib",
-	"lastUpdated": "2012-08-14 19:51:41"
+	"lastUpdated": "2012-08-19 22:48:04"
 }
 
 /*
@@ -174,30 +174,7 @@ function scrapeEM(doc, url, pdfUrl) {
 			}
 		}
 
-		//fetch pdf url. There seems to be some magic value that must be sent
-		// with the request
-		if(!pdfUrl) {
-			var u = ZU.xpathText(doc, '//meta[@name="citation_pdf_url"]/@content');
-			if(u) {
-				ZU.doGet(u, function(text) {
-					var m = text.match(/<iframe id="pdfDocument"[^>]+?src="([^"]+)"/i);
-					if(m) {
-						Z.debug(m[1]);
-						item.attachments.push({url: m[1], title: 'Full Text PDF', mimeType: 'application/pdf'});
-					} else {
-						Z.debug('Could not determine PDF URL.');
-						m = text.match(/<iframe[^>]*>/i);
-						if(m) Z.debug(m[0]);
-					}
-					item.complete();
-				});
-			} else {
-				item.complete();
-			}
-		} else {
-			item.attachments.push({url: pdfUrl, title: 'Full Text PDF', mimeType: 'application/pdf'});
-			item.complete();
-		}
+		addPDFAndComplete(item, doc, pdfUrl);
 	});
 	translator.translate();
 }
@@ -277,40 +254,58 @@ function scrapeBibTeX(doc, url, pdfUrl) {
 				document: doc,
 				mimeType: 'text/html'
 			}];
-
-			//fetch pdf url. There seems to be some magic value that must be sent
-			// with the request
-			if(!pdfUrl &&
-				(pdfUrl = ZU.xpathText(doc,
-					'//meta[@name="citation_pdf_url"]/@content'))) {
-
-				ZU.doGet(pdfUrl, function(text) {
-					var m = text.match(
-						/<iframe id="pdfDocument"[^>]+?src="([^"]+)"/i);
-					if(m) {
-						Z.debug('PDF url: ' + m[1]);
-						item.attachments.push({url: m[1],
-							title: 'Full Text PDF',
-							mimeType: 'application/pdf'});
-					} else {
-						Z.debug('Could not determine PDF URL.');
-						m = text.match(/<iframe[^>]*>/i);
-						if(m) Z.debug(m[0]);
-						else Z.debug('No iframe found');
-					}
-					item.complete();
-				});
-			} else {
-				if(pdfUrl)
-					item.attachments.push({url: pdfUrl,
-						title: 'Full Text PDF',
-						mimeType: 'application/pdf'});
-				item.complete();
-			}
+			
+			addPDFAndComplete(item, doc, pdfUrl);
 		});
 
 		translator.translate();
 	});
+}
+
+/**
+ * Add PDF to item and complete.
+ * @param {Zotero.Item} item
+ * @param {Document} doc
+ * @param {String} [pdfurl] PDF URL, if already known
+ */
+function addPDFAndComplete(item, doc, pdfUrl) {
+	if(pdfUrl) {
+		item.attachments.push({url: pdfUrl,
+			title: 'Full Text PDF',
+			mimeType: 'application/pdf'});
+		item.complete();
+	} else {
+		var u = ZU.xpathText(doc, '//meta[@name="citation_pdf_url"]/@content');
+		if(u) {
+			Zotero.debug("Testing for Safari");
+			if(doc.defaultView.navigator.userAgent.indexOf("Safari/") !== -1) {
+				Zotero.debug("Safari found");
+				// For some reason, Wiley serves PDFs to users with Safari/ in the 
+				// user agent without a frame. This seems pretty weird, since Safari
+				// >=5.1 can handle PDFs in frames, and the vast majority of users
+				// with Safari/ in the user agent are Chrome users. But, we need to
+				// handle this case.
+				item.attachments.push({url: u, title: 'Full Text PDF',
+					mimeType: 'application/pdf'});
+				item.complete();
+			} else {
+				ZU.doGet(u, function(text) {
+					var m = text.match(/<iframe id="pdfDocument"[^>]+?src="([^"]+)"/i);
+					if(m) {
+						Z.debug(m[1]);
+						item.attachments.push({url: m[1], title: 'Full Text PDF', mimeType: 'application/pdf'});
+					} else {
+						Z.debug('Could not determine PDF URL.');
+						m = text.match(/<iframe[^>]*>/i);
+						if(m) Z.debug(m[0]);
+					}
+					item.complete();
+				});
+			}
+		} else {
+			item.complete();
+		}
+	}
 }
 
 function scrape(doc, url, pdfUrl) {


### PR DESCRIPTION
On each abstract/full text pages, Wiley Online Library includes a link that points to a PDF. This URL is the same across browsers, but the content served

This patch takes this behavior into account by inspecting the browser's User-Agent string. If it contains "Safari/", it directly attaches the PDF link UR

To work properly with Zotero Standalone, this requires a current 3.0 branch build (post-c81c9478d9fc3cb71b482edcd89e5ec6ce19d923), so that Zotero Standal

First reported at http://forums.zotero.org/discussion/22409/wiley-online/#Item_9
