### PR TITLE
Enable 5 translators for translation-server and add url to Google Books

### DIFF
--- a/Google Books.js
+++ b/Google Books.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsb",
+	"browserSupport": "gcsbv",
 	"lastUpdated": "2015-09-24 15:24:15"
 }
 
@@ -116,17 +116,22 @@ function parseXML(text) {
 	}
 	
 	var ISBN;
-	const ISBN10Re = /(ISBN:)(\w{10})$/;
-	const ISBN13Re = /(ISBN:)(\w{13})$/;
+	const ISBN10Re = /(?:ISBN:)(\w{10})$/;
+	const ISBN13Re = /(?:ISBN:)(\w{13})$/;
+	const booksIDRe = /^(\w{12})$/;
 	var identifiers = ZU.xpath(xml, "dc:identifier", ns);
 	for (var i in identifiers) {
 		var ISBN10Match = ISBN10Re.exec(identifiers[i].textContent);
 		var ISBN13Match = ISBN13Re.exec(identifiers[i].textContent);
+		var booksIDMatch = booksIDRe.exec(identifiers[i].textContent);
 		if (ISBN10Match != null) {
-			ISBN = ISBN10Match[2];
+			ISBN = ISBN10Match[1];
 		}
 		if (ISBN13Match != null) {
-			ISBN = ISBN13Match[2];
+			ISBN = ISBN13Match[1];
+		}
+		if (booksIDMatch != null) {
+			newItem.url = 'https://books.google.com/books?id=' + booksIDMatch[1];
 		}
 	}
 	newItem.ISBN = ISBN;

--- a/JSTOR.js
+++ b/JSTOR.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
+	"browserSupport": "gcsibv",
 	"lastUpdated": "2016-05-13 22:51:52"
 }
 

--- a/Primo.js
+++ b/Primo.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsb",
+	"browserSupport": "gcsbv",
 	"lastUpdated": "2016-04-22 09:32:07"
 }
 

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
+	"browserSupport": "gcsibv",
 	"lastUpdated": "2015-12-08 05:47:08"
 }
 

--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
+	"browserSupport": "gcsibv",
 	"lastUpdated": "2015-06-04 16:47:36"
 }
 


### PR DESCRIPTION
Enable JSTOR, Primo, ScienceDirect, Wiley Online,
and Google Books translators for translation-server. 

Add regex for 12 character google books ID,
and add url to citation based on that ID.

Change-Id: I706250304fb8df4e53ee45c3e32ced7970e7f19e