### PR TITLE
[WorldCat] add support for user notes from item lists

### DIFF
--- a/Open WorldCat.js
+++ b/Open WorldCat.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 12,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2013-09-12 17:46:24"
+	"lastUpdated": "2013-09-12 18:19:47"
 }
 
 /**
@@ -45,10 +45,12 @@ function scrape(doc, url, callDoneWhenFinished, itemData) {
 	}
 	//Z.debug(newurl)
 	Zotero.Utilities.HTTP.doGet(newurl, function (text) {
+		//Z.debug(text);
+		
 		//2013-05-28 RIS export currently has messed up authors
 		// e.g. A1  - Gabbay, Dov M., Woods, John Hayden., Hartmann, Stephan, 
 		text = text.replace(/^((?:A1|ED)\s+-\s+)(.+)/mg, function(m, tag, value) {
-			var authors = value.replace(/[,\s]+$/, '')
+			var authors = value.replace(/[.,\s]+$/, '')
 					.split(/[.,],/);
 			var replStr = '';
 				var author;
@@ -58,6 +60,8 @@ function scrape(doc, url, callDoneWhenFinished, itemData) {
 			}
 			return replStr.trim();
 		});
+		//ebooks are exported as ELEC. We need them as BOOK
+		text = text.replace(/^TY\s+-\s+ELEC\s*$/mg, 'TY  - BOOK');
 		
 		//Zotero.debug("RIS: " + text)
 		
@@ -75,19 +79,11 @@ function scrape(doc, url, callDoneWhenFinished, itemData) {
 			item.title = item.title.replace(/\s+:/, ":")
 			
 			
-			//creators have period after firstName
+			//correct field mode for corporate authors
 			for (i in item.creators) {
-				if (item.creators[i].firstName){
-				item.creators[i].firstName = item.creators[i].firstName.replace(/\.$/, "");
+				if (!item.creators[i].firstName){
+					item.creators[i].fieldMode=1;
 				}
-				else {
-					item.creators[i].lastName = item.creators[i].lastName.replace(/\.$/, "");
-					item.creators[i].fieldMode=1;			
-				}
-			}
-			//We want ebooks to be treated like books, not webpages (is ISBN the best choice here?)
-			if (item.itemType == "webpage" && item.ISBN) {
-				item.itemType = "book";
 			}
 			
 			//attach notes
@@ -118,6 +114,13 @@ function generateItem(doc, node) {
 		type = getZoteroType(type);
 		if (type) item.itemType = type;
 	}
+	
+	//check under Material Type
+	var matType = ZU.xpathText(doc, '//div[@id="details"]//tr[./th[normalize-space(text())="Material Type:"]]/td');
+	if(matType && ZU.trimInternal(matType).toLowerCase() == 'conference publication') {
+		item.itemType = 'conferencePaper';
+	}
+	
 	return item;
 }
 
@@ -321,7 +324,7 @@ var testCases = [
 						"lastName": "Griffiths",
 						"firstName": "Arlo",
 						"creatorType": "author"
-	}
+					}
 				],
 				"notes": [],
 				"tags": [],
@@ -334,6 +337,34 @@ var testCases = [
 				"date": "2011",
 				"ISBN": "9067183849 9789067183840",
 				"shortTitle": "From Laṅkā eastwards"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://www.worldcat.org/title/newmans-relation-to-modernism/oclc/676747555",
+		"items": [
+			{
+				"itemType": "book",
+				"creators": [
+					{
+						"lastName": "Smith",
+						"firstName": "Sydney F",
+						"creatorType": "author"
+					}
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [],
+				"libraryCatalog": "Open WorldCat",
+				"language": "English",
+				"url": "http://www.archive.org/details/a626827800smituoft/",
+				"title": "Newman's relation to modernism",
+				"publisher": "s.n.",
+				"place": "London",
+				"date": "1912",
+				"accessDate": "CURRENT_TIMESTAMP"
 			}
 		]
 	}


### PR DESCRIPTION
This makes multiple retrieval asynchronous. WorldCat may not like this.

Re https://forums.zotero.org/discussion/27336
