### PR TITLE
remove the period before colon in titles for MARC

### DIFF
--- a/MARC.js
+++ b/MARC.js
@@ -1,6 +1,5 @@
 {
 	"translatorID": "a6ee60df-1ddc-4aae-bb25-45e0537be973",
-	"translatorType": 1,
 	"label": "MARC",
 	"creator": "Simon Kornblith, Sylvain Machefert",
 	"target": "marc",
@@ -8,8 +7,9 @@
 	"maxVersion": null,
 	"priority": 100,
 	"inRepository": true,
+	"translatorType": 1,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-08-07 22:26:11"
+	"lastUpdated": "2012-11-03 16:31:18"
 }
 
 function detectImport() {
@@ -535,6 +535,9 @@ record.prototype.translate = function(item) {
 		}
 		if (this.getFieldSubfields("335")[0]) {
 			item.title = item.title + ": " + this.getFieldSubfields("335")[0]['a'];
+		}
+		if(item.title) {
+			item.title = item.title.replace(/\s+:/ , ":");
 		}
 	}
 }


### PR DESCRIPTION
I talked to a bunch of librarians and they all agree this has no bibliographical purpose - it's just a cataloging convention. I'll merge this in a couple of days but wanted to see if @aurimasv or @simonster have any objections or suggestions on how to do this more effectively. This might also affect a couple of tests, I'll take care of those separately.
