### PR TITLE
Fixed keeping journal abbreviation

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -1693,7 +1693,7 @@ function processField(item, field, value) {
 	} else if(field == "fjournal") {
 		if(item.publicationTitle) {
 			// move publicationTitle to abbreviation
-			item.journalAbbreviation = value;
+			item.journalAbbreviation = item.publicationTitle;
 		}
 		item.publicationTitle = value;
 	} else if(field == "author" || field == "editor" || field == "translator") {


### PR DESCRIPTION
The comment in line 1695 says "move publicationTitle to abbreviation" but line 1696 did nothing of the sort. As a result, journal abbreviations were dropped, while complete journal names were stored in both item.publicationTitle and item.journalAbbreviation.
