### PR TITLE
Bib{TeX,LaTeX}: fix for uppercase regex

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -225,8 +225,9 @@ function writeField(field, value, isMacro, noEscape) {
 		// treat hyphen as whitespace for this purpose so that Large-scale etc. don't get enclosed
 		// treat curly bracket as whitespace because of mark-up immediately preceding word
 		// treat opening parentheses &brackets as whitespace
+                // terminate matching on encountering comma, or closing parenthesis
 		if (field != "pages") {
-			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,]*)/g, "{$1}");
+			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,\)]*)/g, "{$1}");
 		}
 	}
 	//we write utf8

--- a/BibTeX.js
+++ b/BibTeX.js
@@ -2178,8 +2178,9 @@ function writeField(field, value, isMacro) {
 		// treat hyphen as whitespace for this purpose so that Large-scale etc. don't get enclosed
 		// treat curly bracket as whitespace because of mark-up immediately preceding word
 		// treat opening parentheses &brackets as whitespace
+                // terminate matching on encountering comma, or closing parenthesis
 		if (field != "pages") {
-			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,]*)/g, "{$1}");
+			value = value.replace(/([^\s-\}\(\[]+[A-Z][^\s,\)]*)/g, "{$1}");
 		}
 	}
 	if (Zotero.getOption("exportCharset") != "UTF-8") {


### PR DESCRIPTION
Terminate pattern matching on encountering closing whitespace, comma, or
a closing parenthesis.
Ex: "A (TEST) case" -> "A ({TEST}) case"
