### PR TITLE
[IEEE Xplore] Fix PDF download for no-frame (mobile) pages

### DIFF
--- a/IEEE Xplore.js
+++ b/IEEE Xplore.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-01-30 18:30:13"
+	"lastUpdated": "2016-01-30 20:32:15"
 }
 
 function detectWeb(doc, url) {
@@ -142,13 +142,9 @@ function scrape (doc, url) {
 			if (pdf) {
 				ZU.doGet(pdf, function (src) {
 					var m = /<frame src="(.*\.pdf.*)"|<meta HTTP-EQUIV="REFRESH" content="0; url=(.*\.pdf.*)"/.exec(src);
-					if (m[1]) item.attachments = [{
-						url: m[1],
-						title: "IEEE Xplore Full Text PDF",
-						mimeType: "application/pdf"
-					}, {url: url, title: "IEEE Xplore Abstract Record", mimeType: "text/html"}];
-					else if (m[2]) item.attachments = [{
-						url: m[2],
+					var pdfUrl = m && (m[1] || m[2]);
+					if (pdfUrl) item.attachments = [{
+						url: pdfUrl,
 						title: "IEEE Xplore Full Text PDF",
 						mimeType: "application/pdf"
 					}, {url: url, title: "IEEE Xplore Abstract Record", mimeType: "text/html"}];
@@ -360,10 +356,6 @@ var testCases = [
 				"publicationTitle": "IEEE Transactions on Electron Devices",
 				"volume": "52",
 				"attachments": [
-					{
-						"title": "IEEE Xplore Full Text PDF",
-						"mimeType": "application/pdf"
-					},
 					{
 						"title": "IEEE Xplore Abstract Record",
 						"mimeType": "text/html"

--- a/IEEE Xplore.js
+++ b/IEEE Xplore.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2015-06-09 07:32:25"
+	"lastUpdated": "2016-01-30 18:30:13"
 }
 
 function detectWeb(doc, url) {
@@ -141,9 +141,14 @@ function scrape (doc, url) {
 			}
 			if (pdf) {
 				ZU.doGet(pdf, function (src) {
-					var m = /<frame src="(.*\.pdf.*)"/.exec(src);
-					if (m) item.attachments = [{
+					var m = /<frame src="(.*\.pdf.*)"|<meta HTTP-EQUIV="REFRESH" content="0; url=(.*\.pdf.*)"/.exec(src);
+					if (m[1]) item.attachments = [{
 						url: m[1],
+						title: "IEEE Xplore Full Text PDF",
+						mimeType: "application/pdf"
+					}, {url: url, title: "IEEE Xplore Abstract Record", mimeType: "text/html"}];
+					else if (m[2]) item.attachments = [{
+						url: m[2],
 						title: "IEEE Xplore Full Text PDF",
 						mimeType: "application/pdf"
 					}, {url: url, title: "IEEE Xplore Abstract Record", mimeType: "text/html"}];
@@ -355,6 +360,10 @@ var testCases = [
 				"publicationTitle": "IEEE Transactions on Electron Devices",
 				"volume": "52",
 				"attachments": [
+					{
+						"title": "IEEE Xplore Full Text PDF",
+						"mimeType": "application/pdf"
+					},
 					{
 						"title": "IEEE Xplore Abstract Record",
 						"mimeType": "text/html"


### PR DESCRIPTION
Discovered Problem:  IEEE Xplore pages do not use frames when the user agent is a mobile browser (test case is iOS).  As a result, the frame associated with the PDF download link is not present for mobile devices, and PDF download does not happen on iOS devices because the script looks for that frame.  The problem can be observed in Firefox by changing the user agent to "Mozilla/5.0 (iPad; CPU OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H321 Safari/600.1.4".

Proposed Solution:  I have expanded the REGEX expression to find the PDF path for pages containing frames and pages not containing frames.  A test case was also updated to show apparent, correct results.

Assuming this fix is approved, it will need to be pushed to the bookmarklets to be useful.