### PR TITLE
Several fixes to biblatex

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -56,7 +56,7 @@ var fieldMap = {
 
 var zotero2biblatexTypeMap = {
 	"book": "book",
-	"bookSection": "inbook",
+	"bookSection": "incollection",
 	"journalArticle": "article",
 	"magazineArticle": "article",
 	"newspaperArticle": "article",


### PR DESCRIPTION
I have updated quite a few things in the BibLaTeX translator (first in my BibLaTeX-with-hacks, then copied them (dehackified) over here).

Everything is mostly the result of me going through all specifications and trying to make things map more perfectly from Zotero to BibLaTeX.

One thing that probably could be added is a cleanup of indentation. This file is incredibly messy due to me using spaces instead of tabs for indentation when I adapted this from the BibTeX translator three years ago.

Doing a commit with only whitespace changes is pretty ugly (but of course good to keep to one commit). If you want me to add this cleanup in this pull request, just tell me.
