### PR TITLE
Remove colon from bibtex cite key

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -1066,7 +1066,7 @@ var numberRe = /^[0-9]+/;
 // Also remove markup
 var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l\'|el|las|los|al|uno|una|unos|unas|de|des|del|d\')(\s+|\b)|(<\/?(i|b|sup|sub|sc|span style=\"small-caps\"|span)>)/g;
 var citeKeyConversionsRe = /%([a-zA-Z])/;
-var citeKeyCleanRe = /[^a-z0-9\!\$\&\*\+\-\.\/\:\;\<\>\?\[\]\^\_\`\|]+/g;
+var citeKeyCleanRe = /[^a-z0-9\!\$\&\*\+\-\.\/\;\<\>\?\[\]\^\_\`\|]+/g;
 
 var citeKeyConversions = {
 	"a":function (flags, item) {


### PR DESCRIPTION
Having a colon in bibtex cite key will cause issues when using the babel latex package with the french language and the pagebackref option from hyperref.
Babel will insert a space before the colon at some point, which will confuse hyperref.
