### PR TITLE
map "location" to "place" on import

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -77,7 +77,6 @@ var fieldMap = {
 	isbn:"ISBN",
 	issn:"ISSN",
 	lccn:"callNumber",
-	location:"archiveLocation",
 	shorttitle:"shortTitle",
 	url:"url",
 	doi:"DOI",
@@ -92,7 +91,8 @@ var inputFieldMap = {
 	school:"publisher",
 	institution:"publisher",
 	publisher:"publisher",
-	issue:"issue"
+	issue:"issue",
+	location:"place"
 };
 
 var zotero2bibtexTypeMap = {


### PR DESCRIPTION
bib(la)tex "location" field does not correspond to archiveLocation

on import, location, if present, is mapped to "place"
on export, "place" should still be mapped to "address" for backward
compatibility with bibtex

all translator tests pass in Scaffold (on my system)
