### PR TITLE
Changes to the TEI Translator

### DIFF
--- a/TEI.js
+++ b/TEI.js
@@ -19,7 +19,7 @@
 		"Full TEI Document": false,
 		"Export Collections": false
 	},
-	"lastUpdated":"2015-09-01 06:39:12"
+	"lastUpdated":"2015-09-22 15:19:00"
 }
 
 // ********************************************************************
@@ -109,6 +109,30 @@ var exportedXMLIds = {};
 var generatedItems = {};
 var allItems = {};
 
+// replace formatting with TEI tags
+function replaceFormatting (title){
+    var titleText = title;
+    // italics
+    titleText = titleText.replace(/<i>/g, '<hi rend="italics">');
+    titleText = titleText.replace(/<\/i>/g, '</hi>');
+    // bold
+    titleText = titleText.replace(/<b>/g, '<hi rend="bold">');
+    titleText = titleText.replace(/<\/b>/g, '</hi>');
+    // subscript
+    titleText = titleText.replace(/<sub>/g, '<hi rend="sub">');
+    titleText = titleText.replace(/<\/sub>/g, '</hi>');
+    // superscript
+    titleText = titleText.replace(/<sup>/g, '<hi rend="sup">');
+    titleText = titleText.replace(/<\/sup>/g, '</hi>');
+    // small caps
+    titleText = titleText.replace(/<span style="font-variant:\s*small-caps;">(.*?)<\/span>/g, '<hi rend="smallcaps">$1</hi>');
+    titleText = titleText.replace(/<sc>/g, '<hi rend="smallcaps">');
+    titleText = titleText.replace(/<\/sc>/g, '</hi>');
+    // no capitalization
+    titleText = titleText.replace(/<span class="nocase">(.*?)<\/span>/g, '<hi rend="nocase">$1</hi>');
+            
+    return titleText;
+}
 
 function genXMLId (item){
     var xmlid = '';
@@ -196,6 +220,8 @@ function generateItem(item, teiDoc) {
             bibl.setAttributeNS(ns.xml, "xml:id", myXmlid);
             exportedXMLIds[myXmlid] = bibl;
         }
+        //create attribute for Zotero item URI
+        bibl.setAttribute("corresp", item.uri);
     }
 
     generatedItems[item.itemID] = bibl;
@@ -214,7 +240,7 @@ function generateItem(item, teiDoc) {
         analyticTitle.setAttribute("level", "a");
         analytic.appendChild(analyticTitle);
         if(item.title){
-            analyticTitle.appendChild(teiDoc.createTextNode(item.title));
+            analyticTitle.appendChild(teiDoc.createTextNode(replaceFormatting(item.title)));
         }
 
         // there should be a publication title!
@@ -226,7 +252,7 @@ function generateItem(item, teiDoc) {
             else{
                 pubTitle.setAttribute("level", "m");
             }
-            pubTitle.appendChild(teiDoc.createTextNode(item.publicationTitle));
+            pubTitle.appendChild(teiDoc.createTextNode(replaceFormatting(item.publicationTitle)));
             monogr.appendChild(pubTitle);
         }
         // nonetheless if the user pleases this has to be possible
@@ -235,26 +261,40 @@ function generateItem(item, teiDoc) {
             pubTitle.setAttribute("level", "m");
             monogr.appendChild(pubTitle);
         }
+        // short title
+        if(item.shortTitle){
+            var shortTitle = teiDoc.createElementNS(ns.tei, "title");
+            shortTitle.setAttribute("type", "short");
+            shortTitle.appendChild(teiDoc.createTextNode(item.shortTitle));
+            analytic.appendChild(shortTitle);		
+        }
     }
     else {
         bibl.appendChild(monogr);
         if(item.title){
             var title = teiDoc.createElementNS(ns.tei, "title");
             title.setAttribute("level", "m");
-            title.appendChild(teiDoc.createTextNode(item.title));
+            title.appendChild(teiDoc.createTextNode(replaceFormatting(item.title)));
             monogr.appendChild(title);
         }
         else if(!item.conferenceName){
             var title = teiDoc.createElementNS(ns.tei, "title");
             monogr.appendChild(title);
         }
+        // short title
+        if(item.shortTitle){
+            var shortTitle = teiDoc.createElementNS(ns.tei, "title");
+            shortTitle.setAttribute("type", "short");
+            shortTitle.appendChild(teiDoc.createTextNode(item.shortTitle));
+            monogr.appendChild(shortTitle);		
+        } 
     }
 
     // add name of conference
     if(item.conferenceName){
         var conferenceName = teiDoc.createElementNS(ns.tei, "title");
         conferenceName.setAttribute("type", "conferenceName");
-        conferenceName.appendChild(teiDoc.createTextNode(item.conferenceName));
+        conferenceName.appendChild(teiDoc.createTextNode(replaceFormatting(item.conferenceName)));
         monogr.appendChild(conferenceName);
     }
 
@@ -267,14 +307,14 @@ function generateItem(item, teiDoc) {
         if(item.series){
             var title = teiDoc.createElementNS(ns.tei, "title");
             title.setAttribute("level", "s");
-            title.appendChild(teiDoc.createTextNode(item.series));
+            title.appendChild(teiDoc.createTextNode(replaceFormatting(item.series)));
             series.appendChild(title);
         }
         if(item.seriesTitle){
             var seriesTitle = teiDoc.createElementNS(ns.tei, "title");
             seriesTitle.setAttribute("level", "s");
             seriesTitle.setAttribute("type", "alternative");
-            seriesTitle.appendChild(teiDoc.createTextNode(item.seriesTitle));
+            seriesTitle.appendChild(teiDoc.createTextNode(replaceFormatting(item.seriesTitle)));
             series.appendChild(seriesTitle);
         }
         if(item.seriesText){


### PR DESCRIPTION
The changes refer to the export of the Zotero key, the export 
of the short title and the tei-conform export of formatting in titles.

Here is a more detailed description of the changes:

1. the export of the Zotero key
If you enable "Generate XML IDs", an XML ID is generated for
each entry. The current translator uses the author's last name
and the date of publication to generate the XML ID (e.g.
xml:id="McDermott1934"). These values are not stable, they can
change for some reason and a different XML ID can be generated
with the next export (e.g. xml:id="McDermott1934a"). 

In some cases, a unique and stable value for an item is needed.
We propose to export the unique item key for each entry.

The item key does not replace the XML ID. Zotero item keys can
start with a number but valid values for the attribute @xml:id
have to begin with a letter. Therefore we propose to export the
item key in addition to the XML ID.

2. export of short title
Content of the field "Short Title" is now exported as the following
<title type="short">Short Title</title>.

3. tei-conform export of formatting in titles
Zotero's tags for formatting (e.g. <i></i> and <sup></sup>) are
replaced by the TEI tags (e.g. <hi rend="italics"></hi> and
<hi rend="sup"></hi>). For example, the text <i>italic text</i>
is exported as follows: &lt;hi rend="italics&gt;italic text&lt;/hi&gt;

Unfortunately, the less-than sign and the greater-than sign are shown
as entities similar to the export result of the current TEI translator
(&lt;i&gt;italic text&lt;/i&gt;). Up to now it was not possible for
us to solve this.

Here is an example of an exported item:

                [...]
                 <biblStruct type="conferencePaper" xml:id="Sundström2009" corresp="IZECEB9P">
                    <analytic>
                        <title level="a">&lt;hi rend="italics"&gt;Rodskarl&lt;/hi&gt;,
                            &lt;i&gt;Trynta&lt;/i&gt; and &lt;i&gt;Spænneklo&lt;/i&gt;. Bynames in
                            the Town Court Record Book of Arboga from a Name-Semantic Point of
                            View</title>
                        <title type="short">Sundström 2009 – &lt;i&gt;Rodskarl&lt;/i&gt;,
                            &lt;i&gt;Trynta&lt;/i&gt; and &lt;i&gt;Spænneklo&lt;/i&gt;</title>
                        <author>
                            <forename>Agneta</forename>
                            <surname>Sundström</surname>
                        </author>
                    </analytic>
                    <monogr>
                        <title level="m">Names in Multi-Lingual, Multi-Cultural and Multi-Ethnic
                            Contact</title>
                        <editor>
                            <forename>Wolfgang</forename>
                            <surname>Ahrens</surname>
                        </editor>
                        [....]
                    </monogr>
                </biblStruct>
               [...]

Of course, we also changed some metadata (label, translatorID etc.). The basis
is the TEI translator by Stefan Majewski (last update 2015-07-20 06:45:00)