### PR TITLE
Fixes various escaping issues (both directions) in Bibtex, adds greek letters.

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -15,7 +15,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-12-20 00:46:26"
+	"lastUpdated": "2012-12-20 09:36:51"
 }
 
 function detectImport() {
@@ -2033,8 +2033,8 @@ function mapHTMLmarkup(characters) {
 	return DOMtoTeX(dom.body);
 }
 
-function DOMtoTeX(element) {
-	const HTMLtoTeXMap = {
+
+var HTMLtoTeXMap = {
 	i: {
 		open: "\\textit{",
 		close: "}"
@@ -2060,6 +2060,9 @@ function DOMtoTeX(element) {
 		close: "}"
 	}
 }
+
+function DOMtoTeX(element) {
+	
 	
 	
 	var str = "";
@@ -2112,7 +2115,7 @@ function mapTeXmarkup(tex){
 }
 
 /*
-const skipWords = ["but", "or", "yet", "so", "for", "and", "nor",
+var skipWords = ["but", "or", "yet", "so", "for", "and", "nor",
 	"a", "an", "the", "at", "by", "from", "in", "into", "of", "on",
 	"to", "with", "up", "down", "as", "while", "aboard", "about",
 	"above", "across", "after", "against", "along", "amid", "among",


### PR DESCRIPTION
Capitalization handling is commented out. Since this fixes a couple of bugs I wanted to get it out while we're still figuring out what to do with capitalization. I've tested this pretty extensively in both directions.
Includes Aurimas's HTML code and a rewrite by me in the other direction - have a look if that makes sense to you.
@aurimasv - if I don't put the constants into the relevant functions, Firefox throws an error for me (not when using Scaffold, but either the tests or regular translation does).
