### PR TITLE
Restrict Wikisource translator to en.wikisource.org

### DIFF
--- a/Wikisource.js
+++ b/Wikisource.js
@@ -2,7 +2,7 @@
 	"translatorID": "076bd26a-1517-469d-85e9-31316a6f6cb0",
 	"label": "Wikisource",
 	"creator": "Sebastian Karcher",
-	"target": "^https?://[a-z]{2}\\.wikisource\\.org/w",
+	"target": "^https?://en\\.wikisource\\.org/w",
 	"minVersion": "2.1.9",
 	"maxVersion": "",
 	"priority": 100,


### PR DESCRIPTION
The HTML nodes used by this translator are currently only used by en.wikisource.org, causing Zotero failues on other language based Wikisources.

Example of page where the failure is reproducible: https://fr.wikisource.org/wiki/Lettre_%C3%A0_M._Dacier_relative_%C3%A0_l%E2%80%99alphabet_des_hi%C3%A9roglyphes_phon%C3%A9tiques
