### PR TITLE
[CrossRef] Retain rich markup in titles

### DIFF
--- a/CrossRef.js
+++ b/CrossRef.js
@@ -18,20 +18,7 @@ var ns;
 /**********************
  * Utilitiy Functions *
  **********************/
-var outerXML;
-try {
-	outerXML = (new XMLSerializer()).serializeToString;
-} catch(e) {
-	outerXML = function(n) {
-		try {
-			return n.xml;	//IE
-		} catch(e) {
-			//fallback
-			return '<' + n.nodeName.toLowerCase() + '>' + n.textContent
-				+ '</' + n.nodeName.toLowerCase() + '>';
-		}
-	};
-}
+var outerXML = (new XMLSerializer()).serializeToString;
 function innerXML(n) {
 	return outerXML(n).replace(/^[^>]*>|<[^<]*$/g, '');
 }


### PR DESCRIPTION
Re http://forums.zotero.org/discussion/28446/additional-spaces-in-long-item-titles-when-importing-citations/

Regarding spacing around markup, I emailed CrossRef support and they said that there is no trick and that this is the way the data was deposited to CrossRef. In fact, they display the title incorrectly in their Metadata Search as well (http://search.labs.crossref.org/?q=10.1111%2F1574-6941.12040). Here, I think, we do a little better: we keep the spaces around markup. 

According to http://help.crossref.org/#face_markup CrossRef supports a bit more markup than Zotero can handle, so we strip out everything that's unsupported or convert it.
