### PR TITLE
The author field is probably the most sensible field

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -2126,16 +2126,6 @@ var citeKeyCleanRe = /[^a-z0-9\!\$\&\*\+\-\.\/\:\;\<\>\?\[\]\^\_\`\|]+/g;
 
 var citeKeyConversions = {
 	"a":function (flags, item) {
-		/*
-		var primaryCreatorType = Zotero.Utilities.getCreatorsForType(item.itemType)[0];
-		if(Zotero.Utilities.getConfigurationParameter("extensions.zotero.preferPrimaryAuthorsInCiteKeys") && item.creators && item.creators[0]) {
-			for(var i in item.creators) {
-				if(item.creators[i].lastName && item.creators[i].creatorType === primaryCreatorType) {
-					return item.creators[i].lastName.toLowerCase().replace(/ /g,"_").replace(/,/g,"");
-				}
-			}
-		}
-		*/
 		if(item.creators && item.creators[0] && item.creators[0].lastName) {
 			return item.creators[0].lastName.toLowerCase().replace(/ /g,"_").replace(/,/g,"");
 		}


### PR DESCRIPTION
Real authors could be upset when sharing their credit. I'd suggest to use a different field as the default field to store values that don't match anything else, for instance editor, or simply dropping fields whose meaning is unknown, as done here (line 2285). Ignoring when the meaning of something is unknown seems the safest option, some data may be missing but at least no garbage is added.
