### PR TITLE
Keep bibtex keeys on import/export

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -2053,7 +2053,11 @@ function beginRecord(type, closeChar) {
 			field = "";
 		} else if(read == closeChar) {
 			if(item) {
-				if(!item.extra) item.extra = '';
+				if(item.extra) {
+          item.extra += "\n";
+        } else {
+          item.extra = '';
+        }
         item.extra += JSON.stringify({bibtexCiteKey: item.itemID})
 
 				item.complete();


### PR DESCRIPTION
A bit hackish, but should be allow for expansion, and is roundtrip-safe.
