### PR TITLE
APS-Physics.js translator for physics.aps.org

### DIFF
--- a/APS-Physics.js
+++ b/APS-Physics.js
@@ -3,7 +3,7 @@
 	"label": "APS-Physics",
 	"creator": "Will Shanks",
 	"target": "^https?://(?:www\\.)?(physics)\\.aps\\.org[^/]*/(articles)/?",
-	"minVersion": "1.0.0b3.r1",
+	"minVersion": "2.1.9",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,


### PR DESCRIPTION
This translator works for Viewpoint and Focus articles on physics.aps.org.  I modeled it off of the APS.js translator for the APS journals at aps.org (which are formatted differently from physics.aps.org).  It pulls the abstract ("byline") text and the DOI from the webpage text.  It uses the DOI to create the URLs for the PDF (if the article is a Viewpoint; Focus articles don't have PDFs) and for the RIS.  It uses the RIS translator to process the rest of the item data.
