### PR TITLE
[RDF.js+Bibliontology RDF.js] Replace (deprecated) for each loops

### DIFF
--- a/RDF.js
+++ b/RDF.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2015-02-25 13:12:47"
+	"lastUpdated": "2015-06-27 19:45:13"
 }
 
 /*
@@ -159,7 +159,8 @@ function processCollection(node, collection) {
 	
 	// check for children
 	var children = getFirstResults(node, [n.dcterms+"hasPart"]);
-	for each(var child in children) {
+	for (var i=0; i<children.length; i++) {
+		var child = children[i];
 		var type = Zotero.RDF.getTargets(child, rdf+"type");
 		if(type) {
 			type = Zotero.RDF.getResourceURI(type[0]);
@@ -186,8 +187,8 @@ function processSeeAlso(node, newItem) {
 	newItem.itemID = Zotero.RDF.getResourceURI(node);
 	newItem.seeAlso = new Array();
 	if(relations = getFirstResults(node, [n.dc+"relation", n.dc1_0+"relation", n.dcterms+"relation"])) {
-		for each(var relation in relations) {
-			newItem.seeAlso.push(Zotero.RDF.getResourceURI(relation));
+		for (var i=0; i<relations.length; i++) {
+			newItem.seeAlso.push(Zotero.RDF.getResourceURI(relations[i]));
 		}
 	}
 }
@@ -196,7 +197,8 @@ function processTags(node, newItem) {
 	var subjects;
 	newItem.tags = new Array();
 	if(subjects = getFirstResults(node, [n.dc+"subject", n.dc1_0+"subject", n.dcterms+"subject"])) {
-		for each(var subject in subjects) {
+		for (var i=0; i<subjects.length; i++) {
+			var subject = subjects[i];
 			if(typeof(subject) == "string") {	// a regular tag
 				newItem.tags.push(subject);
 			} else {
@@ -223,7 +225,8 @@ function getNodeByType(nodes, type) {
 		type = [type];
 	}
 	
-	for each(var node in nodes) {
+	for (var i=0; i<nodes.length; i++) {
+		var node = nodes[i];
 		var nodeType = Zotero.RDF.getTargets(node, rdf+"type");
 		if(nodeType) {
 			nodeType = Zotero.RDF.getResourceURI(nodeType[0]);
@@ -242,7 +245,8 @@ function getNodeByType(nodes, type) {
 function isPart(node) {
 	var arcs = Zotero.RDF.getArcsIn(node);
 	var skip = false;
-	for each(var arc in arcs) {
+	for (var i=0; i<arcs.length; i++) {
+		var arc = arcs[i];
 		arc = Zotero.RDF.getResourceURI(arc);
 		if(arc != n.dc+"relation" && arc != n.dc1_0+"relation"
 			&& arc != n.dcterms+"relation" && arc != n.dcterms+"hasPart") {	
@@ -739,7 +743,8 @@ function importItem(newItem, node) {
 	// regular author-type creators
 	var possibleCreatorTypes = Zotero.Utilities.getCreatorsForType(newItem.itemType);
 	var creators;
-	for each(var creatorType in possibleCreatorTypes) {
+	for (var i=0; i<possibleCreatorTypes.length; i++) {
+		var creatorType = possibleCreatorTypes[i];
 		if(creatorType == "author") {
 			creators = getFirstResults(node, [n.bib+"authors", n.dc+"creator", n.dc1_0+"creator",
 				n.dcterms+"creator", n.eprints+"creators_name",
@@ -951,8 +956,8 @@ function importItem(newItem, node) {
 	var typeProperties = ["reportType", "letterType", "manuscriptType",
 				"mapType", "thesisType", "websiteType",
 				"presentationType", "postType",	"audioFileType"];
-	for each(var property in typeProperties) {
-		newItem[property] = type;
+	for (var i=0; i<typeProperties.length; i++) {
+		newItem[ typeProperties[i] ] = type;
 	}
 	
 	//thesis type from eprints
@@ -1015,7 +1020,8 @@ function importItem(newItem, node) {
 	/** NOTES **/
 	
 	var referencedBy = Zotero.RDF.getTargets(node, n.dcterms+"isReferencedBy");
-	for each(var referentNode in referencedBy) {
+	for (var i=0; i<referencedBy.length; i++) {
+		var referentNode = referencedBy[i];
 		var type = Zotero.RDF.getTargets(referentNode, rdf+"type");
 		if(type && Zotero.RDF.getResourceURI(type[0]) == n.bib+"Memo") {
 			// if this is a memo
@@ -1044,7 +1050,8 @@ function importItem(newItem, node) {
 	
 	var subjects = getFirstResults(node, [n.dc+"subject", n.dc1_0+"subject", n.dcterms+"subject", n.article+"tag",
 		n.prism2_0+"keyword", n.prism2_1+"keyword", n.prism2_0+"object", n.prism2_1+"object", n.prism2_0+"organization", n.prism2_1+"organization", n.prism2_0+"person", n.prism2_1+"person"]);
-	for each(var subject in subjects) {
+	for (var i=0; i<subjects.length; i++) {
+		var subject = subjects[i];
 		if(typeof(subject) == "string") {	// a regular tag
 			newItem.tags.push(subject);
 		} else {							// a call number or automatic tag
@@ -1062,7 +1069,8 @@ function importItem(newItem, node) {
 	
 	/** ATTACHMENTS **/
 	var relations = getFirstResults(node, [n.link+"link"]);
-	for each(var relation in relations) {			
+	for (var i=0; i<relations.length; i++) {
+		var relation = relations[i];		
 		var type = Zotero.RDF.getTargets(relation, rdf+"type");
 		if(Zotero.RDF.getResourceURI(type[0]) == n.z+"Attachment") {
 			var attachment = new Zotero.Item();
@@ -1082,8 +1090,8 @@ function importItem(newItem, node) {
 	
 	/** OTHER FIELDS **/
 	var arcs = Zotero.RDF.getArcsOut(node);
-	for each(var arc in arcs) {
-		var uri = Zotero.RDF.getResourceURI(arc);
+	for (var i=0; i<arcs.length; i++) {
+		var uri = Zotero.RDF.getResourceURI(arcs[i]);
 		if(uri.substr(0, n.z.length) == n.z) {
 			var property = uri.substr(n.z.length);
 			newItem[property] = Zotero.RDF.getTargets(node, n.z+property)[0];
@@ -1097,7 +1105,8 @@ function getNodes(skipCollections) {
 	var nodes = Zotero.RDF.getAllResources();
 
 	var goodNodes = new Array();
-	for each(var node in nodes) {
+	for (var i=0; i<nodes.length; i++) {
+		var node = nodes[i];
 		// figure out if this is a part of another resource, or a linked
 		// attachment, or a creator
 		if(Zotero.RDF.getSources(node, n.dcterms+"isPartOf") ||
@@ -1135,8 +1144,8 @@ function doImport() {
 	// keep track of collections while we're looping through
 	var collections = new Array();
 	
-	var i = 0;
-	for each(var node in nodes) {
+	for (var i=0; i<nodes.length; i++) {
+		var node = nodes[i];
 		// type
 		var type = Zotero.RDF.getTargets(node, rdf+"type");
 		if(type) {
@@ -1161,12 +1170,13 @@ function doImport() {
 			newItem.complete();
 		}
 
-		Zotero.setProgress(i++/nodes.length*100);
+		Zotero.setProgress((i+1)/nodes.length*100);
 	}
 	
 	/* COLLECTIONS */
 	
-	for each(var collection in collections) {
+	for (var i=0; i<collections.length; i++) {
+		var collection = collections[i];
 		if(!Zotero.RDF.getArcsIn(collection)) {
 			var newCollection = new Zotero.Collection();
 			processCollection(collection, newCollection);


### PR DESCRIPTION
Only two for each loops are with non-array objects,
and they are replaced now with for ... in loops.
Everything else were arrays and could be replaced
with simple for loops.