### PR TITLE
[CrossRef] Try to fix encoding issues

### DIFF
--- a/CrossRef.js
+++ b/CrossRef.js
@@ -70,13 +70,15 @@ function parseCreators(node, item, typeOverrideMap) {
 		var creator = {};
 		
 		var role = creatorXML.getAttribute("contributor_role");
-		if(typeOverrideMap && typeOverrideMap[role]) {
+		if(typeOverrideMap && typeOverrideMap[role] !== undefined) {
 			creator.creatorType = typeOverrideMap[role];
 		} else if(role === "author" || role === "editor" || role === "translator") {
 			creator.creatorType = role;
 		} else {
 			creator.creatorType = "contributor";
 		}
+		
+		if(!creator.creatorType) continue;
 		
 		if(creatorXML.nodeName === "organization") {
 			creator.fieldMode = 1;
@@ -228,7 +230,7 @@ function processCrossRef(xmlOutput) {
 	item.edition = ZU.xpathText(metadataXML, 'c:edition_number', ns);
 	if(!item.volume) item.volume = ZU.xpathText(metadataXML, 'c:volume', ns);
 	
-	parseCreators(refXML, item, "author");
+	parseCreators(refXML, item, (item.itemType == 'bookSection' ? {"editor": null} : "author") );
 	
 	if(seriesXML && seriesXML.length) {
 		parseCreators(refXML, item, {"editor":"seriesEditor"});
@@ -237,9 +239,9 @@ function processCrossRef(xmlOutput) {
 	}
 	//prefer article to journal metadata and print to other dates
 	var pubDateNode = ZU.xpath(refXML, 'c:publication_date[@media_type="print"]', ns);
-	if(!pubDateNode) pubDateNode = ZU.xpath(refXML, 'c:publication_date', ns);
-	if(!pubDateNode) pubDateNode = ZU.xpath(metadataXML, 'c:publication_date[@media_type="print"]', ns);
-	if(!pubDateNode) pubDateNode = ZU.xpath(metadataXML, 'c:publication_date', ns);
+	if(!pubDateNode.length) pubDateNode = ZU.xpath(refXML, 'c:publication_date', ns);
+	if(!pubDateNode.length) pubDateNode = ZU.xpath(metadataXML, 'c:publication_date[@media_type="print"]', ns);
+	if(!pubDateNode.length) pubDateNode = ZU.xpath(metadataXML, 'c:publication_date', ns);
 
 	
 	if(pubDateNode.length) {
@@ -344,12 +346,54 @@ var testCases = [
 				"attachments": [],
 				"bookTitle": "The Cambridge Companion to George Orwell",
 				"place": "Cambridge",
-				"ISBN": "0521858429, 9780521858427, 0521675073, 9780521675079",
+				"ISBN": "9781139001472",
 				"publisher": "Cambridge University Press",
 				"pages": "201-207",
+				"date": "2007",
 				"DOI": "10.1017/CCOL0521858429.016",
-				"url": "http://cco.cambridge.org/extract?id=ccol0521858429_CCOL0521858429A016",
+				"url": "http://universitypublishingonline.org/ref/id/companions/CBO9781139001472A019",
 				"title": "Why Orwell still matters",
+				"libraryCatalog": "CrossRef"
+			}
+		]
+	},
+	{
+		"type": "search",
+		"input": {
+			"DOI":"10.1057/9780230391116.0016"
+		},
+		"items": [
+			{
+				"itemType": "bookSection",
+				"creators": [
+					{
+						"creatorType": "editor",
+						"firstName": "Claus-Christian W.",
+						"lastName": "Szejnmann"
+					},
+					{
+						"creatorType": "editor",
+						"firstName": "Maiken",
+						"lastName": "Umbach"
+					},
+					{
+						"creatorType": "author",
+						"firstName": "Oliver",
+						"lastName": "Werner"
+					}
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [],
+				"bookTitle": "Heimat, Region, and Empire",
+				"ISBN": "9780230391116",
+				"publisher": "Palgrave Macmillan",
+				"language": "en",
+				"date": "2012-10-17",
+				"DOI": "10.1017/CCOL0521858429.016",
+				"url": "http://www.palgraveconnect.com/doifinder/10.1057/9780230391116.0016",
+				"title": "Conceptions, Competences and Limits of German Regional Planning during the Four Year Plan, 1936–1940",
 				"libraryCatalog": "CrossRef"
 			}
 		]


### PR DESCRIPTION
Not sure if this has been reported, but I remember seeing this issue before.

E.g. see the title in [10.1057/9780230391116.0016](http://doi.crossref.org/servlet/query?usr=zter&pwd=zter321&format=unixref&qdata=%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%3Cquery_batch%20version%3D%222.0%22%20xmlns%3D%22http%3A%2F%2Fwww.crossref.org%2Fqschema%2F2.0%22%20xmlns%3Axsi%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%3E%3Chead%3E%3Cemail_address%3Eckoscher%40crossref.org%3C%2Femail_address%3E%3Cdoi_batch_id%3Etrackingid1%3C%2Fdoi_batch_id%3E%3C%2Fhead%3E%3Cbody%3E%3Cquery%20key%3D%2210.1057%2F9780230391116.0016%22%20expanded-results%3D%22true%22%3E%3Cdoi%3E10.1057%2F9780230391116.0016%3C%2Fdoi%3E%3C%2Fquery%3E%3C%2Fbody%3E%3C%2Fquery_batch%3E) (notice the â instead of en dash in the title)

I think this happens when UTF-8 encoded string is treated as ISO-8859-1 (or some similar single-byte encoding) and that is then transcoded into UTF-8. So en dash in UTF-8 (U+2013; hex E28093) treated as ISO-8859-1 (E2 80 93; 3 separate characters), transcoded into UTF-8 (U+00E2 U+0080 U+0093; hex C3A2C280C293) resulting in `<control><control>â`

Here we check for some control characters that should never appear in strings (at least I don't expect them to) and reverse the above. This probably won't catch every case where the encoding is messed up, but it should also not break anything. The fixes are not applied to creators. I don't recall a case where that was an issue.
