### PR TITLE
Delete dataMode "block" and "line"

### DIFF
--- a/CTX.js
+++ b/CTX.js
@@ -3,16 +3,13 @@
 	"label": "CTX",
 	"creator": "Avram Lyon and Simon Kornblith",
 	"target": "^https?://freecite\\.library\\.brown\\.edu",
-	"minVersion": "2.0",
+	"minVersion": "2.1",
 	"maxVersion": "",
 	"priority": 100,
-	"configOptions": {
-		"dataMode": "line"
-	},
 	"inRepository": true,
 	"translatorType": 5,
 	"browserSupport": "gcv",
-	"lastUpdated": "2014-04-03 16:47:18"
+	"lastUpdated": "2014-12-17 22:27:41"
 }
 
 /*

--- a/MEDLINEnbib.js
+++ b/MEDLINEnbib.js
@@ -6,13 +6,10 @@
 	"minVersion": "4.0",
 	"maxVersion": "",
 	"priority": 100,
-	"configOptions": {
-		"dataMode": "line"
-	},
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2014-03-12 04:43:57"
+	"lastUpdated": "2014-12-17 22:44:27"
 }
 
 /*

--- a/NCBI PubMed.js
+++ b/NCBI PubMed.js
@@ -6,13 +6,10 @@
 	"minVersion": "2.1.9",
 	"maxVersion": "",
 	"priority": 100,
-	"configOptions": {
-		"dataMode": "block"
-	},
 	"inRepository": true,
 	"translatorType": 13,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2014-06-20 04:23:04"
+	"lastUpdated": "2014-12-17 22:37:36"
 }
 
 /*****************************

--- a/OVID Tagged.js
+++ b/OVID Tagged.js
@@ -6,13 +6,10 @@
 	"minVersion": "4.0",
 	"maxVersion": "",
 	"priority": 100,
-	"configOptions": {
-		"dataMode": "line"
-	},
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2014-11-27 10:45:12"
+	"lastUpdated": "2014-12-17 22:33:06"
 }
 
 /*

--- a/ReferBibIX.js
+++ b/ReferBibIX.js
@@ -3,19 +3,16 @@
 	"label": "Refer/BibIX",
 	"creator": "Simon Kornblith",
 	"target": "txt",
-	"minVersion": "1.0.0b4.r5",
+	"minVersion": "2.1",
 	"maxVersion": "",
 	"priority": 100,
-	"configOptions": {
-		"dataMode": "line"
-	},
 	"displayOptions": {
 		"exportCharset": "UTF-8"
 	},
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcs",
-	"lastUpdated": "2014-06-05 08:00:52"
+	"lastUpdated": "2014-12-17 22:35:48"
 }
 
 function detectImport() {


### PR DESCRIPTION
- These values are no longer needed (and are therefore somehow deprecated).
- Deleted all occurrencies of block or line as dataMode
- solves #823
- I run all tests for these translators successively.
