### PR TITLE
Bibtex import translator is now called instead

### DIFF
--- a/DBLP Computer Science Bibliography.js
+++ b/DBLP Computer Science Bibliography.js
@@ -1,106 +1,104 @@
 {
 	"translatorID": "625c6435-e235-4402-a48f-3095a9c1a09c",
 	"label": "DBLP Computer Science Bibliography",
-	"creator": "Adam Crymble, Sebastian Karcher",
-	"target": "^https?://(www\\.)?(dblp(\\.org|\\.uni-trier\\.de/)|informatik\\.uni-trier\\.de/\\~ley//)",
+	"creator": "Adam Crymble, Sebastian Karcher, Philipp Zumstein",
+	"target": "^https?://(www\\.)?(dblp(\\.org|\\.uni-trier\\.de/|\\.dagstuhl\\.de/)|informatik\\.uni-trier\\.de/\\~ley/)",
 	"minVersion": "1.0.0b4.r5",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2012-10-06 11:58:01"
+	"lastUpdated": "2014-02-09 16:59:54"
 }
 
 function detectWeb(doc, url) {
-	if (doc.title.match("journals")) {
-		return "journalArticle";
-	} else if (doc.title.match("conf")) {
-		return "conferencePaper";
-	} else if (doc.title.match("DBLP entry")) {
-		return "bookSection";
-	}
-	else if (url.match(/\/db\/(journals|conf|series|books|reference)/) && !url.match(/index\.html/)){
+	if (url.indexOf('rec/bibtex') !== -1) {
+		if (url.indexOf('journals') !== -1) {
+			return "journalArticle";
+		} else if (url.indexOf('conf') !== -1) {
+			return "conferencePaper";
+		} else if (url.indexOf('series') !== -1 || url.indexOf('reference') !== -1) {
+			return "bookSection";
+		} else if (url.indexOf('books') !== -1) {
+			return "book";
+		} else if (url.indexOf('phd') !== -1) {
+			return "thesis";
+		} else { //generic fallback
+			return "journalArticle";
+		}
+	} else if ((url.match(/\/db\/(journals|conf|series|reference)/) || url.match(/\/pers\/(hd|ht|hy)/)) && !url.match(/index[\w-]*\.html/)) {
 		return "multiple"
 	}
 }
 
 
-//DBLP Computer Science Database Translator. Code by Adam Crymble.
-//Doesn't work for multiple entries. Site uses a different URL for the search and single entry. Multiple code attached as comment.
+function scrape(doc, url) {
+	var xPathAllData = doc.evaluate('//pre', doc, null, XPathResult.ANY_TYPE, null);
+	var firstData = xPathAllData.iterateNext(); //only if exists
+	var firstDataText = firstData.textContent.replace(/ ee\s*=/, " url ="); //e.g. ee = {http://dx.doi.org/10.1007/978-3-319-00035-0_37},
+	Zotero.debug(firstDataText);
 
-function associateData (newItem, dataTags, field, zoteroField) {
-	if (dataTags[field]) {
-		newItem[zoteroField] = dataTags[field];
+	//conferencePapers and bookSections are linked in DBLP
+	//with the crossref field to the second BibTeX entry
+	//for the proceeding or book. In these cases the following
+	//lines (if-part) are handling the second entry and extracting
+	//relevant fields and save it (later) to the main entry.
+	var secondData;
+	if (secondData = xPathAllData.iterateNext()) {
+		var secondDataText = secondData.textContent;
+		Zotero.debug(secondDataText);
+
+		var trans = Zotero.loadTranslator('import');
+		trans.setTranslator('9cb70025-a888-4a29-a210-93ec52da40d4');//https://github.com/zotero/translators/blob/master/BibTeX.js
+		trans.setString(secondDataText);
+
+		trans.setHandler('itemDone', function (obj, item) {
+			scrapeMainPart(firstDataText, item);
+		});
+
+		trans.translate();
+	} else { //if there are no secondData: scrape without additional data
+		scrapeMainPart(firstDataText, null);
 	}
 }
 
-function scrape(doc, url) {
-	var dataTags = new Object();
-	var mediaType = detectWeb(doc, url);
-	
-	if (mediaType == "bookSection") {
-		var newItem = new Zotero.Item("bookSection");
-	} else if (mediaType == "conferencePaper") {
-		var newItem = new Zotero.Item("conferencePaper");
-	} else if (mediaType == "journalArticle") {
-		var newItem = new Zotero.Item("journalArticle");
-	}
-	
-	var xPathAllData = doc.evaluate('//pre', doc, null, XPathResult.ANY_TYPE, null);
-	var allData = xPathAllData.iterateNext().textContent.split("},");
-	
-	var cleanFirstEntry = allData[0].indexOf(",");
-	allData[0] = allData[0].substr(cleanFirstEntry);
 
-	var headers = new Array();
-	var content = new Array();
-	var splitAllData;
-	
-	for (var i = 0; i < allData.length-2; i++) {
-		splitAllData = allData[i].split("=");
-		headers.push(splitAllData[0].replace(/^\s*|\s*$|\W*/g, ''));
-		content.push(splitAllData[1].replace(/^\s*|\s*$|\{*/g, ''));
-		
-		fieldTitle = headers[i].replace(",", '');
-	
-		if (fieldTitle == "author") {
-			var authors = content[i].split("and");
-	
-			for (var j =0; j<authors.length; j++) {
-				newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[j], "author"));
-			}
-		} else if (fieldTitle == "editor") {
-			var editors = content[i].split("and");
+function scrapeMainPart(firstDataText, secondDataItem) {
+	//scrape from the firstDataText and if secondDataItem
+	//is not null, add/update these information
+	var trans = Zotero.loadTranslator('import');
+	trans.setTranslator('9cb70025-a888-4a29-a210-93ec52da40d4');//https://github.com/zotero/translators/blob/master/BibTeX.js
+	trans.setString(firstDataText);
 
-			for (var j =0; j<editors.length; j++) {
-				newItem.creators.push(Zotero.Utilities.cleanAuthor(editors[j], "editor"));
-			}
-		} else {
-
-			dataTags[fieldTitle] = content[i];
+	trans.setHandler('itemDone', function (obj, item) {
+		Zotero.debug("item.itemType = " + item.itemType);
+		if (secondDataItem) {
+			if (secondDataItem.title && item.itemType == "conferencePaper") item.proceedingsTitle = secondDataItem.title;
+			if (secondDataItem.title && item.itemType == "bookSection") item.booktitle = secondDataItem.titel;
+			if (secondDataItem.creators && secondDataItem.creators.length > 0) item.creators = item.creators.concat(secondDataItem.creators);
+			if (secondDataItem.publisher && !item.publisher) item.publisher = secondDataItem.publisher;
+			if (secondDataItem.series && !item.series) item.series = secondDataItem.series;
+			if (secondDataItem.volume && !item.volume) item.volume = secondDataItem.volume;
+			if (secondDataItem.ISBN && !item.ISBN) item.ISBN = secondDataItem.ISBN;
 		}
-	}
+		
+		//Assume that the url contains an doi. If the item does not
+		//yet contain a doi, then save the doi and delete the url.
+		//If the item contains the doi corresponding to the url
+		//then just delete the url and keep the doi.
+		if(item.url && item.url.search(/^http:\/\/(?:dx\.)?doi\.org\/10\./i) != -1) {
+			var doi = ZU.cleanDOI(item.url);
+			if(doi && (!item.DOI || item.DOI == doi)) {
+				item.DOI = doi;
+				delete item.url;
+			}
+		}
+		
+		item.complete();
+	});
 
-	if (mediaType == "conferencePaper") {
-		associateData (newItem, dataTags, "booktitle", "conferenceName");
-	} else {
-		associateData (newItem, dataTags, "booktitle", "bookTitle");
-	}
-	
-	newItem.url = doc.location.href;
-	
-	associateData (newItem, dataTags, "year", "date");
-	associateData (newItem, dataTags, "pages", "pages");
-	associateData (newItem, dataTags, "title", "title");	
-	associateData (newItem, dataTags, "publisher", "publisher");
-	associateData (newItem, dataTags, "volume", "volume");
-	associateData (newItem, dataTags, "isbn", "ISBN");
-	associateData (newItem, dataTags, "series", "series");
-	associateData (newItem, dataTags, "journal", "publicationTitle");
-	associateData (newItem, dataTags, "number", "issue");
-
-	newItem.complete();
+	trans.translate();
 
 }
 
@@ -108,10 +106,12 @@ function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		var items = new Object();
 		var articles = new Array();
-		var rows  = ZU.xpath(doc, '//body/ul/li|//li[@class="entry article"]')	
-		for (i in rows){
-			 var title = ZU.xpathText(rows[i], './b|./div/span[@class="title"]');
-			 var link = ZU.xpathText(rows[i], './a[contains(@href, "rec/bibtex") and not(contains(@href, ".xml"))]/@href|./nav//div/a[contains(@href, "rec/bibtex") and not(contains(@href, ".xml"))]/@href');
+		var rows = ZU.xpath(doc, '//body/ul/li|//li[contains(@class, "entry")]')
+		for(var i=0; i<rows.length; i++) {
+			//Careful: If you get more than one node,
+			//ZU.xpathText will join the textContent of each with commas. 
+			var title = ZU.xpathText(rows[i], './b|./div/span[@class="title"]');
+			var link = ZU.xpathText(rows[i], './a[contains(@href, "rec/bibtex") and not(contains(@href, ".xml"))]/@href|./nav//div/a[contains(@href, "rec/bibtex") and not(contains(@href, ".xml"))]/@href');
 			items[link] = title;
 		}
 		Zotero.selectItems(items, function (items) {
@@ -121,15 +121,12 @@ function doWeb(doc, url) {
 			for (var i in items) {
 				articles.push(i);
 			}
-			Zotero.Utilities.processDocuments(articles, scrape, function () {
-				Zotero.done();
-			});
-			Zotero.wait();	
+			ZU.processDocuments(articles, scrape);
 		});
 	} else {
 		scrape(doc, url);
 	}
-}/** BEGIN TEST CASES **/
+} /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
@@ -153,15 +150,15 @@ var testCases = [
 				"tags": [],
 				"seeAlso": [],
 				"attachments": [],
-				"url": "http://www.dblp.org/rec/bibtex/journals/cssc/XuY12",
+				"itemID": "DBLP:journals/cssc/XuY12",
+				"title": "On the Preliminary Test Backfitting and Speckman Estimators in Partially Linear Models and Numerical Comparisons",
+				"publicationTitle": "Communications in Statistics - Simulation and Computation",
+				"volume": "41",
+				"issue": "3",
 				"date": "2012",
 				"pages": "327-341",
-				"title": "On the Preliminary Test Backfitting and Speckman Estimators\n               in Partially Linear Models and Numerical Comparisons",
-				"volume": "41",
-				"publicationTitle": "Communications in Statistics - Simulation and Computation",
-				"issue": "3",
-				"libraryCatalog": "DBLP Computer Science Bibliography",
-				"accessDate": "CURRENT_TIMESTAMP"
+				"DOI": "10.1080/03610918.2011.588356",
+				"libraryCatalog": "DBLP Computer Science Bibliography"
 			}
 		]
 	},
@@ -217,13 +214,16 @@ var testCases = [
 				"tags": [],
 				"seeAlso": [],
 				"attachments": [],
-				"conferenceName": "Asian Test Symposium",
-				"url": "http://www.dblp.org/rec/bibtex/conf/ats/KochteZBIWHCP10",
+				"itemID": "DBLP:conf/ats/KochteZBIWHCP10",
+				"title": "Efficient Simulation of Structural Faults for the Reliability Evaluation at System-Level",
+				"publicationTitle": "Asian Test Symposium",
 				"date": "2010",
 				"pages": "3-8",
-				"title": "Efficient Simulation of Structural Faults for the Reliability\n               Evaluation at System-Level",
-				"libraryCatalog": "DBLP Computer Science Bibliography",
-				"accessDate": "CURRENT_TIMESTAMP"
+				"proceedingsTitle": "Proceedings of the 19th IEEE Asian Test Symposium, ATS 2010, 1-4 December 2010, Shanghai, China",
+				"publisher": "IEEE Computer Society",
+				"ISBN": "978-0-7695-4248-5",
+				"DOI": "10.1109/ATS.2010.10",
+				"libraryCatalog": "DBLP Computer Science Bibliography"
 			}
 		]
 	},
@@ -236,6 +236,68 @@ var testCases = [
 		"type": "web",
 		"url": "http://dblp.uni-trier.de/db/journals/tods/tods31.html",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "http://dblp.dagstuhl.de/pers/hd/k/Knuth:Donald_E=.html",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "http://dblp.uni-trier.de/rec/bibtex/conf/approx/SchederT13",
+		"items": [
+			{
+				"itemType": "conferencePaper",
+				"creators": [
+					{
+						"firstName": "Dominik",
+						"lastName": "Scheder",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Li-Yang",
+						"lastName": "Tan",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Prasad",
+						"lastName": "Raghavendra",
+						"creatorType": "editor"
+					},
+					{
+						"firstName": "Sofya",
+						"lastName": "Raskhodnikova",
+						"creatorType": "editor"
+					},
+					{
+						"firstName": "Klaus",
+						"lastName": "Jansen",
+						"creatorType": "editor"
+					},
+					{
+						"firstName": "José D. P.",
+						"lastName": "Rolim",
+						"creatorType": "editor"
+					}
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [],
+				"itemID": "DBLP:conf/approx/SchederT13",
+				"title": "On the Average Sensitivity and Density of k-CNF Formulas",
+				"publicationTitle": "APPROX-RANDOM",
+				"date": "2013",
+				"pages": "683-698",
+				"proceedingsTitle": "Approximation, Randomization, and Combinatorial Optimization. Algorithms and Techniques - 16th International Workshop, APPROX 2013, and 17th International Workshop, RANDOM 2013, Berkeley, CA, USA, August 21-23, 2013. Proceedings",
+				"publisher": "Springer",
+				"series": "Lecture Notes in Computer Science",
+				"volume": "8096",
+				"ISBN": "978-3-642-40327-9",
+				"DOI": "10.1007/978-3-642-40328-6_47",
+				"libraryCatalog": "DBLP Computer Science Bibliography"
+			}
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
- Bibtex import translator is now called internally (this deals with all kind of character encoding problems as well as spacing problems)
- every entry types is handled now by just checking if the class "entry" is contained in the list of all classes
- detectWeb is (for creating the right symbols) updated
- there are also person-pages, i.e. lists of publication from an author (added in detectWeb as multiple)
- cases where DBLP uses crossref fields and links for example an inproceeding to the proceeding (second entry) is dealt and the information of it is used as well
- replace BibTeX field "ee" (DBLP) which is normally named "url"
