### PR TITLE
 [Don't Merge] fix html escaping on bibtex export. Preserve capitalization via sentence case on bibtex export

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -14,7 +14,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 3,
-	"browserSupport": "gcs",
+	"browserSupport": "gcsv",
 	"lastUpdated": "2012-12-13 23:00:11"
 }
 


### PR DESCRIPTION
addresses https://github.com/zotero/translators/pull/477
