### PR TITLE
DOI translator checks DataCite as well (test)

### DIFF
--- a/CSL JSON.js
+++ b/CSL JSON.js
@@ -9,10 +9,8 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcs",
-	"lastUpdated": "2015-06-05 23:03:52"
+	"lastUpdated": "2016-01-18 22:04:27"
 }
-
-var parsedData;
 
 function parseInput() {
 	var str, json = "";
@@ -23,7 +21,7 @@ function parseInput() {
 	while((str = Z.read(1048576)) !== false) json += str;
 	
 	try {
-		parsedData = JSON.parse(json);	
+		return JSON.parse(json);
 	} catch(e) {
 		Zotero.debug(e);
 	}
@@ -40,7 +38,7 @@ function detectImport() {
 		"post":true, "post-weblog":true, "report":true, "review":true, "review-book":true,
 		"song":true, "speech":true, "thesis":true, "treaty":true, "webpage":true};
 		
-	parseInput();
+	var parsedData = parseInput();
 	if(!parsedData) return false;
 	
 	if(typeof parsedData !== "object") return false;
@@ -56,7 +54,7 @@ function detectImport() {
 }
 
 function doImport() {
-	if(!parsedData) parseInput();
+	var parsedData = parseInput();
 	if(!parsedData) return;
 	
 	for(var i=0; i<parsedData.length; i++) {


### PR DESCRIPTION
I tried to expand the DOI translator to handle calling besides the CrossRef translator also the DataCite translator. I know that there is an old PR #632 and much more discussion how this could be achieved...

My approach in the `retrieveDOIs` function is just before calling the `completeDOIs` function to recursively call the `retrieveDOIs` function again but using the DataCite translator with the `remainingDOIs` (and make sure we don't create an infinite loop). Actually, this seemed to work pretty well, but maybe I am missing some things here.

My test case is the webpage: http://www.egms.de/static/de/journals/mbi/2015-15/mbi000336.shtml with 6 CrossRef doi's and 1 DataCite doi. Actually, the DataCite doi works as expected, but only the last CrossRef doi is recognized. However, I think that this behaviour is not a new bug but it is the same with the current translator. (Check). I tried to code another (non-asynchronous) version `retrieveDOIs2` which works fine for several CrossRef/DataCite doi's.

I am looking forward for your comments. Is this some idea which is worth to continue? Is it working for you?