### PR TITLE
[arXiv]: Update test cases and cleanup work

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -2,18 +2,18 @@
 	"translatorID": "ecddda2e-4fc6-4aea-9f17-ef3b56d7377a",
 	"label": "arXiv.org",
 	"creator": "Sean Takats and Michael Berkowitz",
-	"target": "^https?://(?:[^\\.]+\\.)?(?:(?:arxiv\\.org|xxx.lanl.gov)/(?:find/\\w|list/\\w|abs/)|eprintweb.org/S/(?:search|archive|article)(?!.*(?:refs|cited)$))",
+	"target": "^https?://(?:[^\\.]+\\.)?(?:arxiv\\.org|xxx\\.lanl\\.gov)/(?:find|catchup|list/\\w|abs/)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2014-06-07 08:29:23"
+	"lastUpdated": "2015-09-26 22:41:56"
 }
 
 function detectWeb(doc, url) {
-	var searchRe = /^https?:\/\/(?:([^\.]+\.))?(?:(?:arxiv\.org|xxx\.lanl\.gov)\/(?:find|list)|eprintweb.org\/S\/(?:archive|search$))/;
+	var searchRe = /^https?:\/\/(?:([^\.]+\.))?(?:arxiv\.org|xxx\.lanl\.gov)\/(?:find|list|catchup)/;
 	
 	if(searchRe.test(url)) {
 		return "multiple";
@@ -82,23 +82,26 @@ function doWeb(doc, url) {
 	}
 }
 
-var ns = {
-	oai_dc: 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-	dc: 'http://purl.org/dc/elements/1.1/',
-	xsi: 'http://www.w3.org/2001/XMLSchema-instance',
-	n: 'http://www.openarchives.org/OAI/2.0/' // Default
-};
+
 
 function parseXML(text) {
 	//Z.debug(text);
+	
+	var ns = {
+		oai_dc: 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+		dc: 'http://purl.org/dc/elements/1.1/',
+		xsi: 'http://www.w3.org/2001/XMLSchema-instance',
+		n: 'http://www.openarchives.org/OAI/2.0/' // Default
+	};
 	var newItem = new Zotero.Item("journalArticle");
 	
 	var xml = (new DOMParser()).parseFromString(text, "text/xml");
 	var dcMeta = ZU.xpath(xml, '//n:GetRecord/n:record/n:metadata/oai_dc:dc', ns)[0];
 
-	newItem.title = getXPathNodeTrimmed(dcMeta, "dc:title");
-	getCreatorNodes(dcMeta, "dc:creator", newItem, "author");		
-	newItem.date = getXPathNodeTrimmed(dcMeta, "dc:date");
+	newItem.title = getXPathNodeTrimmed(dcMeta, "dc:title", ns);
+	getCreatorNodes(dcMeta, "dc:creator", newItem, "author", ns);		
+	newItem.date = getXPathNodeTrimmed(dcMeta, "dc:date", ns);
+	
 	
 	var descriptions = ZU.xpath(dcMeta, "./dc:description", ns);
 	
@@ -183,7 +186,7 @@ function parseXML(text) {
 }
 
 
-function getXPathNodeTrimmed(dcMeta, name) {
+function getXPathNodeTrimmed(dcMeta, name, ns) {
 	var node = ZU.xpath(dcMeta, './'+name, ns);
 	if(node.length) {
 		return ZU.trimInternal(node[0].textContent);
@@ -191,7 +194,7 @@ function getXPathNodeTrimmed(dcMeta, name) {
 	return '';
 }
 
-function getCreatorNodes(dcMeta, name, newItem, creatorType) {
+function getCreatorNodes(dcMeta, name, newItem, creatorType, ns) {
 	var nodes = ZU.xpath(dcMeta, './'+name, ns);
 	for(var i=0; i<nodes.length; i++) {
 		newItem.creators.push(
@@ -211,6 +214,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "A Model For Polarised Microwave Foreground Emission From Interstellar Dust",
 				"creators": [
 					{
 						"firstName": "D. T.",
@@ -233,16 +237,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [
-					{
-						"note": "Comment: 7 pages, 4 figures"
-					}
-				],
-				"tags": [
-					"Astrophysics - Astrophysics of Galaxies",
-					"Astrophysics - Cosmology and Nongalactic Astrophysics"
-				],
-				"seeAlso": [],
+				"date": "2012-01-11",
+				"DOI": "10.1111/j.1365-2966.2011.19851.x",
+				"ISSN": "00358711",
+				"abstractNote": "The upcoming generation of cosmic microwave background (CMB) experiments face a major challenge in detecting the weak cosmic B-mode signature predicted as a product of primordial gravitational waves. To achieve the required sensitivity these experiments must have impressive control of systematic effects and detailed understanding of the foreground emission that will influence the signal. In this paper, we present templates of the intensity and polarisation of emission from one of the main Galactic foregrounds, interstellar dust. These are produced using a model which includes a 3D description of the Galactic magnetic field, examining both large and small scales. We also include in the model the details of the dust density, grain alignment and the intrinsic polarisation of the emission from an individual grain. We present here Stokes parameter template maps at 150GHz and provide an on-line repository (http://www.imperial.ac.uk/people/c.contaldi/fgpol) for these and additional maps at frequencies that will be targeted by upcoming experiments such as EBEX, Spider and SPTpol.",
+				"extra": "arXiv: 1107.4612",
+				"issue": "2",
+				"libraryCatalog": "arXiv.org",
+				"pages": "1795-1803",
+				"publicationTitle": "Monthly Notices of the Royal Astronomical Society",
+				"url": "http://arxiv.org/abs/1107.4612",
+				"volume": "419",
 				"attachments": [
 					{
 						"title": "arXiv:1107.4612 PDF",
@@ -253,18 +258,16 @@ var testCases = [
 						"mimeType": "text/html"
 					}
 				],
-				"abstractNote": "The upcoming generation of cosmic microwave background (CMB) experiments face a major challenge in detecting the weak cosmic B-mode signature predicted as a product of primordial gravitational waves. To achieve the required sensitivity these experiments must have impressive control of systematic effects and detailed understanding of the foreground emission that will influence the signal. In this paper, we present templates of the intensity and polarisation of emission from one of the main Galactic foregrounds, interstellar dust. These are produced using a model which includes a 3D description of the Galactic magnetic field, examining both large and small scales. We also include in the model the details of the dust density, grain alignment and the intrinsic polarisation of the emission from an individual grain. We present here Stokes parameter template maps at 150GHz and provide an on-line repository (http://www.imperial.ac.uk/people/c.contaldi/fgpol) for these and additional maps at frequencies that will be targeted by upcoming experiments such as EBEX, Spider and SPTpol.",
-				"url": "http://arxiv.org/abs/1107.4612",
-				"DOI": "10.1111/j.1365-2966.2011.19851.x",
-				"extra": "arXiv: 1107.4612",
-				"issue": "2",
-				"ISSN": "00358711",
-				"libraryCatalog": "arXiv.org",
-				"title": "A Model For Polarised Microwave Foreground Emission From Interstellar Dust",
-				"date": "2012-01-11",
-				"publicationTitle": "Monthly Notices of the Royal Astronomical Society",
-				"volume": "419",
-				"pages": "1795-1803"
+				"tags": [
+					"Astrophysics - Astrophysics of Galaxies",
+					"Astrophysics - Cosmology and Nongalactic Astrophysics"
+				],
+				"notes": [
+					{
+						"note": "Comment: 7 pages, 4 figures"
+					}
+				],
+				"seeAlso": []
 			}
 		]
 	},
@@ -274,6 +277,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "Properties of the $\\delta$ Scorpii Circumstellar Disk from Continuum Modeling",
 				"creators": [
 					{
 						"firstName": "A. C.",
@@ -331,15 +335,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [
-					{
-						"note": "Comment: 27 pages, 9 figures, submitted to ApJ"
-					}
-				],
-				"tags": [
-					"Astrophysics"
-				],
-				"seeAlso": [],
+				"date": "12/2006",
+				"DOI": "10.1086/507935",
+				"ISSN": "0004-637X, 1538-4357",
+				"abstractNote": "We present optical $WBVR$ and infrared $JHKL$ photometric observations of the Be binary system $\\delta$ Sco, obtained in 2000--2005, mid-infrared (10 and $18 \\mu$m) photometry and optical ($\\lambda\\lambda$ 3200--10500 \\AA) spectropolarimetry obtained in 2001. Our optical photometry confirms the results of much more frequent visual monitoring of $\\delta$ Sco. In 2005, we detected a significant decrease in the object's brightness, both in optical and near-infrared brightness, which is associated with a continuous rise in the hydrogen line strenghts. We discuss possible causes for this phenomenon, which is difficult to explain in view of current models of Be star disks. The 2001 spectral energy distribution and polarization are succesfully modeled with a three-dimensional non-LTE Monte Carlo code which produces a self-consistent determination of the hydrogen level populations, electron temperature, and gas density for hot star disks. Our disk model is hydrostatically supported in the vertical direction and radially controlled by viscosity. Such a disk model has, essentially, only two free parameters, viz., the equatorial mass loss rate and the disk outer radius. We find that the primary companion is surrounded by a small (7 $R_\\star$), geometrically-thin disk, which is highly non-isothermal and fully ionized. Our model requires an average equatorial mass loss rate of $1.5\\times 10^{-9} M_{\\sun}$ yr$^{-1}$.",
+				"extra": "arXiv: astro-ph/0603274",
+				"issue": "2",
+				"libraryCatalog": "arXiv.org",
+				"pages": "1617-1625",
+				"publicationTitle": "The Astrophysical Journal",
+				"url": "http://arxiv.org/abs/astro-ph/0603274",
+				"volume": "652",
 				"attachments": [
 					{
 						"title": "arXiv:astro-ph/0603274 PDF",
@@ -350,18 +356,15 @@ var testCases = [
 						"mimeType": "text/html"
 					}
 				],
-				"abstractNote": "We present optical $WBVR$ and infrared $JHKL$ photometric observations of the Be binary system $\\delta$ Sco, obtained in 2000--2005, mid-infrared (10 and $18 \\mu$m) photometry and optical ($\\lambda\\lambda$ 3200--10500 \\AA) spectropolarimetry obtained in 2001. Our optical photometry confirms the results of much more frequent visual monitoring of $\\delta$ Sco. In 2005, we detected a significant decrease in the object's brightness, both in optical and near-infrared brightness, which is associated with a continuous rise in the hydrogen line strenghts. We discuss possible causes for this phenomenon, which is difficult to explain in view of current models of Be star disks. The 2001 spectral energy distribution and polarization are succesfully modeled with a three-dimensional non-LTE Monte Carlo code which produces a self-consistent determination of the hydrogen level populations, electron temperature, and gas density for hot star disks. Our disk model is hydrostatically supported in the vertical direction and radially controlled by viscosity. Such a disk model has, essentially, only two free parameters, viz., the equatorial mass loss rate and the disk outer radius. We find that the primary companion is surrounded by a small (7 $R_\\star$), geometrically-thin disk, which is highly non-isothermal and fully ionized. Our model requires an average equatorial mass loss rate of $1.5\\times 10^{-9} M_{\\sun}$ yr$^{-1}$.",
-				"url": "http://arxiv.org/abs/astro-ph/0603274",
-				"DOI": "10.1086/507935",
-				"extra": "arXiv: astro-ph/0603274",
-				"issue": "2",
-				"ISSN": "0004-637X, 1538-4357",
-				"libraryCatalog": "arXiv.org",
-				"title": "Properties of the $\\delta$ Scorpii Circumstellar Disk from Continuum Modeling",
-				"date": "12/2006",
-				"publicationTitle": "The Astrophysical Journal",
-				"volume": "652",
-				"pages": "1617-1625"
+				"tags": [
+					"Astrophysics"
+				],
+				"notes": [
+					{
+						"note": "Comment: 27 pages, 9 figures, submitted to ApJ"
+					}
+				],
+				"seeAlso": []
 			}
 		]
 	},
@@ -371,6 +374,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "Precision of a Low-Cost InGaAs Detector for Near Infrared Photometry",
 				"creators": [
 					{
 						"firstName": "Peter W.",
@@ -388,16 +392,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [
-					{
-						"note": "Comment: Accepted to PASP"
-					}
-				],
-				"tags": [
-					"Astrophysics - Earth and Planetary Astrophysics",
-					"Astrophysics - Instrumentation and Methods for Astrophysics"
-				],
-				"seeAlso": [],
+				"date": "09/2013",
+				"DOI": "10.1086/672573",
+				"ISSN": "00046280, 15383873",
+				"abstractNote": "We have designed, constructed, and tested an InGaAs near-infrared camera to explore whether low-cost detectors can make small (<1 m) telescopes capable of precise (<1 mmag) infrared photometry of relatively bright targets. The camera is constructed around the 640x512 pixel APS640C sensor built by FLIR Electro-Optical Components. We designed custom analog-to-digital electronics for maximum stability and minimum noise. The InGaAs dark current halves with every 7 deg C of cooling, and we reduce it to 840 e-/s/pixel (with a pixel-to-pixel variation of +/-200 e-/s/pixel) by cooling the array to -20 deg C. Beyond this point, glow from the readout dominates. The single-sample read noise of 149 e- is reduced to 54 e- through up-the-ramp sampling. Laboratory testing with a star field generated by a lenslet array shows that 2-star differential photometry is possible to a precision of 631 +/-205 ppm (0.68 mmag) hr^-0.5 at a flux of 2.4E4 e-/s. Employing three comparison stars and de-correlating reference signals further improves the precision to 483 +/-161 ppm (0.52 mmag) hr^-0.5. Photometric observations of HD80606 and HD80607 (J=7.7 and 7.8) in the Y band shows that differential photometry to a precision of 415 ppm (0.45 mmag) hr^-0.5 is achieved with an effective telescope aperture of 0.25 m. Next-generation InGaAs detectors should indeed enable Poisson-limited photometry of brighter dwarfs with particular advantage for late-M and L types. In addition, one might acquire near-infrared photometry simultaneously with optical photometry or radial velocity measurements to maximize the return of exoplanet searches with small telescopes.",
+				"extra": "arXiv: 1307.1469",
+				"issue": "931",
+				"libraryCatalog": "arXiv.org",
+				"pages": "1021-1030",
+				"publicationTitle": "Publications of the Astronomical Society of the Pacific",
+				"url": "http://arxiv.org/abs/1307.1469",
+				"volume": "125",
 				"attachments": [
 					{
 						"title": "arXiv:1307.1469 PDF",
@@ -408,13 +413,16 @@ var testCases = [
 						"mimeType": "text/html"
 					}
 				],
-				"abstractNote": "We have designed, constructed, and tested an InGaAs near-infrared camera to explore whether low-cost detectors can make small (<1 m) telescopes capable of precise (<1 mmag) infrared photometry of relatively bright targets. The camera is constructed around the 640x512 pixel APS640C sensor built by FLIR Electro-Optical Components. We designed custom analog-to-digital electronics for maximum stability and minimum noise. The InGaAs dark current halves with every 7 deg C of cooling, and we reduce it to 840 e-/s/pixel (with a pixel-to-pixel variation of +/-200 e-/s/pixel) by cooling the array to -20 deg C. Beyond this point, glow from the readout dominates. The single-sample read noise of 149 e- is reduced to 54 e- through up-the-ramp sampling. Laboratory testing with a star field generated by a lenslet array shows that 2-star differential photometry is possible to a precision of 631 +/-205 ppm (0.68 mmag) hr^-0.5 at a flux of 2.4E4 e-/s. Employing three comparison stars and de-correlating reference signals further improves the precision to 483 +/-161 ppm (0.52 mmag) hr^-0.5. Photometric observations of HD80606 and HD80607 (J=7.7 and 7.8) in the Y band shows that differential photometry to a precision of 415 ppm (0.45 mmag) hr^-0.5 is achieved with an effective telescope aperture of 0.25 m. Next-generation InGaAs detectors should indeed enable Poisson-limited photometry of brighter dwarfs with particular advantage for late-M and L types. In addition, one might acquire near-infrared photometry simultaneously with optical photometry or radial velocity measurements to maximize the return of exoplanet searches with small telescopes.",
-				"url": "http://arxiv.org/abs/1307.1469",
-				"extra": "arXiv: 1307.1469",
-				"libraryCatalog": "arXiv.org",
-				"title": "Precision of a Low-Cost InGaAs Detector for Near Infrared Photometry",
-				"date": "2013-07-04",
-				"publicationTitle": "arXiv:1307.1469 [astro-ph]"
+				"tags": [
+					"Astrophysics - Earth and Planetary Astrophysics",
+					"Astrophysics - Instrumentation and Methods for Astrophysics"
+				],
+				"notes": [
+					{
+						"note": "Comment: Accepted to PASP"
+					}
+				],
+				"seeAlso": []
 			}
 		]
 	},
@@ -424,6 +432,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "Precision of a Low-Cost InGaAs Detector for Near Infrared Photometry",
 				"creators": [
 					{
 						"firstName": "Peter W.",
@@ -441,16 +450,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [
-					{
-						"note": "Comment: Accepted to PASP"
-					}
-				],
-				"tags": [
-					"Astrophysics - Earth and Planetary Astrophysics",
-					"Astrophysics - Instrumentation and Methods for Astrophysics"
-				],
-				"seeAlso": [],
+				"date": "09/2013",
+				"DOI": "10.1086/672573",
+				"ISSN": "00046280, 15383873",
+				"abstractNote": "We have designed, constructed, and tested an InGaAs near-infrared camera to explore whether low-cost detectors can make small (<1 m) telescopes capable of precise (<1 mmag) infrared photometry of relatively bright targets. The camera is constructed around the 640x512 pixel APS640C sensor built by FLIR Electro-Optical Components. We designed custom analog-to-digital electronics for maximum stability and minimum noise. The InGaAs dark current halves with every 7 deg C of cooling, and we reduce it to 840 e-/s/pixel (with a pixel-to-pixel variation of +/-200 e-/s/pixel) by cooling the array to -20 deg C. Beyond this point, glow from the readout dominates. The single-sample read noise of 149 e- is reduced to 54 e- through up-the-ramp sampling. Laboratory testing with a star field generated by a lenslet array shows that 2-star differential photometry is possible to a precision of 631 +/-205 ppm (0.68 mmag) hr^-0.5 at a flux of 2.4E4 e-/s. Employing three comparison stars and de-correlating reference signals further improves the precision to 483 +/-161 ppm (0.52 mmag) hr^-0.5. Photometric observations of HD80606 and HD80607 (J=7.7 and 7.8) in the Y band shows that differential photometry to a precision of 415 ppm (0.45 mmag) hr^-0.5 is achieved with an effective telescope aperture of 0.25 m. Next-generation InGaAs detectors should indeed enable Poisson-limited photometry of brighter dwarfs with particular advantage for late-M and L types. In addition, one might acquire near-infrared photometry simultaneously with optical photometry or radial velocity measurements to maximize the return of exoplanet searches with small telescopes.",
+				"extra": "arXiv: 1307.1469",
+				"issue": "931",
+				"libraryCatalog": "arXiv.org",
+				"pages": "1021-1030",
+				"publicationTitle": "Publications of the Astronomical Society of the Pacific",
+				"url": "http://arxiv.org/abs/1307.1469",
+				"volume": "125",
 				"attachments": [
 					{
 						"title": "arXiv:1307.1469 PDF",
@@ -461,72 +471,22 @@ var testCases = [
 						"mimeType": "text/html"
 					}
 				],
-				"abstractNote": "We have designed, constructed, and tested an InGaAs near-infrared camera to explore whether low-cost detectors can make small (<1 m) telescopes capable of precise (<1 mmag) infrared photometry of relatively bright targets. The camera is constructed around the 640x512 pixel APS640C sensor built by FLIR Electro-Optical Components. We designed custom analog-to-digital electronics for maximum stability and minimum noise. The InGaAs dark current halves with every 7 deg C of cooling, and we reduce it to 840 e-/s/pixel (with a pixel-to-pixel variation of +/-200 e-/s/pixel) by cooling the array to -20 deg C. Beyond this point, glow from the readout dominates. The single-sample read noise of 149 e- is reduced to 54 e- through up-the-ramp sampling. Laboratory testing with a star field generated by a lenslet array shows that 2-star differential photometry is possible to a precision of 631 +/-205 ppm (0.68 mmag) hr^-0.5 at a flux of 2.4E4 e-/s. Employing three comparison stars and de-correlating reference signals further improves the precision to 483 +/-161 ppm (0.52 mmag) hr^-0.5. Photometric observations of HD80606 and HD80607 (J=7.7 and 7.8) in the Y band shows that differential photometry to a precision of 415 ppm (0.45 mmag) hr^-0.5 is achieved with an effective telescope aperture of 0.25 m. Next-generation InGaAs detectors should indeed enable Poisson-limited photometry of brighter dwarfs with particular advantage for late-M and L types. In addition, one might acquire near-infrared photometry simultaneously with optical photometry or radial velocity measurements to maximize the return of exoplanet searches with small telescopes.",
-				"url": "http://arxiv.org/abs/1307.1469",
-				"extra": "arXiv: 1307.1469",
-				"libraryCatalog": "arXiv.org",
-				"title": "Precision of a Low-Cost InGaAs Detector for Near Infrared Photometry",
-				"date": "2013-07-04",
-				"publicationTitle": "arXiv:1307.1469 [astro-ph]"
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://eprintweb.org/s/article/arxiv/1307.1469",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"creators": [
-					{
-						"firstName": "Peter W.",
-						"lastName": "Sullivan",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Bryce",
-						"lastName": "Croll",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Robert A.",
-						"lastName": "Simcoe",
-						"creatorType": "author"
-					}
+				"tags": [
+					"Astrophysics - Earth and Planetary Astrophysics",
+					"Astrophysics - Instrumentation and Methods for Astrophysics"
 				],
 				"notes": [
 					{
 						"note": "Comment: Accepted to PASP"
 					}
 				],
-				"tags": [
-					"Astrophysics - Earth and Planetary Astrophysics",
-					"Astrophysics - Instrumentation and Methods for Astrophysics"
-				],
-				"seeAlso": [],
-				"attachments": [
-					{
-						"title": "arXiv:1307.1469 PDF",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "arXiv.org Snapshot",
-						"mimeType": "text/html"
-					}
-				],
-				"abstractNote": "We have designed, constructed, and tested an InGaAs near-infrared camera to explore whether low-cost detectors can make small (<1 m) telescopes capable of precise (<1 mmag) infrared photometry of relatively bright targets. The camera is constructed around the 640x512 pixel APS640C sensor built by FLIR Electro-Optical Components. We designed custom analog-to-digital electronics for maximum stability and minimum noise. The InGaAs dark current halves with every 7 deg C of cooling, and we reduce it to 840 e-/s/pixel (with a pixel-to-pixel variation of +/-200 e-/s/pixel) by cooling the array to -20 deg C. Beyond this point, glow from the readout dominates. The single-sample read noise of 149 e- is reduced to 54 e- through up-the-ramp sampling. Laboratory testing with a star field generated by a lenslet array shows that 2-star differential photometry is possible to a precision of 631 +/-205 ppm (0.68 mmag) hr^-0.5 at a flux of 2.4E4 e-/s. Employing three comparison stars and de-correlating reference signals further improves the precision to 483 +/-161 ppm (0.52 mmag) hr^-0.5. Photometric observations of HD80606 and HD80607 (J=7.7 and 7.8) in the Y band shows that differential photometry to a precision of 415 ppm (0.45 mmag) hr^-0.5 is achieved with an effective telescope aperture of 0.25 m. Next-generation InGaAs detectors should indeed enable Poisson-limited photometry of brighter dwarfs with particular advantage for late-M and L types. In addition, one might acquire near-infrared photometry simultaneously with optical photometry or radial velocity measurements to maximize the return of exoplanet searches with small telescopes.",
-				"url": "http://arxiv.org/abs/1307.1469",
-				"extra": "arXiv: 1307.1469",
-				"libraryCatalog": "arXiv.org",
-				"title": "Precision of a Low-Cost InGaAs Detector for Near Infrared Photometry",
-				"date": "2013-07-04",
-				"publicationTitle": "arXiv:1307.1469 [astro-ph]"
+				"seeAlso": []
 			}
 		]
 	},
 	{
 		"type": "web",
-		"url": "http://eprintweb.org/S/archive/astro-ph/recent",
+		"url": "http://arxiv.org/find/cs/1/au:+Hoffmann_M/0/1/0/all/0/1",
 		"items": "multiple"
 	}
 ]


### PR DESCRIPTION
 * The mirror eprintweb.org does not exists any more.
 * Update all remaining test cases.
 * Add test case for result page from find.
 * The advanced search will result in the url arxiv.org.gov/find
   and some post variables.
 * Multiple results from catchup are now considered as well.
 * The namespaces ns are not anymore a global variable.