### PR TITLE
Update BibTeX.js

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -131,7 +131,8 @@ var bibtex2zoteroTypeMap = {
 	"manual":"book",
 	"mastersthesis":"thesis",
 	"misc":"book",
-	"proceedings":"book"
+	"proceedings":"book",
+	"online":"webpage"
 };
 
 /*


### PR DESCRIPTION
Adding a new type of entry that could be recognized from a BibTeX file.
Indeed, the BibLaTeX export translator output this kind of entry type, but if I reimport my newly exported file, Zotero do not import the @online entries.
With this little patch, it helps me enough, maybe you should know how to do it clenly to avoid side effects.
