### PR TITLE
make pubmed throw an error when there's no data rather than fail silentl...

### DIFF
--- a/NCBI PubMed.js
+++ b/NCBI PubMed.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 13,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2013-05-26 17:34:04"
+	"lastUpdated": "2013-06-02 19:18:28"
 }
 
 /*****************************
@@ -280,6 +280,9 @@ function processAuthors(newItem, authorsLists) {
 }
 
 function doImportFromText(text, next) {
+	if (text.length<300){
+		throw("No Pubmed Data found - Most likely eutils is temporarily down")
+	}
 	if (text.substr(0,1000).indexOf("<PubmedArticleSet>") == -1) {
 		// Pubmed data in the wild, perhaps copied from the web site's search results,
 		// can be missing the <PubmedArticleSet> root tag. Let's add a pair!


### PR DESCRIPTION
...y - not 100% this is the best way to achieve this - 300 chars is an arbitrary length, but should be _much_ shorter than any actual record
