### PR TITLE
Store unsupported and unknown RIS fields in a single note

### DIFF
--- a/RIS.js
+++ b/RIS.js
@@ -14,7 +14,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-11-15 06:49:29"
+	"lastUpdated": "2012-11-15 16:25:08"
 }
 
 function detectImport() {
@@ -361,11 +361,16 @@ var fieldMap = {
 //these are not exported the same way
 var degenerateImportFieldMap = {
 	A1: fieldMap["AU"],
+	AD: {
+		"__default": "unsupported/Author Address",
+		"unsupported/Inventor Address": ["patent"]
+	},
 	BT: {
 		title: ["book", "manuscript"],
 		bookTitle: ["bookSection"],
 		"__default": "backupPublicationTitle" //we do more filtering on this later
 	},
+	CA: "unsupported/Caption",
 	CR: "rights",
 	CT: "title",
 	ED: "creators/editor",
@@ -376,6 +381,7 @@ var degenerateImportFieldMap = {
 		"__default": "journalAbbreviation",
 		conferenceName: ["conferencePaper"]
 	},
+	LB: "unsupported/Label",
 	M1: {
 		"__default":"extra",
 		numberOfVolumes: ["bookSection"],	//EndNote exports here instead of IS
@@ -384,6 +390,15 @@ var degenerateImportFieldMap = {
 	M2: "extra", //not in spec
 	M3: "DOI",
 	N2: "abstractNote",
+	OP: {
+		"__default": "unsupported/Original Publication",
+		"unsupported/Content": ["blogPost", "computerProgram", "film", "presentation", "report", "videoRecording", "webpage"]
+	},
+	RI: {
+		"__default":"unsupported/Reviewed Item",
+		"unsupported/Article Number": ["statute"]
+	},
+	RN: "unsupported/Research Notes",
 	SE: {
 		"unsupported/File Date": ["case"]
 	},
@@ -392,6 +407,8 @@ var degenerateImportFieldMap = {
 	T3: {
 		series: ["book"]
 	},
+	TA: "unsupported/Translated Author",
+	TT: "unsupported/Translated Title",
 	VL: {
 		"unsupported/Patent Version Number":['patent'],
 		accessDate: ["webpage"]	//technically access year according to EndNote
@@ -1308,7 +1325,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Date Published<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RN  - ResearchNotes<br/>SE  - Screens<br/>SN  - ISSN/ISBN<br/>SP  - Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 2<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: ResearchNotes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Date Published<br/>J2  - Periodical Title<br/>M3  - Type of Work<br/>SE  - Screens<br/>SN  - ISSN/ISBN<br/>SP  - Pages<br/>VL  - Volume<br/>ID  - 2<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1361,7 +1378,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviated Publication<br/>LB  - Label<br/>M3  - Type of Work<br/>NV  - Number of Volumes<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - ResearchNotes<br/>RP  - Reprint Edition<br/>SN  - ISBN<br/>SP  - Pages<br/>T3  - Volume Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 3<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: ResearchNotes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviated Publication<br/>M3  - Type of Work<br/>NV  - Number of Volumes<br/>RP  - Reprint Edition<br/>SN  - ISBN<br/>SP  - Pages<br/>T3  - Volume Title<br/>VL  - Volume<br/>ID  - 3<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1402,7 +1419,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SP  - Description<br/>TT  - Translated Title<br/>TA  - Author, Translated<br/>ID  - 4<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Title: Translated Title<br/>Translated Author: Author, Translated<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>PB  - Publisher<br/>SP  - Description<br/>ID  - 4<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1454,7 +1471,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Performers<br/>AD  - Author Address<br/>C1  - Cast<br/>C2  - Credits<br/>C3  - Size/Length<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type<br/>NV  - Extent of Work<br/>OP  - Contents<br/>RN  - Research Notes<br/>SN  - ISBN<br/>T3  - Series Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 5<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Content: Contents<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Performers<br/>C1  - Cast<br/>C2  - Credits<br/>C3  - Size/Length<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>M3  - Type<br/>NV  - Extent of Work<br/>SN  - ISBN<br/>T3  - Series Title<br/>VL  - Volume<br/>ID  - 5<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1495,7 +1512,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>AN  - Accession Number<br/>CA  - Caption<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>LB  - Label<br/>RN  - Research Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 6<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>AN  - Accession Number<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ID  - 6<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1543,7 +1560,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor<br/>A3  - Illustrator<br/>AD  - Author Address<br/>AN  - Accession Number<br/>C1  - Author Affiliation<br/>CA  - Caption<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>OP  - Contents<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SE  - Message Number<br/>SN  - ISBN<br/>SP  - Description<br/>T3  - Institution<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Access Year<br/>ID  - 7<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Content: Contents<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor<br/>A3  - Illustrator<br/>AN  - Accession Number<br/>C1  - Author Affiliation<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>PB  - Publisher<br/>SE  - Message Number<br/>SN  - ISBN<br/>SP  - Description<br/>T3  - Institution<br/>VL  - Access Year<br/>ID  - 7<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1598,7 +1615,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 8<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>DO  - DOI<br/>J2  - Abbreviation<br/>M3  - Type of Work<br/>RP  - Reprint Edition<br/>SE  - Pages<br/>ID  - 8<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1664,7 +1681,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Section<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Packaging Method<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Chapter<br/>SV  - Series Volume<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 9<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Section<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Packaging Method<br/>DO  - DOI<br/>J2  - Abbreviation<br/>RP  - Reprint Edition<br/>SE  - Chapter<br/>SV  - Series Volume<br/>ID  - 9<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1711,7 +1728,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>File Date: Filed Date<br/>A3  - Court, Higher<br/>AD  - Author Address<br/>AN  - Accession Number<br/>CA  - Caption<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Action of Higher Court<br/>J2  - Parallel Citation<br/>LB  - Label<br/>M3  - Citation of Reversal<br/>NV  - Reporter Abbreviation<br/>RN  - ResearchNotes<br/>T3  - Decision<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 10<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: ResearchNotes<br/>File Date: Filed Date<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A3  - Court, Higher<br/>AN  - Accession Number<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Action of Higher Court<br/>J2  - Parallel Citation<br/>M3  - Citation of Reversal<br/>NV  - Reporter Abbreviation<br/>T3  - Decision<br/>ID  - 10<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1761,7 +1778,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Institution<br/>AD  - Author Address<br/>C5  - Packaging Method<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviation<br/>LB  - Label<br/>M3  - Type of Work<br/>NV  - Catalog Number<br/>OP  - Original Publication<br/>PB  - Publisher<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Number of Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 11<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Institution<br/>C5  - Packaging Method<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviation<br/>M3  - Type of Work<br/>NV  - Catalog Number<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>SE  - Number of Pages<br/>ID  - 11<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1805,7 +1822,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - File, Name of<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>LB  - Label<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Image Size<br/>ID  - 12<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - File, Name of<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>PB  - Publisher<br/>SP  - Description<br/>VL  - Image Size<br/>ID  - 12<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1854,7 +1871,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type<br/>OP  - Original Publication<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 23<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>DO  - DOI<br/>J2  - Periodical Title<br/>M3  - Type<br/>RP  - Reprint Edition<br/>ID  - 23<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1901,7 +1918,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor, Series<br/>AD  - Author Address<br/>C1  - Computer<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type<br/>OP  - Contents<br/>RN  - Research Notes<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Edition<br/>ID  - 14<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Content: Contents<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor, Series<br/>C1  - Computer<br/>DO  - DOI<br/>J2  - Periodical Title<br/>M3  - Type<br/>SP  - Description<br/>VL  - Edition<br/>ID  - 14<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -1954,7 +1971,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Type<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Conference Location<br/>LB  - Label<br/>RN  - Research Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 15<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Type<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Conference Location<br/>ID  - 15<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2015,7 +2032,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C2  - Year Published<br/>C5  - Packaging Method<br/>CA  - Caption<br/>CY  - Conference Location<br/>ET  - Edition<br/>LB  - Label<br/>NV  - Number of Volumes<br/>OP  - Source<br/>RN  - Research Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 16<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Source<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C2  - Year Published<br/>C5  - Packaging Method<br/>CY  - Conference Location<br/>ET  - Edition<br/>NV  - Number of Volumes<br/>ID  - 16<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2071,7 +2088,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Time Period<br/>C2  - Unit of Observation<br/>C3  - Data Type<br/>C4  - Dataset(s)<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>J2  - Abbreviation<br/>LB  - Label<br/>NV  - Study Number<br/>OP  - Version History<br/>RI  - Geographic Coverage<br/>RN  - Research Notes<br/>SE  - Original Release Date<br/>SN  - ISSN<br/>T3  - Series Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 17<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Version History<br/>Reviewed Item: Geographic Coverage<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Time Period<br/>C2  - Unit of Observation<br/>C3  - Data Type<br/>C4  - Dataset(s)<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>J2  - Abbreviation<br/>NV  - Study Number<br/>SE  - Original Release Date<br/>SN  - ISSN<br/>T3  - Series Title<br/>ID  - 17<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2124,7 +2141,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Term<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Version<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 13<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Term<br/>DO  - DOI<br/>J2  - Abbreviation<br/>M3  - Type of Work<br/>RP  - Reprint Edition<br/>SE  - Version<br/>ID  - 13<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2180,7 +2197,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Editor Address<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 19<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Editor Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>DO  - DOI<br/>J2  - Periodical Title<br/>M3  - Type of Work<br/>RP  - Reprint Edition<br/>ID  - 19<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2233,7 +2250,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Type of Work<br/>AD  - Author Address<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>C3  - PMCID<br/>C4  - Reviewer<br/>C5  - Issue Title<br/>C6  - NIHMSID<br/>C7  - Article Number<br/>CA  - Caption<br/>CY  - Place Published<br/>ET  - Edition<br/>LB  - Label<br/>NV  - Document Number<br/>PB  - Publisher<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - E-Pub Date<br/>T3  - Website Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 20<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Type of Work<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>C3  - PMCID<br/>C4  - Reviewer<br/>C5  - Issue Title<br/>C6  - NIHMSID<br/>C7  - Article Number<br/>CY  - Place Published<br/>ET  - Edition<br/>NV  - Document Number<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>SE  - E-Pub Date<br/>T3  - Website Title<br/>ID  - 20<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2290,7 +2307,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>series: Series Title<br/>AD  - Author Address<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Last Update Date<br/>C6  - NIHMSID<br/>C7  - PMCID<br/>CA  - Caption<br/>DO  - DOI<br/>LB  - Label<br/>M3  - Type of Medium<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 21<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>series: Series Title<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Last Update Date<br/>C6  - NIHMSID<br/>C7  - PMCID<br/>DO  - DOI<br/>M3  - Type of Medium<br/>RP  - Reprint Edition<br/>ID  - 21<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2353,7 +2370,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>numberOfVolumes: Number of Volumes<br/>AD  - Author Address<br/>C1  - Section<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Packaging Method<br/>C6  - NIHMSID<br/>C7  - PMCID<br/>CA  - Caption<br/>DO  - DOI<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 22<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>numberOfVolumes: Number of Volumes<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Section<br/>C3  - Title Prefix<br/>C4  - Reviewer<br/>C5  - Packaging Method<br/>C6  - NIHMSID<br/>C7  - PMCID<br/>DO  - DOI<br/>M3  - Type of Work<br/>RP  - Reprint Edition<br/>ID  - 22<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2414,7 +2431,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Term<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 18<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Term<br/>DO  - DOI<br/>J2  - Abbreviation<br/>RP  - Reprint Edition<br/>ID  - 18<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2466,7 +2483,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>LB  - Label<br/>M3  - Type of Image<br/>RN  - Research Notes<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Image Size<br/>ID  - 24<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>M3  - Type of Image<br/>SP  - Description<br/>VL  - Image Size<br/>ID  - 24<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2507,7 +2524,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - File, Name of<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>LB  - Label<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Image Size<br/>ID  - 25<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - File, Name of<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Version<br/>PB  - Publisher<br/>SP  - Description<br/>VL  - Image Size<br/>ID  - 25<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2555,7 +2572,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Director, Series<br/>AD  - Author Address<br/>C1  - Cast<br/>C2  - Credits<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Medium<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 26<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Director, Series<br/>C1  - Cast<br/>C2  - Credits<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>M3  - Medium<br/>RP  - Reprint Edition<br/>ID  - 26<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2614,7 +2631,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Type of Work<br/>A3  - Author, Tertiary<br/>AD  - Author Address<br/>C1  - Custom 1<br/>C2  - Custom 2<br/>C3  - Custom 3<br/>C4  - Custom 4<br/>C5  - Custom 5<br/>C6  - Custom 6<br/>C7  - Custom 7<br/>C8  - Custom 8<br/>CA  - Caption<br/>CY  - Place Published<br/>ET  - Edition<br/>LB  - Label<br/>NV  - Number of Volumes<br/>OP  - Original Publication<br/>PB  - Publisher<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Section<br/>T3  - Tertiary Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 27<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Type of Work<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A3  - Author, Tertiary<br/>C1  - Custom 1<br/>C2  - Custom 2<br/>C3  - Custom 3<br/>C4  - Custom 4<br/>C5  - Custom 5<br/>C6  - Custom 6<br/>C7  - Custom 7<br/>C8  - Custom 8<br/>CY  - Place Published<br/>ET  - Edition<br/>NV  - Number of Volumes<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>SE  - Section<br/>T3  - Tertiary Title<br/>ID  - 27<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2664,7 +2681,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Department<br/>AD  - Author Address<br/>C1  - Government Body<br/>C2  - Congress Number<br/>C3  - Congress Session<br/>CA  - Caption<br/>DO  - DOI<br/>ET  - Edition<br/>LB  - Label<br/>RN  - Research Notes<br/>SE  - Section<br/>T3  - Series Title<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 28<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Department<br/>C1  - Government Body<br/>C2  - Congress Number<br/>C3  - Congress Session<br/>DO  - DOI<br/>ET  - Edition<br/>SE  - Section<br/>T3  - Series Title<br/>VL  - Volume<br/>ID  - 28<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2709,7 +2726,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Funding Type<br/>AD  - Author Address<br/>C1  - Contact Name<br/>C2  - Contact Address<br/>C3  - Contact Phone<br/>C4  - Contact Fax<br/>C5  - Funding Number<br/>C6  - CFDA Number<br/>CA  - Caption<br/>CY  - Activity Location<br/>ET  - Requirements<br/>LB  - Label<br/>NV  - Amount Received<br/>OP  - Original Grant Number<br/>PB  - Sponsoring Agency<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Review Date<br/>SE  - Duration of Grant<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 29<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Funding Type<br/>Original Publication: Original Grant Number<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Contact Name<br/>C2  - Contact Address<br/>C3  - Contact Phone<br/>C4  - Contact Fax<br/>C5  - Funding Number<br/>C6  - CFDA Number<br/>CY  - Activity Location<br/>ET  - Requirements<br/>NV  - Amount Received<br/>PB  - Sponsoring Agency<br/>RP  - Review Date<br/>SE  - Duration of Grant<br/>ID  - 29<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2747,7 +2764,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>AN  - Accession Number<br/>C2  - Congress Number<br/>CA  - Caption<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>LB  - Label<br/>RN  - Research Notes<br/>SN  - ISBN<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 30<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>AN  - Accession Number<br/>C2  - Congress Number<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>SN  - ISBN<br/>ID  - 30<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2793,7 +2810,7 @@ var testCases = [
 				],
 				"notes": [
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Type of Article<br/>AD  - Author Address<br/>C1  - Legal Note<br/>C2  - PMCID<br/>C6  - NIHMSID<br/>C7  - Article Number<br/>CA  - Caption<br/>ET  - Epub Date<br/>LB  - Label<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 31<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Type of Article<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Legal Note<br/>C2  - PMCID<br/>C6  - NIHMSID<br/>C7  - Article Number<br/>ET  - Epub Date<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>ID  - 31<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2839,7 +2856,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>File Date: Section Number<br/>AD  - Author Address<br/>AN  - Accession Number<br/>CA  - Caption<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type of Work<br/>NV  - Session Number<br/>RN  - Research Notes<br/>SN  - ISSN/ISBN<br/>T3  - Supplement No.<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 32<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>File Date: Section Number<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>AN  - Accession Number<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>M3  - Type of Work<br/>NV  - Session Number<br/>SN  - ISSN/ISBN<br/>T3  - Supplement No.<br/>ID  - 32<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2885,7 +2902,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>M3  - Type of Article<br/>NV  - Frequency<br/>OP  - Original Publication<br/>PB  - Publisher<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 33<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>M3  - Type of Article<br/>NV  - Frequency<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>ID  - 33<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2934,7 +2951,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>DO  - DOI<br/>ET  - Description of Material<br/>J2  - Periodical Title<br/>LB  - Label<br/>NV  - Manuscript Number<br/>PB  - Library/Archive<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume/Storage Container<br/>ID  - 34<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>DO  - DOI<br/>ET  - Description of Material<br/>J2  - Periodical Title<br/>NV  - Manuscript Number<br/>PB  - Library/Archive<br/>RP  - Reprint Edition<br/>SE  - Start Page<br/>VL  - Volume/Storage Container<br/>ID  - 34<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -2977,7 +2994,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor, Series<br/>AD  - Author Address<br/>C2  - Area<br/>C3  - Size<br/>C5  - Packaging Method<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Periodical Title<br/>LB  - Label<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 35<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor, Series<br/>C2  - Area<br/>C3  - Size<br/>C5  - Packaging Method<br/>DO  - DOI<br/>J2  - Periodical Title<br/>RP  - Reprint Edition<br/>SP  - Description<br/>ID  - 35<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3034,7 +3051,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A3  - Editor, Series<br/>AD  - Author Address<br/>C1  - Format of Music<br/>C2  - Form of Composition<br/>C3  - Music Parts<br/>CA  - Caption<br/>DO  - DOI<br/>ET  - Edition<br/>LB  - Label<br/>M3  - Form of Item<br/>OP  - Original Publication<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Section<br/>SP  - Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 36<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A3  - Editor, Series<br/>C1  - Format of Music<br/>C2  - Form of Composition<br/>C3  - Music Parts<br/>DO  - DOI<br/>ET  - Edition<br/>M3  - Form of Item<br/>RP  - Reprint Edition<br/>SE  - Section<br/>SP  - Pages<br/>ID  - 36<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3080,7 +3097,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Column<br/>C2  - Issue<br/>CA  - Caption<br/>DO  - DOI<br/>LB  - Label<br/>M3  - Type of Article<br/>NV  - Frequency<br/>OP  - Original Publication<br/>PB  - Publisher<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 37<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Column<br/>C2  - Issue<br/>DO  - DOI<br/>M3  - Type of Article<br/>NV  - Frequency<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>VL  - Volume<br/>ID  - 37<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3131,7 +3148,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Date Published<br/>LB  - Label<br/>M3  - Type of Work<br/>RN  - Research Notes<br/>SN  - Report Number<br/>SP  - Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 38<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Date Published<br/>M3  - Type of Work<br/>SN  - Report Number<br/>SP  - Pages<br/>VL  - Volume<br/>ID  - 38<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3173,7 +3190,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor, Series<br/>AD  - Author Address<br/>C2  - Date Cited<br/>CA  - Caption<br/>DO  - DOI<br/>LB  - Label<br/>M3  - Type of Work<br/>RN  - Research Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 39<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor, Series<br/>C2  - Date Cited<br/>DO  - DOI<br/>M3  - Type of Work<br/>ID  - 39<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3222,7 +3239,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Institution<br/>AD  - Author Address<br/>C5  - Packaging Method<br/>CA  - Caption<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviation<br/>LB  - Label<br/>OP  - Original Publication<br/>PB  - Publisher<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SN  - ISBN<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Number<br/>ID  - 40<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Institution<br/>C5  - Packaging Method<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Abbreviation<br/>PB  - Publisher<br/>RP  - Reprint Edition<br/>SN  - ISBN<br/>VL  - Number<br/>ID  - 40<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3269,7 +3286,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>issueDate: 0000 Date<br/>Patent Version Number: Patent Version Number<br/>A3  - International Author<br/>AD  - Inventor Address<br/>AN  - Accession Number<br/>CA  - Caption<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - International Patent Classification<br/>LB  - Label<br/>M3  - Patent Type<br/>NV  - US Patent Classification<br/>RN  - Research Notes<br/>SE  - International Patent Number<br/>T3  - Title, International<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 41<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Inventor Address: Inventor Address<br/>Caption: Caption<br/>issueDate: 0000 Date<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>Patent Version Number: Patent Version Number<br/>A3  - International Author<br/>AN  - Accession Number<br/>CN  - Call Number<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - International Patent Classification<br/>M3  - Patent Type<br/>NV  - US Patent Classification<br/>SE  - International Patent Number<br/>T3  - Title, International<br/>ID  - 41<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3324,7 +3341,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>C1  - Senders E-Mail<br/>C2  - Recipients E-Mail<br/>CA  - Caption<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Description<br/>J2  - Abbreviation<br/>LB  - Label<br/>NV  - Communication Number<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SP  - Pages<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 42<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Senders E-Mail<br/>C2  - Recipients E-Mail<br/>CY  - Place Published<br/>DO  - DOI<br/>ET  - Description<br/>J2  - Abbreviation<br/>NV  - Communication Number<br/>PB  - Publisher<br/>SP  - Pages<br/>ID  - 42<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3378,7 +3395,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor, Series<br/>AD  - Author Address<br/>C6  - Issue<br/>CA  - Caption<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>NV  - Series Volume<br/>OP  - Contents<br/>RN  - Research Notes<br/>RP  - Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Volume<br/>ID  - 43<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Content: Contents<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor, Series<br/>C6  - Issue<br/>DO  - DOI<br/>ET  - Edition<br/>J2  - Periodical Title<br/>NV  - Series Volume<br/>RP  - Notes<br/>VL  - Volume<br/>ID  - 43<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3443,7 +3460,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>series: Series Title<br/>AD  - Author Address<br/>C1  - Section<br/>C2  - Report Number<br/>C5  - Packaging Method<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>M3  - Type of Work<br/>OP  - Original Publication<br/>RI  - Reviewed Item<br/>RN  - Research Notes<br/>RP  - Reprint Edition<br/>SE  - Chapter<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 44<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Original Publication: Original Publication<br/>Reviewed Item: Reviewed Item<br/>Research Notes: Research Notes<br/>series: Series Title<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>C1  - Section<br/>C2  - Report Number<br/>C5  - Packaging Method<br/>DO  - DOI<br/>J2  - Abbreviation<br/>M3  - Type of Work<br/>RP  - Reprint Edition<br/>SE  - Chapter<br/>ID  - 44<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3490,7 +3507,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>CA  - Caption<br/>DO  - DOI<br/>J2  - Abbreviation<br/>LB  - Label<br/>NV  - Session Number<br/>RN  - Research Notes<br/>SE  - Section Number<br/>T3  - Paper Number<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Rule Number<br/>ID  - 45<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>DO  - DOI<br/>J2  - Abbreviation<br/>NV  - Session Number<br/>SE  - Section Number<br/>T3  - Paper Number<br/>VL  - Rule Number<br/>ID  - 45<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3529,7 +3546,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>AD  - Author Address<br/>AN  - Accession Number<br/>C5  - Publisher<br/>C6  - Volume<br/>CA  - Caption<br/>CN  - Call Number<br/>CY  - Country<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>J2  - Abbreviation<br/>LB  - Label<br/>NV  - Statute Number<br/>PB  - Source<br/>RI  - Article Number<br/>RN  - Research Notes<br/>T3  - International Source<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 46<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Article Number: Article Number<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>AN  - Accession Number<br/>C5  - Publisher<br/>C6  - Volume<br/>CN  - Call Number<br/>CY  - Country<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>J2  - Abbreviation<br/>NV  - Statute Number<br/>PB  - Source<br/>T3  - International Source<br/>ID  - 46<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3577,7 +3594,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A3  - Advisor<br/>AD  - Author Address<br/>CA  - Caption<br/>DO  - DOI<br/>LB  - Label<br/>RN  - Research Notes<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>VL  - Degree<br/>ID  - 47<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A3  - Advisor<br/>DO  - DOI<br/>VL  - Degree<br/>ID  - 47<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3632,7 +3649,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>DOI: Type of Work<br/>AD  - Author Address<br/>CA  - Caption<br/>CY  - Place Published<br/>LB  - Label<br/>PB  - Institution<br/>RN  - Research Notes<br/>T3  - Department<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 48<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>DOI: Type of Work<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>CY  - Place Published<br/>PB  - Institution<br/>T3  - Department<br/>ID  - 48<br/>",
 						"tags": [
 							"_RIS import"
 						]
@@ -3678,7 +3695,7 @@ var testCases = [
 						"note": "<p>Notes</p>"
 					},
 					{
-						"note": "The following values have no corresponding Zotero field:<br/>A2  - Editor, Series<br/>AD  - Author Address<br/>AN  - Accession Number<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>CA  - Caption<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>LB  - Label<br/>OP  - Contents<br/>PB  - Publisher<br/>RN  - Research Notes<br/>SN  - ISBN<br/>SP  - Description<br/>TA  - Author, Translated<br/>TT  - Translated Title<br/>ID  - 49<br/>",
+						"note": "The following values have no corresponding Zotero field:<br/>Author Address: Author Address<br/>Caption: Caption<br/>Label: Label<br/>Content: Contents<br/>Research Notes: Research Notes<br/>Translated Author: Author, Translated<br/>Translated Title: Translated Title<br/>A2  - Editor, Series<br/>AN  - Accession Number<br/>C1  - Year Cited<br/>C2  - Date Cited<br/>CN  - Call Number<br/>CY  - Place Published<br/>DB  - Name of Database<br/>DO  - DOI<br/>DP  - Database Provider<br/>ET  - Edition<br/>J2  - Periodical Title<br/>PB  - Publisher<br/>SN  - ISBN<br/>SP  - Description<br/>ID  - 49<br/>",
 						"tags": [
 							"_RIS import"
 						]


### PR DESCRIPTION
Also, I added a line to the top of the note, which will make it easy to search and delete all the notes if the user doesn't want them.
