### PR TITLE
[Bib(La)TeX] Convert all dashes in pages to double dash on export

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -15,7 +15,7 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2014-06-23 05:03:43"
+	"lastUpdated": "2014-08-22 20:03:43"
 }
 
 
@@ -279,6 +279,11 @@ function writeField(field, value, isMacro, noEscape) {
 		var protectCaps = new ZU.XRegExp("\\b\\p{Letter}+\\p{Uppercase_Letter}\\p{Letter}*", 'g')
 		if (field != "pages") {
 			value = ZU.XRegExp.replace(value, protectCaps, "{$0}");
+		}
+
+		// Page ranges should use double dash
+		if (field == "pages"{
+			value = value.replace(/[-\u2012-\u2015\u2053]+/g,"--");
 		}
 	}
 	//we write utf8

--- a/BibTeX.js
+++ b/BibTeX.js
@@ -18,7 +18,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2014-06-23 03:37:22"
+	"lastUpdated": "2014-08-22 20:37:22"
 }
 
 function detectImport() {
@@ -1246,7 +1246,7 @@ function doExport() {
 		}
 		
 		if(item.pages) {
-			writeField("pages", item.pages.replace("-","--"));
+			writeField("pages", item.pages.replace(/[-\u2012-\u2015\u2053]+/g,"--"));
 		}
 		
 		// Commented out, because we don't want a books number of pages in the BibTeX "pages" field for books.


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/39509/apostrophes-and-dashes-turning-into-odd-characters-in-references/

I don't think this is too aggressive, but maybe someone can think of some edge cases where this is not desired.
