### PR TITLE
Update Library Catalog (PICA).js

### DIFF
--- a/Library Catalog (PICA).js
+++ b/Library Catalog (PICA).js
@@ -2,7 +2,7 @@
 	"translatorID": "1b9ed730-69c7-40b0-8a06-517a89a3a278",
 	"label": "Library Catalog (PICA)",
 	"creator": "Sean Takats, Michael Berkowitz, Sylvain Machefert, Sebastian Karcher",
-	"target": "^https?://[^/]+/DB=\\d",
+	"target": "^https?://[^/]+/?/DB=\\d",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 200,


### PR DESCRIPTION
updating regexp to make it compatible with sudoc urls, built with a double / : http://www.sudoc.abes.fr//DB=2.1/SET=4/TTL=1/CMD?ACT=SRCHA&IKT=1016&SRT=RLV&TRM=wikipedia
