### PR TITLE
Zotero Translators for medical library's website from Lyon hospital

### DIFF
--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -1,19 +1,19 @@
 {
-	"translatorID": "6618c8fb-5419-403d-90ab-1836ccc74905",
+	"translatorID": "26ab1a2b-8740-4f79-a3e7-e0df62818839",
 	"label": "HospicesCivilsdeLyon",
 	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
-	"target": "(.chu-lyon|.cclin-france|.hcl)[^/]*.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",//It's dosen't work for admin and shelves
-	"minVersion": "2.1.9",
+	"target": "(.chu-lyon|.cclin-france|.hcl)[^/]*.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
+	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 25,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
-	"lastUpdated": "2013-08-20 17:31:24"
+	"browserSupport": "g",
+	"lastUpdated": "2013-08-23 14:57:25"
 }
 
-//Translator pour les sites http://rbh.chu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.chu-lyon.progilone.fr/
-//Basé sur le //Based on the Translator "Library Catalog (Koha)" ID: 8e66aa6d-5b2a-4b44-b384-a838e23b8538 par Sebastian Karcher
+//Translator pour les sites http://rbh.chu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.chu-lyon.fr/
+//Basé sur le //Based on the Translator "Library Catalog (Koha)" ID: "8e66aa6d-5b2a-4b44-b384-a838e23b8538" par Sebastian Karcher
 //Contact: Documentation Centrale des Hospices Civils de Lyon sur sa.documentationcentrale@chu-lyon.fr
 
 //Correspondance des types //Match Types
@@ -26,14 +26,22 @@ var typeMap = {
 	' [Rapport]': 'report',
 	' [Mémoire]': 'thesis',
 	' [Article de Presse]': 'newspaperArticle',
-	' [Recommandation]': 'conferencePaper',
+	' [Recommandation]': 'journalArticle',
 	' [Acte de congrès]': 'conferencePaper',
+	' [Poster Scientifique]': 'conferencePaper',
 	' [Affiche]': 'artwork',
+	' [Norme]': 'journalArticle',
+	' [Ouvrage]': 'book',
+	' [Revue]': 'book',
+	' [Presse]': 'book',
+	' [Mallette de bilan]': 'book',
+	' [Dictionnaire]': 'book',
 };
 
 //Détection de la présence de document multiple ou unique //Document detection: multiple or single
 function detectWeb(doc, url) {
 	if (url.match(/\/opac-search\.pl\?/)){return "multiple";}
+	if (url.match(/opac-shelves/)){return "multiple";}
 	if (url.match(/\/opac-detail.pl\?/)) {
 		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
 		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
@@ -47,7 +55,7 @@ function marcURL(url){
 	return marcURL;
 }
 
-//Enregistrement de documents depuis la liste de résultat //Registration from the results list
+//Enregistrement de documents depuis la liste de résultats et listes publiques //Registration from the results list & shelves
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		var articles = [];
@@ -75,7 +83,7 @@ function doWeb(doc, url) {
 function scrape(marcurl) {
 	Zotero.Utilities.HTTP.doGet(marcurl, function (text) {
 		var translator = Zotero.loadTranslator("import");
-		translator.setTranslator("a6ee60df-1ddc-4aae-bb25-45e0537be973");
+		translator.setTranslator("1b77cfcc-f4ae-47bd-86fe-47bda67f7793");
 		translator.setString(text);
 		translator.setHandler("itemDone", function (obj, item) {
 			//editors get mapped as contributors - but so do many others who should be
@@ -103,3 +111,96 @@ function scrape(marcurl) {
 	})
 } 
 
+/** BEGIN TEST CASES **/
+var testCases = [
+         {
+         	"itemType": "journalArticle",
+         	"creators": [
+         		{
+         			"firstName": "Americo",
+         			"lastName": "Agostinho",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Gesuele",
+         			"lastName": "Renzi",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Thomas",
+         			"lastName": "Haustein",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Ghislaine",
+         			"lastName": "Jourdan ",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Chantal",
+         			"lastName": "Bonfillon ",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Mathieu",
+         			"lastName": "Rougemont ",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Pierre",
+         			"lastName": "Hoffmeyer",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Stephan",
+         			"lastName": "Harbarth",
+         			"creatorType": "author"
+         		},
+         		{
+         			"firstName": "Ilker",
+         			"lastName": "Uçkay",
+         			"creatorType": "author"
+         		}
+         	],
+         	"notes": [],
+         	"tags": [
+         		"EPIDEMIOLOGIE",
+         		"ENTEROBACTER",
+         		"BETA-LACTAMASE A SPECTRE ELARGI",
+         		"ENTEROBACTERIE",
+         		"CHIRURGIE ORTHOPEDIQUE",
+         		"TYPAGE",
+         		"BIOLOGIE MOLECULAIRE",
+         		"DEPISTAGE",
+         		"ENVIRONNEMENT",
+         		"CENTRE HOSPITALIER UNIVERSITAIRE",
+         		"ESCHERICHIA COLI",
+         		"CITROBACTER",
+         		"KLEBSIELLA PNEUMONIAE",
+         		"SUISSE",
+         		"Présentation de matériel produit Compte-rendu de recherche"
+         	],
+         	"seeAlso": [],
+         	"attachments": [],
+         	"extra": "HCLID: 367294",
+         	"language": "Eng",
+         	"abstractNote": "Wards cohorting infected orthopaedic patients may be particularly prone to transmitting extended-spectrum beta-lactamase-producing Enterobacteriaceae (ESBL-E). We analyze their epidemic pattern by performing molecular typing of ESBL-E isolated from patients and healthcare workers (HCW) from our septic ward. Between March 2010 and November 2011, 186 patients were admitted. Among 565 anal swabs, ESBL-E were detected in 204 samples from 45 patients, suggesting prolonged carriage in affected patients. Among 25 cases with identical ESBL-E species and positive epidemiological links, only 9 were really attributable to our service. We also screened 41 healthcare workers (HCW) on 49 occasions during the study period. Six samples (13%) were positive. None of the ESBL-E detected in HCW were related to any of the patient isolates. Among 60 environmental samples taken at the peak of the epidemic none revealed ESBL-E. We conclude that HCW also were anal carriers of ESBL-E, however the ESBL- strains from the HCW were not the same strains isolated from patients in the septic ward. Moreover, the epidemiological attribution of ESBL by simple vicinity, timing, and species identification might grossly overestimate transmission within a given unit.\n(RESUME D’AUTEUR)",
+         	"reportType": "Présentation de matériel produit Compte-rendu de recherche",
+         	"thesisType": "Présentation de matériel produit Compte-rendu de recherche",
+         	"genre": "Présentation de matériel produit Compte-rendu de recherche",
+         	"title": "Epidemiology and acquisition of extended-spectrum beta-lactamase-producing Enterobacteriaceae in a septic orthopedic ward",
+         	"date": "2013",
+         	"pages": "1-4",
+         	"codePages": "1-4",
+         	"numPages": "1-4",
+         	"volume": "2",
+         	"issue": "1",
+         	"reportNumber": "1",
+         	"publicationTitle": "Springerplus",
+         	"code": "Springerplus",
+         	"bookTitle": "Springerplus",
+         	"seriesNumber": "2",
+         	"libraryCatalog": "HospicesCivilsdeLyon"
+         }
+]
+/** END TEST CASES **/

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -19,7 +19,7 @@
 //Correspondance des types //Match Types
 var typeMap = {
 	' [Article de Revue]': 'journalArticle',
-	' [Texte législatif]': 'case',
+	' [Texte législatif]': 'statute',
 	' [Thèse]': 'thesis',
 	' [Chapitre d\'ouvrage]': 'bookSection',
 	' [Multimédia]': 'film',

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -45,7 +45,11 @@ function detectWeb(doc, url) {
 	if (url.match(/\/opac-detail.pl\?/)) {
 		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
 		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
-}}
+	}
+	if (url.match(/\/opac-MARCdetail.pl\?/)) {
+		return 'journalArticle'
+	}
+}
 
 //Téléchargement de la notice au format MARC utf8 //Download biblio in MARC utf8
 function marcURL(url){

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -2,7 +2,7 @@
 	"translatorID": "26ab1a2b-8740-4f79-a3e7-e0df62818839",
 	"label": "HospicesCivilsdeLyon",
 	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
-	"target": "(.chu-lyon|.cclin-france|.hcl)[^/]*.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
+	"target": "(\.chu-lyon|\.cclin-france|\.hcl)[^/]*\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
 	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 25,

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -47,16 +47,32 @@ function detectWeb(doc, url) {
 		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
 	}
 	if (url.match(/\/opac-MARCdetail.pl\?/)) {
-		return 'journalArticle'
+		return 'journalArticle';
+	}
+		if (url.match(/\/MARCdetailHCL.pl\?/)) {
+		return 'journalArticle';
+	}
+	if (url.match(/\/catalogue\/detail\.pl\?/)) {
+		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
+		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
 	}
 }
 
 //Téléchargement de la notice au format MARC utf8 //Download biblio in MARC utf8
 function marcURL(url){
 	var bibnumber = url.match(/(biblionumber=)(\d+)/)[2];
-	var host = url.match(/^.+cgi-bin\/koha\//)[0];
-	var marcURL = host + "opac-export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
-	return marcURL;
+	
+	if (url.match(/^.+cgi-bin\/koha\/catalogue\//)){
+		var host = url.match(/^.+cgi-bin\/koha\/catalogue\//)[0];
+		var marcURL = host + "export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
+		return marcURL;
+		}
+		
+	if (url.match(/^.+cgi-bin\/koha\//)){	
+		var host = url.match(/^.+cgi-bin\/koha\//)[0];
+		var marcURL = host + "opac-export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
+		return marcURL;
+		}
 }
 
 //Enregistrement de documents depuis la liste de résultats et listes publiques //Registration from the results list & shelves

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "g",
-	"lastUpdated": "2013-08-23 14:57:25"
+	"lastUpdated": "2013-08-27 14:08:36"
 }
 
 //Translator pour les sites http://rbh.chu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.chu-lyon.fr/
@@ -40,34 +40,34 @@ var typeMap = {
 
 //Détection de la présence de document multiple ou unique //Document detection: multiple or single
 function detectWeb(doc, url) {
-	if (url.match(/\/opac-search\.pl\?/)){return "multiple";}
-	if (url.match(/opac-shelves/)){return "multiple";}
-	if (url.match(/\/opac-detail.pl\?/)) {
-		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
-		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
+	if (url.match(/\/opac-search\.pl\?/)){return "multiple";}		//Listes de résultat
+	if (url.match(/opac-shelves/)){return "multiple";} 				//Listes publiques //Shelves
+	if (url.match(/\/opac-detail.pl\?/)) {							//Notice normale sur OPAC //Single
+		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');	
+		if(type) return typeMap[type] || 'journalArticle';			//valeur par défaut //Default
 	}
-	if (url.match(/\/opac-MARCdetail.pl\?/)) {
+	if (url.match(/\/opac-MARCdetail.pl\?/)) {						//Notice MARC sur OPAC
 		return 'journalArticle';
 	}
-		if (url.match(/\/MARCdetailHCL.pl\?/)) {
+		if (url.match(/\/MARCdetailHCL.pl\?/)) {					//Notice MARC sur interface admin
 		return 'journalArticle';
 	}
-	if (url.match(/\/catalogue\/detail\.pl\?/)) {
+	if (url.match(/\/catalogue\/detail\.pl\?/)) {					//Notice normale sur interface admin
 		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
-		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
+		if(type) return typeMap[type] || 'journalArticle';			//valeur par défaut //Default
 	}
 }
 
 //Téléchargement de la notice au format MARC utf8 //Download biblio in MARC utf8
 function marcURL(url){
 	var bibnumber = url.match(/(biblionumber=)(\d+)/)[2];
-	
+	//Depuis l'interface d'admin
 	if (url.match(/^.+cgi-bin\/koha\/catalogue\//)){
 		var host = url.match(/^.+cgi-bin\/koha\/catalogue\//)[0];
 		var marcURL = host + "export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
 		return marcURL;
 		}
-		
+	//Depuis l'OPAC
 	if (url.match(/^.+cgi-bin\/koha\//)){	
 		var host = url.match(/^.+cgi-bin\/koha\//)[0];
 		var marcURL = host + "opac-export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
@@ -125,102 +125,110 @@ function scrape(marcurl) {
 				}
 			}
 			item.complete();
+			
+			//attachments PROBLEME: faire varier l'url
+			//item.attachments = [{
+			//	title: 'Capture',
+			//	url: 'http://rbh.chu-lyon.fr/cgi-bin/koha/opac-detail.pl?biblionumber='+bibnumber,
+			//	mimeType: 'text/html',
+			//}];
 		});
 		translator.translate();
 	
 	})
 } 
 
+
 /** BEGIN TEST CASES **/
 var testCases = [
-         {
-         	"itemType": "journalArticle",
-         	"creators": [
-         		{
-         			"firstName": "Americo",
-         			"lastName": "Agostinho",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Gesuele",
-         			"lastName": "Renzi",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Thomas",
-         			"lastName": "Haustein",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Ghislaine",
-         			"lastName": "Jourdan ",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Chantal",
-         			"lastName": "Bonfillon ",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Mathieu",
-         			"lastName": "Rougemont ",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Pierre",
-         			"lastName": "Hoffmeyer",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Stephan",
-         			"lastName": "Harbarth",
-         			"creatorType": "author"
-         		},
-         		{
-         			"firstName": "Ilker",
-         			"lastName": "Uçkay",
-         			"creatorType": "author"
-         		}
-         	],
-         	"notes": [],
-         	"tags": [
-         		"EPIDEMIOLOGIE",
-         		"ENTEROBACTER",
-         		"BETA-LACTAMASE A SPECTRE ELARGI",
-         		"ENTEROBACTERIE",
-         		"CHIRURGIE ORTHOPEDIQUE",
-         		"TYPAGE",
-         		"BIOLOGIE MOLECULAIRE",
-         		"DEPISTAGE",
-         		"ENVIRONNEMENT",
-         		"CENTRE HOSPITALIER UNIVERSITAIRE",
-         		"ESCHERICHIA COLI",
-         		"CITROBACTER",
-         		"KLEBSIELLA PNEUMONIAE",
-         		"SUISSE",
-         		"Présentation de matériel produit Compte-rendu de recherche"
-         	],
-         	"seeAlso": [],
-         	"attachments": [],
-         	"extra": "HCLID: 367294",
-         	"language": "Eng",
-         	"abstractNote": "Wards cohorting infected orthopaedic patients may be particularly prone to transmitting extended-spectrum beta-lactamase-producing Enterobacteriaceae (ESBL-E). We analyze their epidemic pattern by performing molecular typing of ESBL-E isolated from patients and healthcare workers (HCW) from our septic ward. Between March 2010 and November 2011, 186 patients were admitted. Among 565 anal swabs, ESBL-E were detected in 204 samples from 45 patients, suggesting prolonged carriage in affected patients. Among 25 cases with identical ESBL-E species and positive epidemiological links, only 9 were really attributable to our service. We also screened 41 healthcare workers (HCW) on 49 occasions during the study period. Six samples (13%) were positive. None of the ESBL-E detected in HCW were related to any of the patient isolates. Among 60 environmental samples taken at the peak of the epidemic none revealed ESBL-E. We conclude that HCW also were anal carriers of ESBL-E, however the ESBL- strains from the HCW were not the same strains isolated from patients in the septic ward. Moreover, the epidemiological attribution of ESBL by simple vicinity, timing, and species identification might grossly overestimate transmission within a given unit.\n(RESUME D’AUTEUR)",
-         	"reportType": "Présentation de matériel produit Compte-rendu de recherche",
-         	"thesisType": "Présentation de matériel produit Compte-rendu de recherche",
-         	"genre": "Présentation de matériel produit Compte-rendu de recherche",
-         	"title": "Epidemiology and acquisition of extended-spectrum beta-lactamase-producing Enterobacteriaceae in a septic orthopedic ward",
-         	"date": "2013",
-         	"pages": "1-4",
-         	"codePages": "1-4",
-         	"numPages": "1-4",
-         	"volume": "2",
-         	"issue": "1",
-         	"reportNumber": "1",
-         	"publicationTitle": "Springerplus",
-         	"code": "Springerplus",
-         	"bookTitle": "Springerplus",
-         	"seriesNumber": "2",
-         	"libraryCatalog": "HospicesCivilsdeLyon"
-         }
+	{
+		"itemType": "journalArticle",
+		"creators": [
+			{
+				"firstName": "Americo",
+				"lastName": "Agostinho",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Gesuele",
+				"lastName": "Renzi",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Thomas",
+				"lastName": "Haustein",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Ghislaine",
+				"lastName": "Jourdan ",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Chantal",
+				"lastName": "Bonfillon ",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Mathieu",
+				"lastName": "Rougemont ",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Pierre",
+				"lastName": "Hoffmeyer",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Stephan",
+				"lastName": "Harbarth",
+				"creatorType": "author"
+			},
+			{
+				"firstName": "Ilker",
+				"lastName": "Uçkay",
+				"creatorType": "author"
+			}
+		],
+		"notes": [],
+		"tags": [
+			"EPIDEMIOLOGIE",
+			"ENTEROBACTER",
+			"BETA-LACTAMASE A SPECTRE ELARGI",
+			"ENTEROBACTERIE",
+			"CHIRURGIE ORTHOPEDIQUE",
+			"TYPAGE",
+			"BIOLOGIE MOLECULAIRE",
+			"DEPISTAGE",
+			"ENVIRONNEMENT",
+			"CENTRE HOSPITALIER UNIVERSITAIRE",
+			"ESCHERICHIA COLI",
+			"CITROBACTER",
+			"KLEBSIELLA PNEUMONIAE",
+			"SUISSE",
+			"Présentation de matériel produit Compte-rendu de recherche"
+		],
+		"seeAlso": [],
+		"attachments": [],
+		"extra": "HCLID: 367294",
+		"language": "Eng",
+		"abstractNote": "Wards cohorting infected orthopaedic patients may be particularly prone to transmitting extended-spectrum beta-lactamase-producing Enterobacteriaceae (ESBL-E). We analyze their epidemic pattern by performing molecular typing of ESBL-E isolated from patients and healthcare workers (HCW) from our septic ward. Between March 2010 and November 2011, 186 patients were admitted. Among 565 anal swabs, ESBL-E were detected in 204 samples from 45 patients, suggesting prolonged carriage in affected patients. Among 25 cases with identical ESBL-E species and positive epidemiological links, only 9 were really attributable to our service. We also screened 41 healthcare workers (HCW) on 49 occasions during the study period. Six samples (13%) were positive. None of the ESBL-E detected in HCW were related to any of the patient isolates. Among 60 environmental samples taken at the peak of the epidemic none revealed ESBL-E. We conclude that HCW also were anal carriers of ESBL-E, however the ESBL- strains from the HCW were not the same strains isolated from patients in the septic ward. Moreover, the epidemiological attribution of ESBL by simple vicinity, timing, and species identification might grossly overestimate transmission within a given unit.\n(RESUME D’AUTEUR)",
+		"reportType": "Présentation de matériel produit Compte-rendu de recherche",
+		"thesisType": "Présentation de matériel produit Compte-rendu de recherche",
+		"genre": "Présentation de matériel produit Compte-rendu de recherche",
+		"title": "Epidemiology and acquisition of extended-spectrum beta-lactamase-producing Enterobacteriaceae in a septic orthopedic ward",
+		"date": "2013",
+		"pages": "1-4",
+		"codePages": "1-4",
+		"numPages": "1-4",
+		"volume": "2",
+		"issue": "1",
+		"reportNumber": "1",
+		"publicationTitle": "Springerplus",
+		"code": "Springerplus",
+		"bookTitle": "Springerplus",
+		"seriesNumber": "2",
+		"libraryCatalog": "HospicesCivilsdeLyon"
+	}
 ]
 /** END TEST CASES **/

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -2,7 +2,7 @@
 	"translatorID": "26ab1a2b-8740-4f79-a3e7-e0df62818839",
 	"label": "HospicesCivilsdeLyon",
 	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
-	"target": "(\.chu-lyon|\.cclin-france|\.hcl)[^/]*\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
+	"target": "(\.docchu-lyon|\.cclin-france|\.hcl)[^/]*\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
 	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 25,
@@ -12,7 +12,7 @@
 	"lastUpdated": "2013-08-27 14:08:36"
 }
 
-//Translator pour les sites http://rbh.chu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.chu-lyon.fr/
+//Translator pour les sites http://rbh.docchu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.docchu-lyon.fr/
 //Basé sur le //Based on the Translator "Library Catalog (Koha)" ID: "8e66aa6d-5b2a-4b44-b384-a838e23b8538" par Sebastian Karcher
 //Contact: Documentation Centrale des Hospices Civils de Lyon sur sa.documentationcentrale@chu-lyon.fr
 
@@ -129,7 +129,7 @@ function scrape(marcurl) {
 			//attachments PROBLEME: faire varier l'url
 			//item.attachments = [{
 			//	title: 'Capture',
-			//	url: 'http://rbh.chu-lyon.fr/cgi-bin/koha/opac-detail.pl?biblionumber='+bibnumber,
+			//	url: 'http://rbh.docchu-lyon.fr/cgi-bin/koha/opac-detail.pl?biblionumber='+bibnumber,
 			//	mimeType: 'text/html',
 			//}];
 		});

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -2,7 +2,7 @@
 	"translatorID": "26ab1a2b-8740-4f79-a3e7-e0df62818839",
 	"label": "HospicesCivilsdeLyon",
 	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
-	"target": "(\\.docchu-lyon|\\.cclin-france|\\.hcl)[^/]*\\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
+	"target": "(\\.docchu-lyon|\\.cclin-arlin.fr|\\.hcl)[^/]*\\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
 	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 25,
@@ -12,7 +12,7 @@
 	"lastUpdated": "2013-12-10 15:33:51"
 }
 
-//Translator pour les sites http://rbh.docchu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.docchu-lyon.fr/
+//Translator pour les sites http://rbh.docchu-lyon.fr | http://www.nosobase-biblio.cclin-arlin.fr.fr/ | http://documentationcentrale.docchu-lyon.fr/
 //Basé sur le //Based on the Translator "Library Catalog (Koha)" ID: "8e66aa6d-5b2a-4b44-b384-a838e23b8538" par Sebastian Karcher
 //Contact: Documentation Centrale des Hospices Civils de Lyon sur sa.documentationcentrale@chu-lyon.fr
 
@@ -187,7 +187,7 @@ var testCases = [
 			},
 			{
 				"firstName": "Ilker",
-				"lastName": "Uçkay",
+				"lastName": "Uc¸kay",
 				"creatorType": "author"
 			}
 		],
@@ -207,16 +207,16 @@ var testCases = [
 			"CITROBACTER",
 			"KLEBSIELLA PNEUMONIAE",
 			"SUISSE",
-			"Présentation de matériel produit Compte-rendu de recherche"
+			"Pre´sentation de mate´riel produit Compte-rendu de recherche"
 		],
 		"seeAlso": [],
 		"attachments": [],
 		"extra": "HCLID: 367294",
 		"language": "Eng",
 		"abstractNote": "Wards cohorting infected orthopaedic patients may be particularly prone to transmitting extended-spectrum beta-lactamase-producing Enterobacteriaceae (ESBL-E). We analyze their epidemic pattern by performing molecular typing of ESBL-E isolated from patients and healthcare workers (HCW) from our septic ward. Between March 2010 and November 2011, 186 patients were admitted. Among 565 anal swabs, ESBL-E were detected in 204 samples from 45 patients, suggesting prolonged carriage in affected patients. Among 25 cases with identical ESBL-E species and positive epidemiological links, only 9 were really attributable to our service. We also screened 41 healthcare workers (HCW) on 49 occasions during the study period. Six samples (13%) were positive. None of the ESBL-E detected in HCW were related to any of the patient isolates. Among 60 environmental samples taken at the peak of the epidemic none revealed ESBL-E. We conclude that HCW also were anal carriers of ESBL-E, however the ESBL- strains from the HCW were not the same strains isolated from patients in the septic ward. Moreover, the epidemiological attribution of ESBL by simple vicinity, timing, and species identification might grossly overestimate transmission within a given unit.\n(RESUME D’AUTEUR)",
-		"reportType": "Présentation de matériel produit Compte-rendu de recherche",
-		"thesisType": "Présentation de matériel produit Compte-rendu de recherche",
-		"genre": "Présentation de matériel produit Compte-rendu de recherche",
+		"reportType": "Pre´sentation de mate´riel produit Compte-rendu de recherche",
+		"thesisType": "Pre´sentation de mate´riel produit Compte-rendu de recherche",
+		"genre": "Pre´sentation de mate´riel produit Compte-rendu de recherche",
 		"title": "Epidemiology and acquisition of extended-spectrum beta-lactamase-producing Enterobacteriaceae in a septic orthopedic ward",
 		"date": "2013",
 		"pages": "1-4",

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -2,14 +2,14 @@
 	"translatorID": "26ab1a2b-8740-4f79-a3e7-e0df62818839",
 	"label": "HospicesCivilsdeLyon",
 	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
-	"target": "(\.docchu-lyon|\.cclin-france|\.hcl)[^/]*\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
+	"target": "(\\.docchu-lyon|\\.cclin-france|\\.hcl)[^/]*\\.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",
 	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 25,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "g",
-	"lastUpdated": "2013-08-27 14:08:36"
+	"lastUpdated": "2013-12-10 15:33:51"
 }
 
 //Translator pour les sites http://rbh.docchu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.docchu-lyon.fr/
@@ -41,18 +41,20 @@ var typeMap = {
 //Détection de la présence de document multiple ou unique //Document detection: multiple or single
 function detectWeb(doc, url) {
 	if (url.match(/\/opac-search\.pl\?/)){return "multiple";}		//Listes de résultat
+	if (url.match(/\/search\.pl\?/)){return "multiple";}			//Listes de résultat admin
+	if (url.match(/\/basket\.pl\?/)){return "multiple";}
 	if (url.match(/opac-shelves/)){return "multiple";} 				//Listes publiques //Shelves
-	if (url.match(/\/opac-detail.pl\?/)) {							//Notice normale sur OPAC //Single
+	if (url.match(/\/opac-detail.pl\?/)) {							//Notice //normale sur OPAC //Single
 		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');	
 		if(type) return typeMap[type] || 'journalArticle';			//valeur par défaut //Default
 	}
-	if (url.match(/\/opac-MARCdetail.pl\?/)) {						//Notice MARC sur OPAC
+	if (url.match(/\/opac-MARCdetail.pl\?/)) {						//Notice //MARC sur OPAC
 		return 'journalArticle';
 	}
-		if (url.match(/\/MARCdetailHCL.pl\?/)) {					//Notice MARC sur interface admin
+		if (url.match(/\/MARCdetailHCL.pl\?/)) {					//Notice //MARC sur interface admin
 		return 'journalArticle';
 	}
-	if (url.match(/\/catalogue\/detail\.pl\?/)) {					//Notice normale sur interface admin
+	if (url.match(/\/catalogue\/detail\.pl\?/)) {					//Notice //normale sur interface admin
 		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
 		if(type) return typeMap[type] || 'journalArticle';			//valeur par défaut //Default
 	}
@@ -103,7 +105,7 @@ function doWeb(doc, url) {
 function scrape(marcurl) {
 	Zotero.Utilities.HTTP.doGet(marcurl, function (text) {
 		var translator = Zotero.loadTranslator("import");
-		translator.setTranslator("1b77cfcc-f4ae-47bd-86fe-47bda67f7793");
+		translator.setTranslator("8afafd94-1f10-440e-ba2f-93676048da41");
 		translator.setString(text);
 		translator.setHandler("itemDone", function (obj, item) {
 			//editors get mapped as contributors - but so do many others who should be
@@ -137,7 +139,6 @@ function scrape(marcurl) {
 	
 	})
 } 
-
 
 /** BEGIN TEST CASES **/
 var testCases = [

--- a/HospicesCivilsdeLyon
+++ b/HospicesCivilsdeLyon
@@ -1,0 +1,105 @@
+{
+	"translatorID": "6618c8fb-5419-403d-90ab-1836ccc74905",
+	"label": "HospicesCivilsdeLyon",
+	"creator": "Sebastian Karcher, Hospices Civils de Lyon",
+	"target": "(.chu-lyon|.cclin-france|.hcl)[^/]*.fr[^/]*/cgi-bin/koha/(opac-(detail|MARCdetail|search|shelves)|catalogue)",//It's dosen't work for admin and shelves
+	"minVersion": "2.1.9",
+	"maxVersion": "",
+	"priority": 25,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsib",
+	"lastUpdated": "2013-08-20 17:31:24"
+}
+
+//Translator pour les sites http://rbh.chu-lyon.fr | http://www.nosobase-biblio.cclin-france.fr/ | http://documentationcentrale.chu-lyon.progilone.fr/
+//Basé sur le //Based on the Translator "Library Catalog (Koha)" ID: 8e66aa6d-5b2a-4b44-b384-a838e23b8538 par Sebastian Karcher
+//Contact: Documentation Centrale des Hospices Civils de Lyon sur sa.documentationcentrale@chu-lyon.fr
+
+//Correspondance des types //Match Types
+var typeMap = {
+	' [Article de Revue]': 'journalArticle',
+	' [Texte législatif]': 'case',
+	' [Thèse]': 'thesis',
+	' [Chapitre d\'ouvrage]': 'bookSection',
+	' [Multimédia]': 'film',
+	' [Rapport]': 'report',
+	' [Mémoire]': 'thesis',
+	' [Article de Presse]': 'newspaperArticle',
+	' [Recommandation]': 'conferencePaper',
+	' [Acte de congrès]': 'conferencePaper',
+	' [Affiche]': 'artwork',
+};
+
+//Détection de la présence de document multiple ou unique //Document detection: multiple or single
+function detectWeb(doc, url) {
+	if (url.match(/\/opac-search\.pl\?/)){return "multiple";}
+	if (url.match(/\/opac-detail.pl\?/)) {
+		var type = ZU.xpathText(doc, '//span[@class="doc_type"]');
+		if(type) return typeMap[type] || 'journalArticle';	//valeur par défaut //Default
+}}
+
+//Téléchargement de la notice au format MARC utf8 //Download biblio in MARC utf8
+function marcURL(url){
+	var bibnumber = url.match(/(biblionumber=)(\d+)/)[2];
+	var host = url.match(/^.+cgi-bin\/koha\//)[0];
+	var marcURL = host + "opac-export.pl?format=utf8&op=export&bib=" + bibnumber +"save=Go";
+	return marcURL;
+}
+
+//Enregistrement de documents depuis la liste de résultat //Registration from the results list
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		var articles = [];
+		var items = {};
+		var titles = doc.evaluate('//span[@class="results_summary"]/a[contains(@href, "opac-detail.pl")]', doc, null, XPathResult.ANY_TYPE, null);
+		var title;
+		while (title = titles.iterateNext()) {
+			items[title.href] = title.textContent.trim();
+		}
+		Zotero.selectItems(items, function (items) {
+			if (!items) {
+				return true;
+			}
+			for (var i in items) {
+				articles.push(marcURL(i));
+			}
+			scrape(articles);
+		});
+	} else {
+		scrape(marcURL(url));
+	}
+}
+
+//Lien vers le Translator MARC //Calling the MARC translator
+function scrape(marcurl) {
+	Zotero.Utilities.HTTP.doGet(marcurl, function (text) {
+		var translator = Zotero.loadTranslator("import");
+		translator.setTranslator("a6ee60df-1ddc-4aae-bb25-45e0537be973");
+		translator.setString(text);
+		translator.setHandler("itemDone", function (obj, item) {
+			//editors get mapped as contributors - but so do many others who should be
+			// --> for books that don't have an author, turn contributors into editors.
+			if (item.itemType=="books"){
+				var hasAuthor = false;
+				for (var i in item.creators) {
+					if (item.creators[i].creatorType=="author") {
+						hasAuthor = true;
+						break;
+					}
+				}
+				if (!hasAuthor) {
+					for (var i in item.creators) {
+						if (item.creators[i].creatorType=="contributor") {
+						item.creators[i].creatorType="editor";
+						}
+					}
+				}
+			}
+			item.complete();
+		});
+		translator.translate();
+	
+	})
+} 
+

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -71,6 +71,43 @@ function clean(value) {
 	 
 };
 
+//Correspondance des labels avec les zones 4xx //Matching Notes Labels with 4xx fields
+	var Label =	{
+	'422':'<b>Est un suplément&nbsp;:&nbsp;</b>',
+	'423':'<b>Est publié avec&nbsp;:&nbsp;</b>',
+	'424':'<b>Est mis à jour Par&nbsp;:&nbsp;</b>',
+	'425':'<b>Met à jour&nbsp;:&nbsp;</b>',
+	'430':'<b>Suite de&nbsp;:&nbsp;</b>',
+	'432':'<b>Remplace&nbsp;:&nbsp;</b>',
+	'433':'<b>Remplace partiellement&nbsp;:&nbsp;</b>',
+	'434':'<b>Absorbe&nbsp;:&nbsp;</b>',
+	'436':'<b>Fusion de&nbsp;:&nbsp;</b>',
+	'440':'<b>Devient&nbsp;:&nbsp;</b>',
+	'442':'<b>Remplacé par&nbsp;:&nbsp;</b>',
+	'447':'<b>Fusionne avec&nbsp;:&nbsp;</b>',
+	//'463':'<b>Source&nbsp;:&nbsp;</b>',
+	'488':'<b>Voir aussi le document&nbsp;:&nbsp;</b>',
+	'300':'<b>Notes sur le document&nbsp;:&nbsp;</b>',
+};
+
+//Test de la valeur du tag des zones 4xx
+function LabelsforNotes(text) {
+	var pullRe = /[0-9]+/;
+	var m = pullRe.exec(text);
+	if(m) {
+		return Label[m];
+	}
+}
+
+// Ajouter un label aux zones 4xx importées en notes
+function Notes400(text) {
+	var pullRe = /.*/;
+	var m = pullRe.exec(text);
+	if(m) {
+		return m[0]+'<br><br>';
+	}
+}
+
 //Modification des types Koha=>Zotero //Change Koha's types to Zotero's one
 function MapType(text) {
 	var pullRe = /[A-Z]+/;
@@ -298,14 +335,15 @@ record.prototype._associateDBField = function(item, fieldNo, part, fieldName, ex
 record.prototype._associateNotes = function(item, fieldNo, part) {
 	var field = this.getFieldSubfields(fieldNo);
 	var texts = [];	
-
+	var TagNote =fieldNo;
 	for(var i in field) {
 		for(var j=0; j<part.length; j++) {
 			var myPart = part.substr(j, 1);
 			if(field[i][myPart]) {
-				texts.push(clean(field[i][myPart]));
+				texts.push(LabelsforNotes(TagNote),Notes400(field[i][myPart])); //Prefix label + Note content
 			}
 		}
+
 	}
 	var text = texts.join(' ');
 	if (text.trim() != "")
@@ -337,7 +375,7 @@ record.prototype.translate = function(item) {
 		// Extract ISBN
 		this._associateDBField(item, "010", "a", "ISBN", pullISBN);
 		// Extract ISSN
-		this._associateDBField(item, "011", "a", "ISSN", pullISBN);
+		this._associateDBField(item, "011", "a", "ISBN", pullISBN);
 		// Extract ISSN source
 		this._associateDBField(item, "463", "x", "ISSN", pullISBN);
 		// Extract ISBN source
@@ -407,7 +445,9 @@ record.prototype.translate = function(item) {
 		this._associateNotes(item, "440", "t");
 		this._associateNotes(item, "442", "t");
 		this._associateNotes(item, "447", "t");
-		
+		//this._associateNotes(item, "463", "t");
+		this._associateNotes(item, "488", "t");
+		this._associateNotes(item, "300", "a");
 		
 		// Extraction des mots-clés //Keywords
 		
@@ -444,6 +484,9 @@ record.prototype.translate = function(item) {
 
 			item.title += ' ' + title.e;
 		}
+		//Extraction des titres ISO
+		this._associateDBField(item, "531", "a", "shortTitle");
+
 		
 		// Extract Mention d'édition
 		this._associateDBField(item, "205", "a", "edition");

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -345,7 +345,7 @@ record.prototype.translate = function(item) {
 		// Extract DOI
 		this._associateDBField(item, "014", "a", "DOI");
 		// Extract Bill Numbers
-		this._associateDBField(item, "022", "b", "billNumber");
+		this._associateDBField(item, "022", "b", "publicLawNumber");
 		// Extract standard number
 		this._associateDBField(item, "017", "a", "issue");
 		// Extract report number

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -5,7 +5,7 @@
 	"target": "marc",
 	"minVersion": "2.1.9",
 	"maxVersion": "",
-	"priority": 100,
+	"priority": 125,
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -45,7 +45,7 @@ function clean(value) {
 	return value;
 }
 
-//Correspondance des types //Match Types
+//Correspondance des types //Match Types //HCL Specific
 	var KohaType = {
 	'ARE': 'journalArticle',
 	'TLEX': 'statute',
@@ -71,7 +71,7 @@ function clean(value) {
 	 
 };
 
-//Correspondance des labels avec les zones 4xx //Matching Notes Labels with 4xx fields
+//Correspondance des labels avec les zones 4xx //Matching Notes Labels with 4xx fields //HCL Specific
 	var Label =	{
 	'422':'<b>Est un suplément&nbsp;:&nbsp;</b>',
 	'423':'<b>Est publié avec&nbsp;:&nbsp;</b>',
@@ -90,7 +90,7 @@ function clean(value) {
 	'300':'<b>Notes sur le document&nbsp;:&nbsp;</b>',
 };
 
-//Test de la valeur du tag des zones 4xx
+//Test de la valeur du tag des zones 4xx //HCL Specific
 function LabelsforNotes(text) {
 	var pullRe = /[0-9]+/;
 	var m = pullRe.exec(text);
@@ -99,7 +99,7 @@ function LabelsforNotes(text) {
 	}
 }
 
-// Ajouter un label aux zones 4xx importées en notes
+// Ajouter un label aux zones 4xx importées en notes //Adding label to notes //HCL Specific
 function Notes400(text) {
 	var pullRe = /.*/;
 	var m = pullRe.exec(text);
@@ -108,7 +108,7 @@ function Notes400(text) {
 	}
 }
 
-//Modification des types Koha=>Zotero //Change Koha's types to Zotero's one
+//Modification des types Koha=>Zotero //Change Koha's types to Zotero's one //HCL Specific
 function MapType(text) {
 	var pullRe = /[A-Z]+/;
 	var m = pullRe.exec(text);
@@ -117,7 +117,7 @@ function MapType(text) {
 	}
 }
 
-//Ajout du préfixe "HCLID" au champ "extra" //Add the prefix "HCLID" to "extra" field
+//Ajout du préfixe "HCLID" au champ "extra" //Add the prefix "HCLID" to "extra" field //HCL Specific
 function IDHCL(text){
 	var pullRe = /[0-9]+/;
 	var m = pullRe.exec(text);
@@ -331,7 +331,7 @@ record.prototype._associateDBField = function(item, fieldNo, part, fieldName, ex
 	}
 }
 
-// add field to DB as note
+// add field to DB as note //HCL Specific
 record.prototype._associateNotes = function(item, fieldNo, part) {
 	var field = this.getFieldSubfields(fieldNo);
 	var texts = [];	
@@ -340,7 +340,7 @@ record.prototype._associateNotes = function(item, fieldNo, part) {
 		for(var j=0; j<part.length; j++) {
 			var myPart = part.substr(j, 1);
 			if(field[i][myPart]) {
-				texts.push(LabelsforNotes(TagNote),Notes400(field[i][myPart])); //Prefix label + Note content
+				texts.push(LabelsforNotes(TagNote),Notes400(field[i][myPart])); //Prefix label + Note content //HCL Specific
 			}
 		}
 
@@ -376,21 +376,21 @@ record.prototype.translate = function(item) {
 		this._associateDBField(item, "010", "a", "ISBN", pullISBN);
 		// Extract ISSN
 		this._associateDBField(item, "011", "a", "ISBN", pullISBN);
-		// Extract ISSN source
+		// Extract ISSN source //HCL Specific
 		this._associateDBField(item, "463", "x", "ISSN", pullISBN);
-		// Extract ISBN source
+		// Extract ISBN source //HCL Specific
 		this._associateDBField(item, "463", "y", "ISBN", pullISBN);
 		// Extract DOI
 		this._associateDBField(item, "014", "a", "DOI");
-		// Extract Bill Numbers
+		// Extract Bill Numbers //HCL Specific
 		this._associateDBField(item, "022", "b", "publicLawNumber");
-		// Extract standard number
+		// Extract standard number //HCL Specific
 		this._associateDBField(item, "017", "a", "issue");
 		// Extract report number
 		this._associateDBField(item, "015", "a", "reportNumber");
-		//Extract internal ID "HCLID"
+		//Extract internal ID "HCLID" //HCL Specific
 		this._associateDBField(item, "090", "a","extra", IDHCL);
-		//Extract ItemType
+		//Extract ItemType //HCL Specific
 		this._associateDBField(item, "200", "b","itemType", MapType);
 	
 		
@@ -433,20 +433,20 @@ record.prototype.translate = function(item) {
 		// Extract notes & summary
 		this._associateDBField(item, "328", "a", "abstractNote");
 		this._associateDBField(item, "330", "a", "abstractNote");
-		this._associateDBField(item, "311", "a", "history");
-		this._associateNotes(item, "422", "t");
-		this._associateNotes(item, "423", "t");
-		this._associateNotes(item, "424", "t");
-		this._associateNotes(item, "425", "t");
-		this._associateNotes(item, "430", "t");
-		this._associateNotes(item, "432", "t");
-		this._associateNotes(item, "434", "t");
-		this._associateNotes(item, "436", "t");
-		this._associateNotes(item, "440", "t");
-		this._associateNotes(item, "442", "t");
-		this._associateNotes(item, "447", "t");
-		//this._associateNotes(item, "463", "t");
-		this._associateNotes(item, "488", "t");
+		this._associateDBField(item, "311", "a", "history"); //HCL Specific
+		this._associateNotes(item, "422", "t"); //HCL Specific
+		this._associateNotes(item, "423", "t"); //HCL Specific
+		this._associateNotes(item, "424", "t"); //HCL Specific
+		this._associateNotes(item, "425", "t"); //HCL Specific
+		this._associateNotes(item, "430", "t"); //HCL Specific
+		this._associateNotes(item, "432", "t"); //HCL Specific
+		this._associateNotes(item, "434", "t"); //HCL Specific
+		this._associateNotes(item, "436", "t"); //HCL Specific
+		this._associateNotes(item, "440", "t"); //HCL Specific
+		this._associateNotes(item, "442", "t"); //HCL Specific
+		this._associateNotes(item, "447", "t"); //HCL Specific
+		//this._associateNotes(item, "463", "t"); //HCL Specific
+		this._associateNotes(item, "488", "t"); //HCL Specific
 		this._associateNotes(item, "300", "a");
 		
 		// Extraction des mots-clés //Keywords
@@ -459,13 +459,13 @@ record.prototype.translate = function(item) {
 		this._associateTags(item, "606", "abcxyz");
 		// termes géographiques
 		this._associateTags(item, "607", "axyz");
-		// genre/forme
+		// genre/forme //HCL Specific
 		this._associateTags(item, "608", "abcxyz");
-		// Type de raport
+		// Type de raport //HCL Specific
 		this._associateDBField(item, "608", "a", "reportType");
-		// Type de thèse
+		// Type de thèse //HCL Specific
 		this._associateDBField(item, "608", "a", "thesisType");
-		// Genre du film
+		// Genre du film //HCL Specific
 		this._associateDBField(item, "608", "a", "genre");
 		//Mots Libres (non utilisé)
 		//this._associateTags(item, "610", "a");
@@ -484,52 +484,52 @@ record.prototype.translate = function(item) {
 
 			item.title += ' ' + title.e;
 		}
-		//Extraction des titres ISO
+		//Extraction des titres ISO //HCL Specific
 		this._associateDBField(item, "531", "a", "shortTitle");
 
 		
 		// Extract Mention d'édition
 		this._associateDBField(item, "205", "a", "edition");
-		this._associateDBField(item, "463", "e", "edition");
+		this._associateDBField(item, "463", "e", "edition"); //HCL Specific
 		
 		// Extract Lieu de publication/production
 		this._associateDBField(item, "210", "a", "place");
-		this._associateDBField(item, "463", "c", "place");
+		this._associateDBField(item, "463", "c", "place"); //HCL Specific
 		
 		// Extract Editeur/distributeur/organisme
 		this._associateDBField(item, "210", "c", "distributor");
 		this._associateDBField(item, "210", "c", "publisher");
-		this._associateDBField(item, "463", "n", "place");
-		this._associateDBField(item, "710", "ab", "institution");
-		this._associateDBField(item, "210", "c", "university");
+		this._associateDBField(item, "463", "n", "place"); //HCL Specific
+		this._associateDBField(item, "710", "ab", "institution"); //HCL Specific
+		this._associateDBField(item, "210", "c", "university"); //HCL Specific
 		
 		// Extract Année de publication/diffusion
-		this._associateDBField(item, "210", "d", "date", pullNumber);
+		this._associateDBField(item, "210", "d", "date", pullNumber); //HCL Specific
 		
 		// Extract pages
-		this._associateDBField(item, "209", "h", "pages");
-		this._associateDBField(item, "209", "h", "codePages");
-		this._associateDBField(item, "209", "h", "numPages");
+		this._associateDBField(item, "209", "h", "pages"); //HCL Specific
+		this._associateDBField(item, "209", "h", "codePages"); //HCL Specific
+		this._associateDBField(item, "209", "h", "numPages"); //HCL Specific
 		
 		// Extract volume/tome-numéro
-		this._associateDBField(item, "209", "b", "volume");
-		this._associateDBField(item, "209", "d", "issue");
+		this._associateDBField(item, "209", "b", "volume"); //HCL Specific
+		this._associateDBField(item, "209", "d", "issue"); //HCL Specific
 		
 		// Extract Durée et format du film
 		this._associateDBField(item, "215", "a", "runningTime");
 		this._associateDBField(item, "215", "d", "videoRecordingFormat");
 		
 		// Extract Numéro de raport
-		this._associateDBField(item, "209", "d", "reportNumber");
+		this._associateDBField(item, "209", "d", "reportNumber"); //HCL Specific
 		
 		// Extract Collection - Publication Source
 		this._associateDBField(item, "225", "a", "series");
-		this._associateDBField(item, "463", "t", "publicationTitle");
-		this._associateDBField(item, "463", "t", "code");
-		this._associateDBField(item, "463", "t", "bookTitle");
+		this._associateDBField(item, "463", "t", "publicationTitle"); //HCL Specific
+		this._associateDBField(item, "463", "t", "code"); //HCL Specific
+		this._associateDBField(item, "463", "t", "bookTitle"); //HCL Specific
 		
 		// Extract series number
-		this._associateDBField(item, "209", "b", "seriesNumber");
+		this._associateDBField(item, "209", "b", "seriesNumber"); //HCL Specific
 
 		// Extract Numéro de cote
 		this._associateDBField(item, "995", "k", "callNumber");

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -48,7 +48,7 @@ function clean(value) {
 //Correspondance des types //Match Types
 	var KohaType = {
 	'ARE': 'journalArticle',
-	'TLEX': 'case',
+	'TLEX': 'statute',
 	'THE': 'thesis',
 	'CHAP': 'bookSection',
 	'MUL': 'film',
@@ -396,10 +396,17 @@ record.prototype.translate = function(item) {
 		this._associateDBField(item, "328", "a", "abstractNote");
 		this._associateDBField(item, "330", "a", "abstractNote");
 		this._associateDBField(item, "311", "a", "history");
-		//this._associateDBField(item, "424", "t", "history");
-		//this._associateDBField(item, "425", "t", "history");
-		//this._associateDBField(item, "432", "t", "history");
-		//this._associateDBField(item, "442", "t", "history");
+		this._associateNotes(item, "422", "t");
+		this._associateNotes(item, "423", "t");
+		this._associateNotes(item, "424", "t");
+		this._associateNotes(item, "425", "t");
+		this._associateNotes(item, "430", "t");
+		this._associateNotes(item, "432", "t");
+		this._associateNotes(item, "434", "t");
+		this._associateNotes(item, "436", "t");
+		this._associateNotes(item, "440", "t");
+		this._associateNotes(item, "442", "t");
+		this._associateNotes(item, "447", "t");
 		
 		
 		// Extraction des mots-clés //Keywords

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -1,0 +1,526 @@
+{
+	"translatorID": "1b77cfcc-f4ae-47bd-86fe-47bda67f7793",
+	"label": "MARC_HospicesCivilsdeLyon",
+	"creator": "Simon Kornblith, Sylvain Machefert, HospicesCivilsdeLyon",
+	"target": "marc",
+	"minVersion": "2.1.9",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 1,
+	"browserSupport": "gcs",
+	"lastUpdated": "2013-08-22 14:00:01"
+}
+
+function detectImport() {
+	var marcRecordRegexp = /^[0-9]{5}[a-z ]{3}$/
+	var read = Zotero.read(8);
+	if(marcRecordRegexp.test(read)) {
+		return true;
+	}
+}
+//test
+var fieldTerminator = "\x1E";
+var recordTerminator = "\x1D";
+var subfieldDelimiter = "\x1F";
+
+/*
+ * CLEANING FUNCTIONS
+ */
+
+
+// general purpose cleaning
+function clean(value) {
+	value = value.replace(/^[\s\.\,\/\:;]+/, '');
+	value = value.replace(/[\s\.\,\/\:;]+$/, '');
+	value = value.replace(/ +/g, ' ');
+	
+	var char1 = value.substr(0, 1);
+	var char2 = value.substr(value.length-1);
+	if((char1 == "[" && char2 == "]") || (char1 == "(" && char2 == ")")) {
+		// chop of extraneous characters
+		return value.substr(1, value.length-2);
+	}
+	
+	return value;
+}
+
+//Correspondance des types //Match Types
+	var KohaType = {
+	'ARE': 'journalArticle',
+	'TLEX': 'case',
+	'THE': 'thesis',
+	'CHAP': 'bookSection',
+	'MUL': 'film',
+	'RAP': 'report',
+	'MEM': 'thesis',
+	'APR': 'newspaperArticle',
+	'RECO': 'journalArticle',	
+	'REV': 'book',
+	'PRE': 'book',
+	'OUV': 'book',
+	'DICO': 'book',
+	'MAB': 'book',
+	'BUL': 'journalArticle',
+	'CONN': 'journalArticle',
+	'ACTI': 'journalArticle',
+	'ACT': 'conferencePaper',
+	'AFF': 'artwork',
+	'POST ': 'conferencePaper',
+	'NOR': 'journalArticle',
+	 
+};
+
+//Modification des types Koha=>Zotero //Change Koha's types to Zotero's one
+function MapType(text) {
+	var pullRe = /[A-Z]+/;
+	var m = pullRe.exec(text);
+	if(m) {
+		return KohaType[m];
+	}
+}
+
+//Ajout du préfixe "HCLID" au champ "extra" //Add the prefix "HCLID" to "extra" field
+function IDHCL(text){
+	var pullRe = /[0-9]+/;
+	var m = pullRe.exec(text);
+	if(m) {	return "HCLID: "+m[0];
+	}
+}
+
+// number extraction
+function pullNumber(text) {
+	var pullRe = /[0-9]+/;
+	var m = pullRe.exec(text);
+	if(m) {
+		return m[0];
+	}
+}
+
+// ISBN extraction
+function pullISBN(text) {
+	var pullRe = /[0-9X\-]+/;
+	var m = pullRe.exec(text);
+	if(m) {
+		return m[0];
+	}
+}
+
+// corporate author extraction
+function corpAuthor(author) {
+	return {lastName:author, fieldMode:true};
+}
+
+// regular author extraction
+function author(author, type, useComma) {
+	return Zotero.Utilities.cleanAuthor(author, type, useComma);
+}
+
+/*
+ * END CLEANING FUNCTIONS
+ */
+
+var record = function() {
+	this.directory = new Object();
+	this.leader = "";
+	this.content = "";
+	
+	// defaults
+	this.indicatorLength = 2;
+	this.subfieldCodeLength = 2;
+}
+
+// import a binary MARC record into this record
+record.prototype.importBinary = function(record) {
+	// get directory and leader
+	var directory = record.substr(0, record.indexOf(fieldTerminator));
+	this.leader = directory.substr(0, 24);
+	var directory = directory.substr(24);
+
+	// get various data
+	this.indicatorLength = parseInt(this.leader.substr(10, 1), 10);
+	this.subfieldCodeLength = parseInt(this.leader.substr(11, 1), 10);
+	var baseAddress = parseInt(this.leader.substr(12, 5), 10);
+
+	// get record data
+	var contentTmp = record.substr(baseAddress);
+
+	// MARC wants one-byte characters, so when we have multi-byte UTF-8
+	// sequences, add null characters so that the directory shows up right. we
+	// can strip the nulls later.
+	this.content = "";
+	for(i=0; i<contentTmp.length; i++) {
+		this.content += contentTmp.substr(i, 1);
+		if(contentTmp.charCodeAt(i) > 0x00FFFF) {
+			this.content += "\x00\x00\x00";
+		} else if(contentTmp.charCodeAt(i) > 0x0007FF) {
+			this.content += "\x00\x00";
+		} else if(contentTmp.charCodeAt(i) > 0x00007F) {
+			this.content += "\x00";
+		}
+	}
+	
+	// read directory
+	for(var i=0; i<directory.length; i+=12) {
+		var tag = parseInt(directory.substr(i, 3), 10);
+		var fieldLength = parseInt(directory.substr(i+3, 4), 10);
+		var fieldPosition = parseInt(directory.substr(i+7, 5), 10);
+		
+		if(!this.directory[tag]) {
+			this.directory[tag] = new Array();
+		}
+		this.directory[tag].push([fieldPosition, fieldLength]);
+	}
+}
+
+// add a field to this record
+record.prototype.addField = function(field, indicator, value) {
+	field = parseInt(field, 10);
+	// make sure indicator is the right length
+	if(indicator.length > this.indicatorLength) {
+		indicator = indicator.substr(0, this.indicatorLength);
+	} else if(indicator.length != this.indicatorLength) {
+		indicator = Zotero.Utilities.lpad(indicator, " ", this.indicatorLength);
+	}
+	
+	// add terminator
+	value = indicator+value+fieldTerminator;
+	
+	// add field to directory
+	if(!this.directory[field]) {
+		this.directory[field] = new Array();
+	}
+	this.directory[field].push([this.content.length, value.length]);
+	
+	// add field to record
+	this.content += value;
+}
+
+// get all fields with a certain field number
+record.prototype.getField = function(field) {
+	field = parseInt(field, 10);
+	var fields = new Array();
+	
+	// make sure fields exist
+	if(!this.directory[field]) {
+		return fields;
+	}
+	
+	// get fields
+	for(var i in this.directory[field]) {
+		var location = this.directory[field][i];
+		
+		// add to array, replacing null characters
+		fields.push([this.content.substr(location[0], this.indicatorLength),
+			this.content.substr(location[0]+this.indicatorLength,
+			location[1]-this.indicatorLength-1).replace(/\x00/g, "")]);
+	}
+	
+	return fields;
+}
+
+//given a field string, split it into subfields
+record.prototype.extractSubfields = function(fieldStr, tag /*for error message only*/) {
+	if(!tag) tag = '<no tag>';
+
+	returnSubfields = new Object();
+
+	var subfields = fieldStr.split(subfieldDelimiter);
+	if (subfields.length == 1) {
+		returnSubfields["?"] = fieldStr;
+	} else {
+		for(var j in subfields) {
+			if(subfields[j]) {
+				var subfieldIndex = subfields[j].substr(0, this.subfieldCodeLength-1);
+				if(!returnSubfields[subfieldIndex]) {
+					returnSubfields[subfieldIndex] = subfields[j].substr(this.subfieldCodeLength-1);
+				} else {
+					// Duplicate subfield
+					Zotero.debug("Duplicate subfield '"+tag+" "+subfieldIndex+"="+subfields[j]);
+					returnSubfields[subfieldIndex] = returnSubfields[subfieldIndex] + " " + subfields[j].substr(this.subfieldCodeLength-1);
+				}
+			}
+		}
+	}
+
+	return returnSubfields;
+}
+
+// get subfields from a field
+record.prototype.getFieldSubfields = function(tag) { // returns a two-dimensional array of values
+	var fields = this.getField(tag);
+	var returnFields = new Array();
+	
+	for(var i=0, n=fields.length; i<n; i++) {
+		returnFields[i] = this.extractSubfields(fields[i][1], tag);
+	}
+	
+	return returnFields;
+}
+
+// add field to DB
+record.prototype._associateDBField = function(item, fieldNo, part, fieldName, execMe, arg1, arg2) {
+	var field = this.getFieldSubfields(fieldNo);
+	
+	Zotero.debug('MARC: found '+field.length+' matches for '+fieldNo+part);
+	if(field) {
+		for(var i in field) {
+			var value = false;
+			for(var j=0; j<part.length; j++) {
+				var myPart = part.substr(j, 1);
+				if(field[i][myPart]) {
+					if(value) {
+						value += " "+field[i][myPart];
+					} else {
+						value = field[i][myPart];
+					}
+				}
+			}
+			if(value) {
+				value = clean(value);
+				
+				if(execMe) {
+					value = execMe(value, arg1, arg2);
+				}
+				
+				if(fieldName == "creator") {
+					item.creators.push(value);
+				} else {
+					item[fieldName] = value;
+					return;
+				}
+			}
+		}
+	}
+}
+
+// add field to DB as note
+record.prototype._associateNotes = function(item, fieldNo, part) {
+	var field = this.getFieldSubfields(fieldNo);
+	var texts = [];	
+
+	for(var i in field) {
+		for(var j=0; j<part.length; j++) {
+			var myPart = part.substr(j, 1);
+			if(field[i][myPart]) {
+				texts.push(clean(field[i][myPart]));
+			}
+		}
+	}
+	var text = texts.join(' ');
+	if (text.trim() != "")
+		item.notes.push({note: text});
+}
+
+// add field to DB as tags
+record.prototype._associateTags = function(item, fieldNo, part) {
+	var field = this.getFieldSubfields(fieldNo);
+	
+	for(var i in field) {
+		for(var j=0; j<part.length; j++) {
+			var myPart = part.substr(j, 1);
+			if(field[i][myPart]) {
+				item.tags.push(clean(field[i][myPart]));
+			}
+		}
+	}
+}
+
+// this function loads a MARC record into our database
+
+
+record.prototype.translate = function(item) {
+
+	if ( (this.getFieldSubfields("200")[0]))
+	{
+		this._associateDBField(item, "010", "a", "ISBN", pullISBN);
+		// Extract ISBN
+		this._associateDBField(item, "010", "a", "ISBN", pullISBN);
+		// Extract ISSN
+		this._associateDBField(item, "011", "a", "ISSN", pullISBN);
+		// Extract ISSN source
+		this._associateDBField(item, "463", "x", "ISSN", pullISBN);
+		// Extract ISBN source
+		this._associateDBField(item, "463", "y", "ISBN", pullISBN);
+		// Extract DOI
+		this._associateDBField(item, "014", "a", "DOI");
+		// Extract Bill Numbers
+		this._associateDBField(item, "022", "b", "billNumber");
+		// Extract standard number
+		this._associateDBField(item, "017", "a", "issue");
+		// Extract report number
+		this._associateDBField(item, "015", "a", "reportNumber");
+		//Extract internal ID "HCLID"
+		this._associateDBField(item, "090", "a","extra", IDHCL);
+		//Extract ItemType
+		this._associateDBField(item, "200", "b","itemType", MapType);
+	
+		
+		// Extract creators (700, 701 & 702)
+		for (var i = 700; i < 703; i++)
+		{
+			var authorTab = this.getFieldSubfields(i);
+			for (var j in authorTab) 
+			{
+				var aut = authorTab[j];
+				var authorText = "";
+				if ( (aut.b) && (aut.a) ){
+					authorText = aut['a'].replace(/,\s*$/,'') + ", " + aut['b'];
+				} 
+				else
+				{
+					authorText = aut['a'];
+				}
+				//prevent this from crashing with empty author tags 
+				if(authorText) item.creators.push(Zotero.Utilities.cleanAuthor(authorText, "author", true));
+			}
+		}
+		
+		// Extract corporate creators (710, 711 & 712)
+		for (var i = 710; i < 713; i++)
+		{
+			var authorTab = this.getFieldSubfields(i);
+			for (var j in authorTab)
+			{
+				if (authorTab[j]['a'])
+				{
+					item.creators.push({lastName:authorTab[j]['a'], creatorType:"contributor", fieldMode:true});
+				}
+			}
+		}
+		
+		// Extract languages
+		this._associateDBField(item, "101", "a", "language");
+		
+		// Extract notes & summary
+		this._associateDBField(item, "328", "a", "abstractNote");
+		this._associateDBField(item, "330", "a", "abstractNote");
+		this._associateDBField(item, "311", "a", "history");
+		//this._associateDBField(item, "424", "t", "history");
+		//this._associateDBField(item, "425", "t", "history");
+		//this._associateDBField(item, "432", "t", "history");
+		//this._associateDBField(item, "442", "t", "history");
+		
+		
+		// Extraction des mots-clés //Keywords
+		
+		// personne
+		this._associateTags(item, "600", "aqtxyz");
+		// Organismes ou congres
+		this._associateTags(item, "601", "abtxyz");
+		// Sujet Noms Communs
+		this._associateTags(item, "606", "abcxyz");
+		// termes géographiques
+		this._associateTags(item, "607", "axyz");
+		// genre/forme
+		this._associateTags(item, "608", "abcxyz");
+		// Type de raport
+		this._associateDBField(item, "608", "a", "reportType");
+		// Type de thèse
+		this._associateDBField(item, "608", "a", "thesisType");
+		// Genre du film
+		this._associateDBField(item, "608", "a", "genre");
+		//Mots Libres (non utilisé)
+		//this._associateTags(item, "610", "a");
+		
+		// Extract title
+		var title = this.getField("200")[0][1]	//non-repeatable
+						.replace(	//chop off any translations, since they may have repeated $e fields
+							new RegExp('\\' + subfieldDelimiter + 'd.+'), '');
+		title = this.extractSubfields(title, '200');
+		item.title = title.a;
+		if(title.e) {
+			//If the title proper did not end in a punctuation mark, we should add a colon
+			if(item.title.search(/[A-Za-z0-9]\s*/) != -1) {
+				item.title += ':';
+			}
+
+			item.title += ' ' + title.e;
+		}
+		
+		// Extract Mention d'édition
+		this._associateDBField(item, "205", "a", "edition");
+		this._associateDBField(item, "463", "e", "edition");
+		
+		// Extract Lieu de publication/production
+		this._associateDBField(item, "210", "a", "place");
+		this._associateDBField(item, "463", "c", "place");
+		
+		// Extract Editeur/distributeur/organisme
+		this._associateDBField(item, "210", "c", "distributor");
+		this._associateDBField(item, "210", "c", "publisher");
+		this._associateDBField(item, "463", "n", "place");
+		this._associateDBField(item, "710", "ab", "institution");
+		this._associateDBField(item, "210", "c", "university");
+		
+		// Extract Année de publication/diffusion
+		this._associateDBField(item, "210", "d", "date", pullNumber);
+		
+		// Extract pages
+		this._associateDBField(item, "209", "h", "pages");
+		this._associateDBField(item, "209", "h", "codePages");
+		this._associateDBField(item, "209", "h", "numPages");
+		
+		// Extract volume/tome-numéro
+		this._associateDBField(item, "209", "b", "volume");
+		this._associateDBField(item, "209", "d", "issue");
+		
+		// Extract Durée et format du film
+		this._associateDBField(item, "215", "a", "runningTime");
+		this._associateDBField(item, "215", "d", "videoRecordingFormat");
+		
+		// Extract Numéro de raport
+		this._associateDBField(item, "209", "d", "reportNumber");
+		
+		// Extract Collection - Publication Source
+		this._associateDBField(item, "225", "a", "series");
+		this._associateDBField(item, "463", "t", "publicationTitle");
+		this._associateDBField(item, "463", "t", "code");
+		this._associateDBField(item, "463", "t", "bookTitle");
+		
+		// Extract series number
+		this._associateDBField(item, "209", "b", "seriesNumber");
+
+		// Extract Numéro de cote
+		this._associateDBField(item, "995", "k", "callNumber");
+		
+		// Extract url
+		this._associateDBField(item, "856", "u", "url");
+	}
+	
+}
+
+function doImport() {
+	var text;
+	var holdOver = "";	// part of the text held over from the last loop
+	
+	while(text = Zotero.read(4096)) {	// read in 4096 byte increments
+		var records = text.split("\x1D");
+		
+		if(records.length > 1) {
+			records[0] = holdOver + records[0];
+			holdOver = records.pop(); // skip last record, since it's not done
+			
+			for(var i in records) {
+				var newItem = new Zotero.Item();
+				
+				// create new record
+				var rec = new record();	
+				rec.importBinary(records[i]);
+				rec.translate(newItem);
+				
+				newItem.complete();
+			}
+		} else {
+			holdOver += text;
+		}
+	}
+}
+
+var exports = {
+	"record":record,
+	"fieldTerminator":fieldTerminator,
+	"recordTerminator":recordTerminator,
+	"subfieldDelimiter":subfieldDelimiter
+};
+

--- a/MARC_HospicesCivilsdeLyon
+++ b/MARC_HospicesCivilsdeLyon
@@ -1,15 +1,15 @@
 {
-	"translatorID": "1b77cfcc-f4ae-47bd-86fe-47bda67f7793",
+	"translatorID": "8afafd94-1f10-440e-ba2f-93676048da41",
 	"label": "MARC_HospicesCivilsdeLyon",
 	"creator": "Simon Kornblith, Sylvain Machefert, HospicesCivilsdeLyon",
 	"target": "marc",
-	"minVersion": "2.1.9",
+	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 125,
 	"inRepository": true,
 	"translatorType": 1,
-	"browserSupport": "gcs",
-	"lastUpdated": "2013-08-22 14:00:01"
+	"browserSupport": "g",
+	"lastUpdated": "2013-12-10 15:31:33"
 }
 
 function detectImport() {


### PR DESCRIPTION
Translators work for these sites:
http://rbh.docchu-lyon.fr/
http://documentationcentrale.docchu-lyon.fr/
http://www.nosobase-biblio.cclin-france.fr/

The "HospicesCivilsdeLyon" file is a fork of the translator "Library Catalog (Koha)" because our database uses Koha but to specific way:
- specific itemtypes
- different default value for type
- specific targets.

The MARC schema describe into the "MARC_HospicesCivilsdeLyon" file  is specific to this database:
- UNIMARC schema only
- New fields Added
- Specific items types
- Specific "extra"
