### PR TITLE
Renamed Talis Prism 2 to Capita Prism

### DIFF
--- a/Library Catalog (Talis Prism 2).js
+++ b/Library Catalog (Talis Prism 2).js
@@ -1,6 +1,6 @@
 {
 	"translatorID": "dc024bfc-2252-4257-b10e-cb95a0f213aa",
-	"label": "Library Catalog (Talis Prism 2)",
+	"label": "Library Catalog (Capita Prism)",
 	"creator": "Sebastian Karcher",
 	"target": "/items(/\\d+|\\?query=)",
 	"minVersion": "2.1.9",


### PR DESCRIPTION
Talis's library business was sold to Capita in 2011, so changing the label to reflect this.

The URI structure being looked for is also from the version of Prism that followed 2, which doesn't have a version number.