### PR TITLE
Some tweaks to how DC item types are identified

### DIFF
--- a/RDF.js
+++ b/RDF.js
@@ -394,7 +394,7 @@ function detectType(newItem, node, ret) {
 			t.dc = type;
 		} else {
 			//on eprints the type fields are often in the form "Journal Article", "Conference Item" etc.
-			type = type.toLowerCase().replace(/\s/g, "")
+			type = type.toLowerCase().replace(/\s/g, "");
 			switch (type) {
 				//eprints
 				//from http://www.ukoln.ac.uk/repositories/digirep/index/Eprints_Type_Vocabulary_Encoding_Scheme
@@ -682,7 +682,7 @@ function detectType(newItem, node, ret) {
 
 	var itemType = t.zotero || t.bib || t.prism ||t.eprints|| t.og || t.dc || 
 		exports.defaultUnknownType || t.zoteroGuess || t.bibGuess || 
-		t.prismGuess || t.ogGuess || t.dcGuess 
+		t.prismGuess || t.ogGuess || t.dcGuess ;
 
 	//in case we still don't have a container, double-check
 	//some are copied from above

--- a/RDF.js
+++ b/RDF.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcs",
-	"lastUpdated": "2016-06-21 08:45:20"
+	"lastUpdated": "2016-06-22 21:09:00"
 }
 
 /*
@@ -413,6 +413,8 @@ function detectType(newItem, node, ret) {
 				case 'conferenceposter':
 					t.dc = 'conferencePaper';
 					break;
+				case 'article':  //from http://www.idealliance.org/specifications/prism/specifications/prism-controlled-vocabularies/prism-12-controlled-vocabularies
+				case 'dataset':  //until dataset gets implemented
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
@@ -444,9 +446,6 @@ function detectType(newItem, node, ret) {
 
 				//from http://www.idealliance.org/specifications/prism/specifications/prism-controlled-vocabularies/prism-12-controlled-vocabularies
 				//some are the same as eprints and are handled above
-				case 'article':
-					t.dcGuess = 'journalArticle';
-					break;
 				case 'electronicbook':
 					t.dc = 'book';
 					break;
@@ -521,6 +520,8 @@ function detectType(newItem, node, ret) {
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
+				case 'dataset':
+				//map to dataset once we have it as item type
 				case 'article':
 					t.eprints = 'journalArticle';
 					break;
@@ -535,8 +536,6 @@ function detectType(newItem, node, ret) {
 					break;
 				//from  samples at http://oro.open.ac.uk, http://eprints.soton.ac.uk/, http://eprints.biblio.unitn.it
 				case 'techreport':
-				case 'dataset':  
-				//map to dataset once we have it as item type
 					t.eprints = 'report';
 					break;
 				case 'bookedit':


### PR DESCRIPTION
- dataset in eprints and DC should become a journal article
- article type in DC should be a journal article, both given common
- usage and for uniformity with eprint
@zuphilip -- pls. review when you get a chance.