### PR TITLE
 Bibtex: add ; as default delimiter for keywords. Escape curly brackets on export. 

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -14,7 +14,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 3,
-	"browserSupport": "gcs",
+	"browserSupport": "gcsv",
 	"lastUpdated": "2012-12-09 18:01:55"
 }
 


### PR DESCRIPTION
@simonster @aurimasv please take a look so that I don't do something dumb here. 
