### PR TITLE
[Zotero RDF] Export/import encyc., dict., & conf. article containers

### DIFF
--- a/RDF.js
+++ b/RDF.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2015-02-11 01:21:39"
+	"lastUpdated": "2015-02-12 09:31:21"
 }
 
 /*
@@ -374,6 +374,11 @@ function detectType(newItem, node, ret) {
 		&& ZU.itemTypeExists(type)
 	) {
 		t.zotero = type;
+		if(type == "encyclopediaArticle" || type == "dictionaryEntry") {
+			container = getNodeByType(isPartOf, n.bib+"Book");
+		} else if(type == "conferencePaper") {
+			container = getNodeByType(isPartOf, n.bib+"Journal");
+		}
 	}
 
 	// dc:type, dcterms:type

--- a/Zotero RDF.js
+++ b/Zotero RDF.js
@@ -10,7 +10,7 @@
 	"configOptions":{"getCollections":"true", "dataMode":"rdf/xml"},
 	"displayOptions":{"exportNotes":true, "exportFileData":false},
 	"inRepository":true,
-	"lastUpdated":"2012-02-13 07:58:03"
+	"lastUpdated":"2015-02-12 09:23:24"
 }
 
 var item;
@@ -197,6 +197,11 @@ function generateItem(item, zoteroType, resource) {
 		type = n.bib+"Recording";
 	} else if(zoteroType == "computerProgram") {
 		type = n.bib+"Data";
+	} else if(zoteroType == "encyclopediaArticle"
+		|| zoteroType == "dictionaryEntry") {
+		container = n.bib+"Book";
+	} else if(zoteroType == "conferencePaper") {
+		container = n.bib+"Journal";
 	}
 	
 	if(type) {


### PR DESCRIPTION
See https://forums.zotero.org/discussion/29970/faulty-rdf-mapping/

I think I made a more extensive list of what goes missing after export -> import, but I can't find it now.

One thing that I did notice is that Access Date get copied into Date if Date is missing. That's because we use dcterms:dateSubmitted for Access Date export, but allow dcterms:dateSubmitted as a fallback Date for compatibility with some websites. dcterms:dateSubmitted for Access Date is a hack and we should use something more appropriate. I couldn't find anything, so perhaps we could add it to Zotero namespace (or somewhere else).

Related forum threads (didn't realize this dates so far back... maybe there were some concerns with this approach):
https://forums.zotero.org/discussion/8634/incorrect-importing-of-conference-proceedings/
https://forums.zotero.org/discussion/12474/conference-names-have-all-disappeared/
https://forums.zotero.org/discussion/14612/zotero-rdf-export-is-broken-for-confernece-paper-type/
https://forums.zotero.org/discussion/29970/faulty-rdf-mapping/