### PR TITLE
fixing regexp to take into account https support

### DIFF
--- a/OpenEdition Books.js
+++ b/OpenEdition Books.js
@@ -2,7 +2,7 @@
 	"translatorID": "4c6b4c5f-7286-45bb-8e99-0c518d177fa7",
 	"label": "OpenEdition Books",
 	"creator": "Cédric Chatelain",
-	"target": "^http://books\\.openedition\\.org/",
+	"target": "^https?://books\\.openedition\\.org/",
 	"minVersion": "1.0",
 	"maxVersion": "",
 	"priority": 100,


### PR DESCRIPTION
OpenEdition Books now supports https. Example: https://books.openedition.org/pup/4528 . Target regexp has to be updated consequently.