### PR TITLE
ScienceDirect is compatible with translation-server

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
+	"browserSupport": "gcsibv",
 	"lastUpdated": "2014-12-04 23:08:27"
 }
 


### PR DESCRIPTION
It seems to me that this scraper (ScienceDirect.js) is compatible with translation-server, based on the tests provided in the scraper (I have not checked that all fields match, though). At least it provides useful information.

Note: this scraper does not work when the client is affiliated to multiple institutions, where it is redirected to a landing page where they have to choose between the affiliations.