### PR TITLE
[Do not merge] DOI search overhaul

### DIFF
--- a/CSL JSON.js
+++ b/CSL JSON.js
@@ -9,21 +9,12 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcs",
-	"lastUpdated": "2011-09-25 20:49:56"
+	"lastUpdated": "2013-10-24 05:03:52"
 }
 
 var parsedData;
-function detectImport() {
-	const CSL_TYPES = {"article":true, "article-journal":true, "article-magazine":true,
-		"article-newspaper":true, "bill":true, "book":true, "broadcast":true,
-		"chapter":true, "dataset":true, "entry":true, "entry-dictionary":true,
-		"entry-encyclopedia":true, "figure":true, "graphic":true, "interview":true,
-		"legal_case":true, "legislation":true, "manuscript":true, "map":true,
-		"motion_picture":true, "musical_score":true, "pamphlet":true,
-		"paper-conference":true, "patent":true, "personal_communication":true,
-		"post":true, "post-weblog":true, "report":true, "review":true, "review-book":true,
-		"song":true, "speech":true, "thesis":true, "treaty":true, "webpage":true};
-		
+
+function parseInput() {
 	var str, json = "";
 	
 	// Read in the whole file at once, since we can't easily parse a JSON stream. The 
@@ -35,8 +26,22 @@ function detectImport() {
 		parsedData = JSON.parse(json);	
 	} catch(e) {
 		Zotero.debug(e);
-		return false;
 	}
+}
+
+function detectImport() {
+	const CSL_TYPES = {"article":true, "article-journal":true, "article-magazine":true,
+		"article-newspaper":true, "bill":true, "book":true, "broadcast":true,
+		"chapter":true, "dataset":true, "entry":true, "entry-dictionary":true,
+		"entry-encyclopedia":true, "figure":true, "graphic":true, "interview":true,
+		"legal_case":true, "legislation":true, "manuscript":true, "map":true,
+		"motion_picture":true, "musical_score":true, "pamphlet":true,
+		"paper-conference":true, "patent":true, "personal_communication":true,
+		"post":true, "post-weblog":true, "report":true, "review":true, "review-book":true,
+		"song":true, "speech":true, "thesis":true, "treaty":true, "webpage":true};
+		
+	parseInput();
+	if(!parsedData) return false;
 	
 	if(typeof parsedData !== "object") return false;
 	if(!(parsedData instanceof Array)) parsedData = [parsedData];
@@ -51,6 +56,9 @@ function detectImport() {
 }
 
 function doImport() {
+	if(!parsedData) parseInput();
+	if(!parsedData) return;
+	
 	for(var i=0; i<parsedData.length; i++) {
 		var item = new Z.Item();
 		ZU.itemFromCSLJSON(item, parsedData[i]);

--- a/DOI.js
+++ b/DOI.js
@@ -7,9 +7,9 @@
 	"maxVersion": "",
 	"priority": 300,
 	"inRepository": true,
-	"translatorType": 4,
+	"translatorType": 12,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-04-04 05:29:41"
+	"lastUpdated": "2013-10-23 07:41:26"
 }
 
 var items = {};
@@ -93,36 +93,26 @@ function completeDOIs(doc) {
 }
 
 function retrieveDOIs(DOIs, doc) {
-	__num_DOIs = DOIs.length;
+	var translate = Zotero.loadTranslator("search");
+	//load self
+	translate.setTranslator("c159dcfe-8a53-4301-a499-30f6549c340d");
+	translate.setSearch(DOIs);
 
-	for(var i=0, n=DOIs.length; i<n; i++) {
-		(function(doc, DOI) {
-			var translate = Zotero.loadTranslator("search");
-			translate.setTranslator("11645bd1-0420-45c1-badb-53fb41eeb753");
-	
-			var item = {"itemType":"journalArticle", "DOI":DOI};
-			translate.setSearch(item);
-	
-			// don't save when item is done
-			translate.setHandler("itemDone", function(translate, item) {
-				item.repository = "CrossRef";
-				items[DOI] = item;
-				selectArray[DOI] = item.title;
-			});
-	
-			translate.setHandler("done", function(translate) {
-				__num_DOIs--;
-				if(__num_DOIs <= 0) {
-					completeDOIs(doc);
-				}
-			});
-	
-			// Don't throw on error
-			translate.setHandler("error", function() {});
-	
-			translate.translate();
-		})(doc, DOIs[i]);
-	}
+	// don't save when item is done
+	translate.setHandler("itemDone", function(translate, item) {
+		if(item._status !== 'success') return;
+		items[item._query] = item;
+		selectArray[item._query] = item.title;
+	});
+
+	translate.setHandler("done", function(translate) {
+		completeDOIs(doc);
+	});
+
+	// Don't throw on error
+	translate.setHandler("error", function() {});
+
+	translate.translate();
 }
 
 function doWeb(doc, url) {
@@ -132,6 +122,269 @@ function doWeb(doc, url) {
 	retrieveDOIs(DOIs, doc);
 }
 
+function detectSearch(items) {
+	if(!items) return false;
+	
+	if(items.directSearch) {
+		Z.debug("DOI: directSearch was set, skipping global DOI search.");
+		return false;
+	}
+	
+	if(typeof items == 'string') {
+		if(ZU.cleanDOI(items)) return true;
+		return false;
+	}
+	
+	if(typeof items == 'string' || !items.length) items = [items];
+	
+	//if we have at least one valid-looking DOI, return true
+	for(var i=0, n=items.length; i<n; i++) {
+		if(items[i]) {
+			if(items[i].DOI && ZU.cleanDOI('' + items[i].DOI)) {
+				return true;
+			} else if(typeof items[i] == 'string' && ZU.cleanDOI(items[i])) {
+				return true;
+			}
+		}
+	}
+	
+	return false;
+}
+
+//try translators until we get a result
+function runTranslator(translators, item) {
+	if(!translators.length) {
+		Z.debug("No more translators left to try.");
+		return;
+	}
+
+	var transDesc = translators.shift();
+	var trans = Zotero.loadTranslator("search");
+	trans.setTranslator(transDesc);
+	trans.setSearch(item);
+
+	trans.setHandler("itemDone", function(obj, newItem) {
+		runTranslator.done = true;
+		newItem.complete();
+	});
+
+	//keep going until we get an item
+	trans.setHandler("done", function(){
+		if(!runTranslator.done) {
+			runTranslator(translators);
+		}
+	});
+
+	trans.translate();
+}
+
+//try to resolve doi via other methods
+function fail_callback(doi) {
+	var trans = Zotero.loadTranslator("search");
+	trans.setTranslator(fallback_search_translators);
+
+	var item = new Zotero.Item();
+	item.DOI = doi;
+	trans.setSearch(item);
+
+	trans.setHandler('translators', function(trans, detected) {
+		runTranslator.done = false;
+		runTranslator(detected, item);
+	});
+
+	trans.getTranslators(false, true);	//get all translators that pass detectSearch
+}
+
+var supportedRAs = {
+	"CrossRef": "11645bd1-0420-45c1-badb-53fb41eeb753",
+	"AIRITI": "5f0ca39b-898a-4b1e-b98d-8cd0d6ce9801",
+	"EIDR": "79c3d292-0afc-42a1-bd86-7e706fc35aa5",
+	"Data Cite": "9f1fb86b-92c8-4db7-b8ee-0b481d456428"
+	//we don't have translators for the following yets
+	//"CNKI"
+	//"JaLC"
+	//"mEDRA"
+	//"OPOCE"
+};
+	
+/**
+ * Takes a single DOI or an array of DOIs as item.DOI
+ * Attempts to retrieve the DOIs from an appropriate authority
+ * Assigns a status code to item._status
+**/
+function doSearch(items) {
+	var query = filterQuery(items);
+	if(!query.length) return;
+	
+	fetchFromCrossRef(query, determineOtherRAs);
+}
+
+/**
+ * Filter out invalid queries
+ */
+function filterQuery(items) {
+	if(!items) return [];
+	
+	if(typeof items == 'string' || !items.length) items = [items];
+	
+	//filter out invalid queries
+	var query = [];
+	for(var i=0, n=items.length; i<n; i++) {
+		if( ( items[i].DOI && ZU.cleanDOI(items[i].DOI) )
+			|| ( typeof items[i] == 'string' && ZU.cleanDOI(items[i]) ) ) {
+			query.push(items[i]);
+		} else {
+			var newItem = new Zotero.Item();
+			newItem._status = 'invalid';
+			newItem._query = items[i];
+			newItem.complete();
+		}
+	}
+	return query;
+}
+
+function fetchFromCrossRef(query, next) {
+	var queryNext = [];
+	
+	var trans = Zotero.loadTranslator("search");
+	// CrossRef
+	trans.setTranslator("11645bd1-0420-45c1-badb-53fb41eeb753");
+	trans.setSearch(query);
+	
+	trans.setHandler("itemDone", function(obj, item) {
+		if(item._status === 'success') {
+			item.libraryCatalog = 'CrossRef';
+			item.complete();
+		} else {
+			queryNext.push(item._query);
+		}
+	});
+	
+	trans.setHandler("done", function(obj) {
+		if(queryNext.length) {
+			next(queryNext);
+		}
+	});
+	
+	trans.translate();
+}
+
+function determineOtherRAs(query) {
+	//determine RAs
+	var getLengthLimit = 2048; //to be on the safe side
+	var requestURL = 'http://doi.crossref.org/doiRA/';
+	var doiRequest = requestURL;
+	var first = true;
+	var urls = [];
+	var queryTracker = {};
+	
+	for(var i=0, n=query.length; i<n; i++) {
+		// Escape some incompatible characters although RA lookup tool doesn't
+		// currently support escaped characters.
+		// This will avoid problems on our end.
+		var doi = ZU.cleanDOI(query[i].DOI || query[i]);
+		queryTracker[doi] = query[i]; //potential issue: searching for the same DOI more than once
+		
+		Z.debug("Looking up RA for " + doi);
+		
+		var escapedDOI = doi.replace(/[,#&?]/g, function(m) { return escapeURIComponent(m); });
+		if( (doiRequest.length + escapedDOI.length + 1) <= getLengthLimit ) {
+			if(!first) doiRequest += ',';
+			else first = false;
+			
+			doiRequest += escapedDOI;
+			continue;
+		}
+		
+		urls.push(doiRequest);
+		doiRequest = requestURL + escapedDOI;
+	}
+	
+	if(doiRequest != requestURL) {
+		urls.push(doiRequest);
+	}
+	
+	var queryByRA = {};
+	var ras = [];
+		
+	ZU.doGet(urls, function(text) {
+		var raList;
+		try {
+			raList = JSON.parse(text);
+		} catch(e) {
+			Z.debug("Error parsing RA list");
+			Z.debug(e);
+			raList = [];
+		}
+		
+		for(var i=0, n=raList.length; i<n; i++) {
+			var inputQuery = queryTracker[raList[i].DOI];
+			if(!inputQuery) {
+				Z.debug("RA lookup returned result for " + raList[i].DOI + " which was not in the input");
+				continue;
+			}
+			
+			delete queryTracker[raList[i].DOI];
+			
+			if(raList[i].RA == "DOI does not exist" || raList[i].RA == "Invalid DOI"
+				|| raList[i].RA == "CrossRef") { //we already checked CrossRef, so no need to check again
+				var item = new Zotero.Item();
+				item._query = inputQuery;
+				item._status = raList[i].RA != "Invalid DOI" ? 'not found' : 'invalid';
+				item.complete();
+				continue;
+			}
+			
+			if(!queryByRA[raList[i].RA]) {
+				queryByRA[raList[i].RA] = [];
+				ras.push(raList[i].RA);
+			}
+			
+			queryByRA[raList[i].RA].push(inputQuery);
+		}
+	},
+	function() {
+		//take care of queries that didn't get results
+		for(var q in queryTracker) {
+			var newItem = new Zotero.Item();
+			newItem._query = queryTracker[q];
+			newItem._status = 'not found';
+			newItem.complete();
+		}
+		
+		fetchFromOtherRAs(queryByRA, ras)
+	});
+}
+
+function fetchFromOtherRAs(queryByRA, ras) {
+	for(var i=0, n=ras.length; i<n; i++) {
+		var transID = supportedRAs[ras[i]];
+		var query = queryByRA[ras[i]];
+		
+		if(!transID) {
+			for(var j=0, m=query.length; j<m; j++) {
+				var item = new Zotero.Item();
+				item._query = query[j];
+				item._status = 'unimplemented';
+				item.complete();
+			}
+			continue;
+		}
+		
+		(function(ra) {
+			var trans = Zotero.loadTranslator("search");
+			trans.setTranslator(transID);
+			trans.setSearch(query);
+			trans.setHandler('itemDone', function(obj, item) {
+				if(item._status == 'success') {
+					item.libraryCatalog = ra;
+					item.complete();
+				}
+			});
+			trans.translate();
+		})(ras[i]);
+	}
+}
 
 /** BEGIN TEST CASES **/
 var testCases = [

--- a/DataCite.js
+++ b/DataCite.js
@@ -1,0 +1,129 @@
+{
+	"translatorID": "9f1fb86b-92c8-4db7-b8ee-0b481d456428",
+	"label": "DataCite",
+	"creator": "Aurimas Vinckevicius",
+	"target": "",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 8,
+	"browserSupport": "gcs",
+	"lastUpdated": "2013-10-24 05:11:41"
+}
+
+function detectSearch(items) {
+	if(!items) return false;
+	
+	if(!items.directSearch) {
+		Z.debug("DataCite: directSearch was not true. Will not attempt to search directly.")
+		return false;
+	}
+	
+	if(typeof items == 'string' || !items.length) items = [items];
+	
+	for(var i=0, n=items.length; i<n; i++) {
+		if(!items[i]) continue;
+		
+		if(items[i].DOI && ZU.cleanDOI(items[i].DOI)) return true;
+		if(typeof items[i] == 'string' && ZU.cleanDOI(items[i])) return true;
+	}
+	
+	return false;
+}
+
+function filterQuery(items) {
+	if(!items) return [];
+	
+	if(typeof items == 'string' || !items.length) items = [items];
+	
+	//filter out invalid queries
+	var query = [];
+	for(var i=0, n=items.length; i<n; i++) {
+		if( ( items[i].DOI && ZU.cleanDOI(items[i].DOI) )
+			|| ( typeof items[i] == 'string' && ZU.cleanDOI(items[i]) ) ) {
+			query.push(items[i]);
+		} else {
+			var newItem = new Zotero.Item();
+			newItem._status = 'invalid';
+			newItem._query = items[i];
+			newItem.complete();
+		}
+	}
+	return query;
+}
+
+function doSearch(items) {
+	var query = filterQuery(items);
+	var queryTracker = {};
+	var dois = [];
+	for(var i=0, n=query.length; i<n; i++) {
+		var doi = ZU.cleanDOI(query[i].DOI || query[i]);
+		queryTracker[doi] = query[i];
+		dois.push(doi);
+	}
+	
+	if(!dois.length) return;
+	
+	processDOIs(dois, queryTracker);
+}
+
+function fixJSON(text) {
+	try {
+		var item = JSON.parse(text);
+		
+		if(item.type == 'misc') item.type = 'article-journal';
+		
+		if(item.issued && item.issued.raw) item.issued.literal = item.issued.raw;
+		if(item.accessed && item.accessed.raw) item.accessed.literal = item.accessed.raw;
+		
+		return JSON.stringify([item]);
+	} catch(e) {
+		return false;
+	}
+}
+
+function processDOIs(dois, queryTracker) {
+	var doi = dois.pop();
+	var query = queryTracker[doi];
+	ZU.doGet('http://data.datacite.org/application/citeproc+json/' + doi, function(text) {
+		text = fixJSON(text);
+		if(!text) {
+			var newItem = new Zotero.Item();
+			newItem._query = query;
+			newItem._status = 'invalid';
+			newItem.complete();
+			return;
+		}
+		
+		// use CSL JSON translator
+		var trans = Zotero.loadTranslator('import');
+		trans.setTranslator('bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7');
+		trans.setString(text);
+		var done = false;
+		trans.setHandler('itemDone', function(obj, item) {
+			item._query = query;
+			item._status = 'success';
+			item.complete();
+			done = true;
+		})
+		trans.setHandler('done', function() {
+			if(!done) {
+				var newItem = new Zotero.Item();
+				newItem._query = query;
+				newItem._status = 'fail';
+				newItem.complete();
+			}
+		});
+		trans.setHandler('error', function() {
+			var newItem = new Zotero.Item();
+			newItem._query = query;
+			newItem._status = 'fail';
+			newItem.complete();
+			done = true;
+		});
+		trans.translate();
+	}, function() {
+		if(dois.length) processDOIs(dois, queryTracker);
+	});
+}


### PR DESCRIPTION
**This still needs some polishing and it will require a couple patches to the Zotero client as well as fixing any translators that are currently using DOI searches** Before proceeding, I would like to know if this will be an acceptable solution.

We want to add support for as many DOIs as we can, which means that we will need 7-8 different search translators to cover all DOIs. Using the current system, we would set priorities for each of these translators and have Zotero query each one in order. Most of our DOIs are for CrossRef and, from the discussion on the forums, the second largest set (though probably quite small compared to CrossRef) would come from DataCite. We could probably do an ok job ranking these with priorities. The biggest problem is that for invalid DOIs, we would pretty much end up querying every single one of the translators, which means that it would go through at least 7-8 http requests for invalid DOIs.

In comes [CrossRef's RA lookup tool](http://www.crossref.org/crweblog/2013/05/find_the_registration_agency_f.html). Using this tool we can intelligently decide which DOIs should be queried through which DOI search translator, thus avoiding all the unnecessary HTTP requests.

Bonus points: with this patch, we can (in theory so far) query CrossRef with up to 10 DOIs in a single HTTP request.

For more details, I'm copying this from the [DOI] translator commit message:

The DOI search translator serves as a dispatcher for other DOI translators:
1. First, it uses CrossRef to look for a DOI, since most DOIs we deal with are from CrossRef
2. If not found, it queries CrossRef's RA lookup tool to determine which RA is responsible for the DOI
3. If available, it uses the appropriate DOI search translator to query the DOI

DOI search translator takes a string (corresponding to a DOI), an item containing a DOI property, or an array containing a combination of these.

The search translator will call `item.complete()` for each DOI queried. `item._query` will be set to the original query corresponding to the resulting item. `item._status` will be a string corresponding to the status of the query. If successful, the status will be 'success'. If the search fails for one of a number of reasons, the status will indicate the reason. Some possible values for `item._status` are 'not found', 'invalid', 'unimplemented', and 'fail'. These are not set in stone.

DOI search translator will pass an array containing the original queries (filtered depending on RA) to the downstream DOI translators. The queries will contain valid DOIs (except those passed to CrossRef) either as literal strings or objects containing DOI properties (or a combination thereof). However, DOI search translators should not assume queries to be valid, because they can be invoked directly from other translators.

DOI search translator should server as the only DOI translator responding to `detectSearch` for DOI queries. All other DOI search translators should not return `true` for these queries. This behavior is overridden (inverted) by setting `directSearch` property to `true` on the query object.

These changes depend on the ability to pass objects associated with items between translators. Implemented in zotero/zotero#401

Replaces #452 Implements #285

Edit: some sample DOIs http://doi.crossref.org/doiRA/10.2353/jmoldx.2009.090037,10.6220/joq.2012.19(1).01,10.5240/6F7E-EF59-329B-1F0A-8440-2,10.12763/ONA1045
