### PR TITLE
Little bug in unimarc import corrected

### DIFF
--- a/MARC.js
+++ b/MARC.js
@@ -332,7 +332,7 @@ record.prototype.translate = function(item) {
 			{
 				var aut = authorTab[j];
 				var authorText = "";
-				if (aut.b) {
+				if ( (aut.b) && (aut.a) ){
 					authorText = aut['a'].replace(/,\s*$/,'') + ", " + aut['b'];
 				} 
 				else


### PR DESCRIPTION
Sometimes (even if it's a mistake according to unimarc manual), some $a are missing in authors field (7xx), resulting in an error on line 336, adding a check to prevent this error.
