### PR TITLE
[Google Scholar] More-precise Decided Date for cases

### DIFF
--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2014-07-25 21:01:15"
+	"lastUpdated": "2014-12-30 23:46:35"
 }
 
 /*
@@ -378,7 +378,7 @@ function scrapeCaseResults(doc, cases) {
 		}
 	
 		// Instantiate item factory with available data
-		var factory = new ItemFactory(citeletString, attachmentLinks,
+		var factory = new ItemFactory(doc, citeletString, attachmentLinks,
 										titleString, cases[i].bibtexUrl);
 	
 		if (!factory.hasUsefulData()) {
@@ -685,7 +685,7 @@ var scrapeCase = function (doc, url) {
 		// citelet looks kind of like this
 		// Powell v. McCormack, 395 US 486 - Supreme Court 1969
 		var item = new Zotero.Item("case");
-		var factory = new ItemFactory(refFrag.textContent, [url]);
+		var factory = new ItemFactory(doc, refFrag.textContent, [url]);
 		factory.repairCitelet();
 		factory.getDate();
 		factory.getCourt();
@@ -706,7 +706,7 @@ var scrapeCase = function (doc, url) {
  * ####################
  */
 
-var ItemFactory = function (citeletString, attachmentLinks, titleString, bibtexLink) {
+var ItemFactory = function (doc, citeletString, attachmentLinks, titleString, bibtexLink) {
 	// var strings
 	this.v = {};
 	this.v.title = titleString;
@@ -720,6 +720,8 @@ var ItemFactory = function (citeletString, attachmentLinks, titleString, bibtexL
 	this.vv.volRepPag = [];
 	// portable array
 	this.attachmentLinks = attachmentLinks;
+	// reference back to doc
+	this.doc = doc;
 	// working strings
 	this.citelet = citeletString;
 	this.bibtexLink = bibtexLink;
@@ -795,6 +797,24 @@ ItemFactory.prototype.getDate = function () {
 				this.hyphenSplit = this.hyphenSplit.slice(0, i + 1);
 				break;
 			}
+		}
+	}
+	// If we can find a more specific date in the case's centered text then use it
+	var nodesSnapshot = this.doc.evaluate('//div[@id="gs_opinion"]/center', this.doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
+	for( var iNode = 0; iNode < nodesSnapshot.snapshotLength; iNode++ ) {
+		var specificDate = nodesSnapshot.snapshotItem(iNode).textContent;
+		// Remove the first word through the first space 
+		//  if it starts with "Deci" or it doesn't start with the first three letters of a month
+		//  and if it doesn't start with Submitted or Argued
+		// (So, words like "Decided", "Dated", and "Released" will be removed)
+		specificDate = specificDate.replace(/^(Deci|(?!(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Submitted|Argued)))\w+.\s*/,"");
+		// Remove the trailing period, if it is there
+		specificDate = specificDate.replace(/\.$/,"");
+		// If the remaining text is a valid date...
+		if (!isNaN(Date.parse(specificDate))) {
+			// ...then use it
+			this.v.date = specificDate;
+			break;
 		}
 	}
 	return this.v.date;
@@ -945,6 +965,55 @@ ItemFactory.prototype.saveItemCommonVars = function () {
 	}
 };
 
+/*
+  The following case FAILS as a test case.  Maybe because it doesn't have a dash in the case citation?
+    http://scholar.google.com/scholar_case?case=15539128432567109896
+  Is it an aberration in the data and thus a data problem that doesn't deserve a test case, 
+  or is it a valid test case?
+  Reported to Zotero Forums.  See https://forums.zotero.org/discussion/44849/zotero-wont-save-google-scholar-case-but-no-error-report-id-949790485/
+*/
+
+/*
+  Test Case Descriptions:  (these have not been included in the test case JSON below as per 
+                            aurimasv's comment on https://github.com/zotero/translators/pull/833)
+
+		"description": "Legacy test case",
+    "url": "http://scholar.google.com/scholar?q=marbury&hl=en&btnG=Search&as_sdt=1%2C22&as_sdtp=on",
+    
+		"description": "Legacy test case",
+		"url": "http://scholar.google.com/scholar?hl=en&q=kelo&btnG=Search&as_sdt=0%2C22&as_ylo=&as_vis=0",
+    
+		"description": "Legacy test case",
+		"url": "http://scholar.google.com/scholar?hl=en&q=smith&btnG=Search&as_sdt=0%2C22&as_ylo=&as_vis=0",
+    
+		"description": "Legacy test case",
+		"url": "http://scholar.google.com/scholar?hl=en&q=view+of+the+cathedral&btnG=Search&as_sdt=0%2C22&as_ylo=&as_vis=0",
+
+		"description": "Legacy test case",
+		"url": "http://scholar.google.com/scholar?hl=en&q=clifford&btnG=Search&as_sdt=0%2C22&as_ylo=&as_vis=0",
+
+		"description": "Legacy test case",
+		"url": "http://scholar.google.com/scholar_case?case=9834052745083343188&q=marbury+v+madison&hl=en&as_sdt=2,5",
+
+		"description": "Decided date not preceded by any word or any other date line",
+		"url": "http://scholar.google.com/scholar_case?case=11350538941232186766",
+
+		"description": "Decided date preceded by 'Dated'",
+		"url": "http://scholar.google.com/scholar_case?case=4250138655935640563",
+
+		"description": "Decided date preceded by 'Released'",
+		"url": "http://scholar.google.com/scholar_case?case=8121501341214166807",
+
+		"description": "Decided date preceded by 'Decided' and also by a 'Submitted' date line",
+		"url": "http://scholar.google.com/scholar_case?case=834584264358299037",
+
+		"description": "Decided date preceded by 'Decided' and also by an 'Argued' date line",
+		"url": "http://scholar.google.com/scholar_case?case=15235797139493194004",
+
+		"description": "Decided date preceded by 'Decided' and also by an 'Argued' date line and followed by an 'As Modified' line; most citers of this case appear to use the Decided date, not the As Modified date",
+		"url": "http://scholar.google.com/scholar_case?case=163483131267446711",
+    
+*/
 
 /** BEGIN TEST CASES **/
 var testCases = [
@@ -998,6 +1067,201 @@ var testCases = [
 				"date": "1803",
 				"itemID": "1",
 				"libraryCatalog": "Google Scholar"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=11350538941232186766",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "288",
+				"reporter": "F. 3d",
+				"pages": "1264",
+				"title": "Meier ex rel. Meier v. Sun Intern. Hotels, Ltd.",
+				"court": "Court of Appeals, 11th Circuit",
+				"date": "April 19, 2002",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "288",
+				"firstPage": "1264",
+				"caseName": "Meier ex rel. Meier v. Sun Intern. Hotels, Ltd.",
+				"dateDecided": "April 19, 2002"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=4250138655935640563",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "2005",
+				"reporter": "Ohio",
+				"pages": "4933",
+				"title": "Patio Enclosures, Inc. v. Four Seasons Marketing Corp.",
+				"court": "Court of Appeals, 9th Appellate Dist.",
+				"extra": "{:jurisdiction: Ohio}",
+				"date": "September 21, 2005",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "2005",
+				"firstPage": "4933",
+				"caseName": "Patio Enclosures, Inc. v. Four Seasons Marketing Corp.",
+				"dateDecided": "September 21, 2005"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=8121501341214166807",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "2007",
+				"reporter": "Ohio",
+				"pages": "3029",
+				"title": "click v. estate of click",
+				"court": "Court of Appeals, 4th Appellate Dist.",
+				"extra": "{:jurisdiction: Ohio}",
+				"date": "June 13, 2007",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "2007",
+				"firstPage": "3029",
+				"caseName": "click v. estate of click",
+				"dateDecided": "June 13, 2007"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=834584264358299037",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "72",
+				"reporter": "Ohio St. 3d",
+				"pages": "415",
+				"title": "Kenty v. Transamerica Premium Ins. Co.",
+				"court": "Supreme Court",
+				"extra": "{:jurisdiction: Ohio}",
+				"date": "July 5, 1995",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "72",
+				"firstPage": "415",
+				"caseName": "Kenty v. Transamerica Premium Ins. Co.",
+				"dateDecided": "July 5, 1995"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=15235797139493194004",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "393",
+				"reporter": "US",
+				"pages": "503",
+				"title": "Tinker v. Des Moines Independent Community School Dist. ",
+				"court": "Supreme Court",
+				"date": "February 24, 1969",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "393",
+				"firstPage": "503",
+				"caseName": "Tinker v. Des Moines Independent Community School Dist.",
+				"dateDecided": "February 24, 1969"
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://scholar.google.com/scholar_case?case=163483131267446711",
+		"items": [
+			{
+				"itemType": "case",
+				"creators": [],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Google Scholar Linked Judgement",
+						"type": "text/html",
+						"url": false
+					}
+				],
+				"volume": "951",
+				"reporter": "F. 2d",
+				"pages": "765",
+				"title": "Kaimowitz v. Board of Trustees of U. of Illinois",
+				"court": "Court of Appeals, 7th Circuit",
+				"date": "December 23, 1991",
+				"itemID": "1",
+				"libraryCatalog": "Google Scholar",
+				"reporterVolume": "951",
+				"firstPage": "765",
+				"caseName": "Kaimowitz v. Board of Trustees of U. of Illinois",
+				"dateDecided": "December 23, 1991"
 			}
 		]
 	}


### PR DESCRIPTION
Added new logic for scrapeCase(...)/getDate(...) to get and save a more precise Decided Date than what is available in the citelet (if the new logic can find one). Added test case descriptions for all test cases. Added six test cases specifically for testing the added logic.

Also included comment about how the code did and still does fail for a specific case. Included link to Zotero Forum post where this was reported. (https://forums.zotero.org/discussion/44849/zotero-wont-save-google-scholar-case-but-no-error-report-id-949790485/)