### PR TITLE
Fix for PDF Download

### DIFF
--- a/CAIRN Info.js
+++ b/CAIRN Info.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2014-03-11 22:36:38"
+	"lastUpdated": "2015-10-15 05:27:29"
 }
 
 /*
@@ -84,6 +84,20 @@ function doWeb(doc,url)
 						tags.push(keywords[i])
 					}
 				}
+
+				// The default value for PDF download is on an HTML page that calls the actual download
+				// we need to add this attachment after the import translator has been running
+				// We remove the attached PDF because they won't be working
+				for(var i=item.attachments.length - 1; i>=0; i--) {
+					if(item.attachments[i].mimeType == 'application/pdf') {
+						item.attachments.splice(i, 1);
+					}
+				}
+				
+				var pdfUrl = ZU.xpathText(doc, '//meta[@name="citation_pdf_url"]/@content');
+				pdfUrlDownload = pdfUrl + "&download=1";
+				item.attachments.push({title : "Full Text PDF", mimeType: "application/pdf", url: pdfUrlDownload});
+				
 				item.complete();
 				});
 		translator.getTranslatorObject(function (obj) {


### PR DESCRIPTION
Cairn has changed the way they handle the PDF download by adding an intermediate page that will call the real PDF download. So the embedded metadata translator won't be able to download the PDF as mimetype is not the good one.

This fix add extra processing after the import translator to request the actual PDF.