### PR TITLE
Update wiso translator

### DIFF
--- a/wiso.js
+++ b/wiso.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2016-02-04 08:08:19"
+	"lastUpdated": "2016-06-26 18:54:53"
 }
 
 /*
@@ -48,7 +48,7 @@ function detectWeb(doc, url) {
 
 
 function scrape(doc, url) {
-	var address = ZU.xpathText(doc, '//pre[strong and contains(text(), "https://www.wiso-net.de/document/")]');
+	var address = ZU.xpathText(doc, '//pre[strong]/a[contains(text(), "https://www.wiso-net.de/document/")]');
 	var docUid = address.substr(address.lastIndexOf('/')+1);
 	var risUrl = "/stream/exportDocuments?docUids="
 		+ docUid + "&dbShortcut=&query=&source=Document&format=Citavi";


### PR DESCRIPTION
The problem was reported in the forum:
https://forums.zotero.org/discussion/59856/wiso-site-translator/

The website simply changed its structure such that the  permalink is now saved in a url tag and not simple text node. This PR change the XPath accordingly.