### PR TITLE
[biblatex] Fix bug: Don't write both "issue" and "number".

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -14,7 +14,7 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2013-12-22 16:46"
+	"lastUpdated": "2014-01-04 21:54"
 }
 
 
@@ -41,7 +41,6 @@ var fieldMap = {
 	volumes: "numberOfVolumes",
 	version: "version",
 	eventtitle: "conferenceName",
-	issue: "issue",
 	pages: "pages",
 	pagetotal: "numPages"
 };


### PR DESCRIPTION
As discussed here: https://forums.zotero.org/discussion/33960/biblatex-importexport-csl-language-biblatex-langid/#Item_13.
Another bug introduced with me through the recent updates where I tried to follow the biblatex specification more clearly: i forgot to remove the old direct mapping of "issue" to "issue" (which didn't correspond that well to how biblatex considers "issue" and "number") resulting in both issue and number being written.
