### PR TITLE
BibLaTeX.js: Fix uppercase regex

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -226,7 +226,7 @@ function writeField(field, value, isMacro, noEscape) {
 		// treat curly bracket as whitespace because of mark-up immediately preceding word
 		// treat opening parentheses &brackets as whitespace
 		if (field != "pages") {
-			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,]*)/g, "{$1}");
+			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,\)]*)/g, "{$1}");
 		}
 	}
 	//we write utf8


### PR DESCRIPTION
Treat ')' as whitespace.
"A (Test) case" => "A ({Test}) case"
