### PR TITLE
Change version to versionNumber for computerProgram

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -4,7 +4,7 @@
 	"label": "BibLaTeX",
 	"creator": "Simon Kornblith, Richard Karnesky and Anders Johansson",
 	"target": "bib",
-	"minVersion": "2.1.9",
+	"minVersion": "4.0.27",
 	"maxVersion": "null",
 	"priority": 100,
 	"inRepository": true,
@@ -15,7 +15,7 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2015-09-10 08:45:20"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 
@@ -40,7 +40,7 @@ var fieldMap = {
 	shorttitle: "shortTitle",
 	abstract: "abstractNote",
 	volumes: "numberOfVolumes",
-	version: "version",
+	version: "versionNumber",
 	eventtitle: "conferenceName",
 	pages: "pages",
 	pagetotal: "numPages"

--- a/Bibliontology RDF.js
+++ b/Bibliontology RDF.js
@@ -4,14 +4,14 @@
 	"label":"Bibliontology RDF",
 	"creator":"Simon Kornblith",
 	"target":"rdf",
-	"minVersion":"2.0",
+	"minVersion":"4.0.27",
 	"maxVersion":"",
 	"priority":50,
 	"browserSupport":"gcs",
 	"configOptions":{"getCollections":"true", "dataMode":"rdf/xml"},
 	"displayOptions":{"exportNotes":true},
 	"inRepository":false,
-	"lastUpdated":"2015-06-27 13:43:17"
+	"lastUpdated":"2016-06-20 20:00:00"
 }
 
 var n = {
@@ -260,7 +260,7 @@ var FIELDS = {
 	"scale":				[ITEM,			n.z+"scale"],
 	"meetingName":			[ITEM,			[n.bibo+"presentedAt", [[n.rdf+"type", n.bibo+"Conference"]], n.dcterms+"title"]],
 	"runningTime":			[ITEM,			n.po+"duration"],
-	"version":				[ITEM,			n.doap+"revision"],
+	"versionNumber":		[ITEM,			n.doap+"revision"],
 	"system":				[ITEM, 			n.doap+"os"],
 	"conferenceName":		[ITEM,			[n.bibo+"presentedAt", [[n.rdf+"type", n.bibo+"Conference"]], n.dcterms+"title"]],
 	"language":				[ITEM,			n.dcterms+"language"],

--- a/CSV.js
+++ b/CSV.js
@@ -3,7 +3,7 @@
 	"label": "CSV",
 	"creator": "Philipp Zumstein and Aurimas Vinckevicius",
 	"target": "csv",
-	"minVersion": "3.0",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"displayOptions": {
@@ -13,7 +13,7 @@
 	"inRepository": true,
 	"translatorType": 2,
 	"browserSupport": "g",
-	"lastUpdated": "2016-01-05 23:10:00"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 /*
@@ -73,7 +73,7 @@ var exportedFields = [
 	"number","edition","runningTime","scale","medium","artworkSize",
 	"filingDate","applicationNumber","assignee","issuingAuthority","country",
 	"meetingName","conferenceName","court","references","reporter",
-	"legalStatus","priorityNumbers","programmingLanguage","version","system",
+	"legalStatus","priorityNumbers","programmingLanguage","versionNumber","system",
 	"code","codeNumber","section","session","committee","history",
 	"legislativeBody"
 ];

--- a/Endnote XML.js
+++ b/Endnote XML.js
@@ -3,7 +3,7 @@
 	"label": "Endnote XML",
 	"creator": "Sebastian Karcher",
 	"target": "xml",
-	"minVersion": "4.0",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"configOptions": {
@@ -16,7 +16,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcv",
-	"lastUpdated": "2015-03-05 03:20:38"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 function detectImport() {
@@ -371,7 +371,7 @@ var fieldMap = {
 		"__default": "edition",
 		//		"__ignore":["journalArticle"], //EPubDate.
 		session: ["bill", "hearing", "statute"],
-		version: ["computerProgram"]
+		versionNumber: ["computerProgram"]
 	},
 	issue: {
 		"__default": "issue",

--- a/Google Play.js
+++ b/Google Play.js
@@ -3,13 +3,13 @@
 	"label": "Google Play",
 	"creator": "Avram Lyon",
 	"target": "^https?://play\\.google\\.com/",
-	"minVersion": "4.0",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsib",
-	"lastUpdated": "2015-02-12 08:57:37"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 /*
@@ -119,7 +119,7 @@ function saveIndividual(doc, url) {
 	var version = findProperty(doc, "softwareVersion");
 	// We exlide "Varies with device"
 	if (/\d/.test(version)) {
-		item.version = version;
+		item.versionNumber = version;
 	}
 	
 	item.company = author;
@@ -143,7 +143,7 @@ var testCases = [
 				"libraryCatalog": "Google Play",
 				"system": "Android 2.1 and up",
 				"url": "https://play.google.com/store/apps/details?id=com.gimranov.zandy.app",
-				"version": "1.4.4",
+				"versionNumber": "1.4.4",
 				"attachments": [
 					{
 						"title": "App Screenshot"

--- a/RDF.js
+++ b/RDF.js
@@ -3,7 +3,7 @@
 	"label": "RDF",
 	"creator": "Simon Kornblith",
 	"target": "rdf",
-	"minVersion": "2.1.9",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"configOptions": {
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2016-01-16 21:09:00"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 /*
@@ -830,7 +830,7 @@ function importItem(newItem, node) {
 	// edition
 	newItem.edition = getFirstResults(node, [n.prism+"edition", n.prism2_0+"edition", n.prism2_1+"edition", n.bibo+"edition"], true);
 	// these fields mean the same thing
-	newItem.version = newItem.edition;
+	newItem.versionNumber = newItem.edition;
 	
 	// pages
 	newItem.pages = getFirstResults(node, [n.bib+"pages", n.eprints+"pagerange", n.prism2_0+"pageRange", n.prism2_1+"pageRange", n.bibo+"pages"], true);

--- a/RIS.js
+++ b/RIS.js
@@ -3,7 +3,7 @@
 	"label": "RIS",
 	"creator": "Simon Kornblith and Aurimas Vinckevicius",
 	"target": "ris",
-	"minVersion": "3.0.4",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"configOptions": {
@@ -17,7 +17,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2015-08-21 22:25:52"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 function detectImport() {
@@ -298,7 +298,7 @@ var fieldMap = {
 		"__default":"edition",
 //		"__ignore":["journalArticle"], //EPubDate
 		session:["bill", "hearing", "statute"],
-		version:["computerProgram"]
+		versionNumber:["computerProgram"]
 	},
 	IS: {
 		"__default":"issue",
@@ -2621,7 +2621,7 @@ var testCases = [
 				"seriesTitle": "Series Title",
 				"shortTitle": "Short Title",
 				"url": "URL",
-				"version": "Version",
+				"versionNumber": "Version",
 				"attachments": [],
 				"tags": [
 					"Keyword1, Keyword2, Keyword3",
@@ -4873,7 +4873,7 @@ var testCases = [
 				"company": "Publisher Name",
 				"place": "Place of Publication",
 				"url": "Location/URL",
-				"version": "Version",
+				"versionNumber": "Version",
 				"attachments": [],
 				"tags": [
 					"Keywords1, Keywords2, Keywords3",

--- a/RefWorks Tagged.js
+++ b/RefWorks Tagged.js
@@ -3,7 +3,7 @@
 	"label": "RefWorks Tagged",
 	"creator": "Simon Kornblith, Aurimas Vinckevicius, and Sebastian Karcher",
 	"target": "txt",
-	"minVersion": "3.0.4",
+	"minVersion": "4.0.27",
 	"maxVersion": "",
 	"priority": 100,
 	"displayOptions": {
@@ -14,7 +14,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2015-03-24 02:55:12"
+	"lastUpdated": "2016-06-20 20:00:00"
 }
 
 /*This Translator mirrors closely Aurimas Vinckevicius' RIS translator
@@ -262,7 +262,7 @@ var fieldMap = {
 	ED: {
 		"__default":"edition",
 		session:["bill", "hearing", "statute"],
-		version:["computerProgram"]
+		versionNumber:["computerProgram"]
 	},
 	LA: {
 		"__default":"language",

--- a/Zotero RDF.js
+++ b/Zotero RDF.js
@@ -4,13 +4,13 @@
 	"label":"Zotero RDF",
 	"creator":"Simon Kornblith",
 	"target":"rdf",
-	"minVersion":"1.0.0b4.r1",
+	"minVersion":"4.0.27",
 	"maxVersion":"",
 	"priority":25,
 	"configOptions":{"getCollections":"true", "dataMode":"rdf/xml"},
 	"displayOptions":{"exportNotes":true, "exportFileData":false},
 	"inRepository":true,
-	"lastUpdated":"2015-07-20 06:39:12"
+	"lastUpdated":"2016-06-20 20:00:00"
 }
 
 var item;
@@ -379,7 +379,7 @@ function generateItem(item, zoteroType, resource) {
 		} else if(property == "rights") {			// rights
 			Zotero.RDF.addStatement(resource, n.dc+"rights", value, true);
 		} else if(property == "edition" ||			// edition
-		          property == "version") {			// version
+		          property == "versionNumber") {			// version
 			Zotero.RDF.addStatement(resource, n.prism+"edition", value, true);
 		} else if(property == "date") {				// date
 			if(item.dateSent) {


### PR DESCRIPTION
See https://groups.google.com/forum/#!msg/zotero-dev/FWCP_R5S_hg/ditgqvOpDwAJ

Searched for `\bversion:|"version"[^,]|\.version\b` in all translators not using the framework.

The TEI translator was already updated in https://github.com/zotero/translators/commit/23f345b70fe721e0050d0a624aff24b3898354b3