### PR TITLE
Fixes #703

### DIFF
--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -55,7 +55,7 @@ function scrape(doc, url) {
 	
 	newItem.date = year;
 	newItem.reportNumber = no;
-	newItem.url = "http://eprint.iacr.org/"+year+"/"+no;
+	newItem.url = "https://eprint.iacr.org/"+year+"/"+no;
 	newItem.title = title;
 	newItem.abstractNote = abstr;
 	for (var i in authors) {


### PR DESCRIPTION
ePrint serves all papers over HTTPS. Prevents unsafe AJAX loading issues in Chrome.
I believe this is the easiest and quickest fix.