### PR TITLE
New Zotero for CanLII in french

### DIFF
--- a/CANLII (French).js
+++ b/CANLII (French).js
@@ -11,6 +11,23 @@
 	"browserSupport": "gcsib",
 	"lastUpdated": "2014-06-08 10:57:58"
 }
+/*
+CanLII French Translator
+Copyright (C) 2014 Marc Lajoie
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 var canLiiRegexp = /https?:\/\/(www\.)?canlii\.org\/.*fr\/[^\/]+\/[^\/]+\/doc\/.+/;
 


### PR DESCRIPTION
This translator is for CanLII. http://www.canlii.org/
CanLII provide free access to Canadian court decisions.
There is already an english translator for CanLII done by Sebastian Karcher 
Since Quebec court decisions are mostly in french, we need a translator.
Perhaps in the future we could make a single translator in both official languages.
