### PR TITLE
BibTeX: Don't export standalone notes and attachments

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -14,7 +14,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-09-24 01:05:06"
+	"lastUpdated": "2012-11-02 09:12:35"
 }
 
 function detectImport() {
@@ -2077,6 +2077,9 @@ function doExport() {
 	var citekeys = new Object();
 	var item;
 	while(item = Zotero.nextItem()) {
+		//don't export standalone notes and attachments
+		if(item.itemType == "note" || item.itemType == "attachment") continue;
+
 		// determine type
 		var type = zotero2bibtexTypeMap[item.itemType];
 		if (typeof(type) == "function") { type = type(item); }


### PR DESCRIPTION
Not sure why this wasn't done to start with, so I'll wait for a "thumbs up" to merge.

There have been several reports of entries like

```
@misc{__????-1
},
```

which I think are from standalone notes/attachments.

On merge, make a note <a href="http://forums.zotero.org/discussion/25417/zotero-bibtex-export-produces-invalid-files/">here</a>
