### PR TITLE
Translator APS.js: Fix for "PDF (free)"

### DIFF
--- a/APS.js
+++ b/APS.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2014-02-23 23:53:47"
+	"lastUpdated": "2014-05-08 21:40:24"
 }
 
 function getSearchResults(doc) {
@@ -75,7 +75,7 @@ function scrape(doc, url) {
 			));
 			
 			// attach PDF
-			if(ZU.xpath(doc, '//section[@id="title"]//a[text()="PDF"]').length) {
+			if(ZU.xpath(doc, '//section[@id="title"]//a[starts-with(text(), "PDF")]')) {
 				item.attachments.push({
 					title: 'Full Text PDF',
 					url: url.replace('{REPLACE}', 'pdf'),


### PR DESCRIPTION
Now recognises also "PDF (free)" button on website. Test case: http://journals.aps.org/pr/abstract/10.1103/PhysRev.69.37
