### PR TITLE
HCSP website could be accessed either with or without "www"

### DIFF
--- a/HCSP.js
+++ b/HCSP.js
@@ -2,14 +2,14 @@
 	"translatorID": "3e375db7-5f6e-4861-ab8b-3ddb0f4accc9",
 	"label": "HCSP",
 	"creator": "Joris Muller",
-	"target": "^https?://www\\.hcsp\\.fr/explore\\.cgi/",
+	"target": "^https?://(www\\.)?hcsp\\.fr/explore\\.cgi/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2015-08-05 09:11:04"
+	"lastUpdated": "2016-01-30 09:11:04"
 }
 
 /*


### PR DESCRIPTION
The pages on the HCSP's website could be accessed either with or without "www". Examples:

- http://www.hcsp.fr/Explore.cgi/avisrapportsdomaine?clefr=533
- http://hcsp.fr/Explore.cgi/avisrapportsdomaine?clefr=533

leads exactly to the same page but with two different URLs. I changed the regex for the target to be able to detect both.