### PR TITLE
Bryn mawr

### DIFF
--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -154,8 +154,8 @@ var testCases = [
 				"itemType": "journalArticle",
 				"creators": [
 					{
- 						"firstName": "Keely Elizabeth"
- 						"lastName": "Heuer"
+ 						"firstName": "Keely Elizabeth",
+ 						"lastName": "Heuer",
  						"creatorType": "author"
 					},
 					{

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -78,6 +78,7 @@ function doWeb(doc, url) {
 		var title = doc.evaluate('//h3/i', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent;
 		item.publicationTitle = "Bryn Mawr Classical Review";
 		item.journalAbbreviation = "BMCR";
+		item.ISSN = "1055-7660";
 		item.title = "Review of: " + Zotero.Utilities.trimInternal(title);
 		var data = doc.evaluate('//h3[i]', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent;
 		var title = title.replace("(", "\\(").replace(")", "\\)");
@@ -137,6 +138,7 @@ var testCases = [
 				],
 				"publicationTitle": "Bryn Mawr Classical Review",
 				"journalAbbreviation": "BMCR",
+				"ISSN": "1055-7660",
 				"title": "Review of: Sallust: The War Against Jugurtha. Aris and Phillips Classical Texts",
 				"url": "http://bmcr.brynmawr.edu/2010/2010-01-02.html",
 				"date": "2010/01",
@@ -185,6 +187,7 @@ var testCases = [
 				],
 				"publicationTitle": "Bryn Mawr Classical Review",
 				"journalAbbreviation": "BMCR",
+				"ISSN": "1055-7660",
 				"title": "Review of: The Classical Tradition",
 				"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
 				"date": "2013/01",

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -78,9 +78,9 @@ function doWeb(doc, url) {
 		item.url = doc.location.href;
 		item.attachments = [{url:item.url, title:item.title, mimeType:"text/html"}];
 		if (doc.evaluate('/html/body/center/table/tbody/tr/td/center/table/tbody/tr/td//font', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext()) {
-			item.date = Zotero.Utilities.trimInternal(doc.evaluate('/html/body/center/table/tbody/tr/td/center/table/tbody/tr/td//font', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent.replace("Bryn Mawr Classical Review ", "").replace(/\./g, "/"));
+			item.date = Zotero.Utilities.trimInternal(doc.evaluate('/html/body/center/table/tbody/tr/td/center/table/tbody/tr/td//font', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent.replace("Bryn Mawr Classical Review ", "").replace(/\./g, "/")).substring(0,7);
 		} else {
-			item.date = Zotero.Utilities.trimInternal(doc.evaluate('/html/body/h3', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent.replace("Bryn Mawr Classical Review ", "").replace(/\./g, "/"))
+			item.date = Zotero.Utilities.trimInternal(doc.evaluate('/html/body/h3', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent.replace("Bryn Mawr Classical Review ", "").replace(/\./g, "/")).substring(0,7)
 		}
 		item.complete();
 	});

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -59,6 +59,8 @@ function doWeb(doc, url) {
 	Zotero.Utilities.processDocuments(arts, function(doc) {
 		var item = new Zotero.Item("journalArticle");
 		var title = doc.evaluate('//h3/i', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent;
+		item.publicationTitle = "Bryn Mawr Classical Review";
+		item.journalAbbreviation = "BMCR";
 		item.title = "Review of: " + Zotero.Utilities.trimInternal(title);
 		var data = doc.evaluate('//h3[i]', doc, nsResolver, XPathResult.ANY_TYPE, null).iterateNext().textContent;
 		var title = title.replace("(", "\\(").replace(")", "\\)");

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -114,14 +114,15 @@ var testCases = [
 				"seeAlso": [],
 				"attachments": [
 					{
-						"url": "http://bmcr.brynmawr.edu/2010/2010-01-02.html",
 						"title": "Review of: Sallust: The War Against Jugurtha. Aris and Phillips Classical Texts",
 						"mimeType": "text/html"
 					}
 				],
+				"publicationTitle": "Bryn Mawr Classical Review",
+				"journalAbbreviation": "BMCR",
 				"title": "Review of: Sallust: The War Against Jugurtha. Aris and Phillips Classical Texts",
 				"url": "http://bmcr.brynmawr.edu/2010/2010-01-02.html",
-				"date": "2010/01/02",
+				"date": "2010/01",
 				"libraryCatalog": "Bryn Mawr Classical Review",
 				"accessDate": "CURRENT_TIMESTAMP",
 				"shortTitle": "Review of"
@@ -136,23 +137,13 @@ var testCases = [
 				"itemType": "journalArticle",
 				"creators": [
 					{
-						"firstName": "Christina S.",
-						"lastName": "Kraus",
-						"creatorType": "author"
+ 						"firstName": "Keely Elizabeth"
+ 						"lastName": "Heuer"
+ 						"creatorType": "author"
 					},
 					{
-						"firstName": "Anthony",
-						"lastName": "Grafton",
-						"creatorType": "reviewedAuthor"
-					},
-					{
-						"firstName": "Glenn W.",
-						"lastName": "Most",
-						"creatorType": "reviewedAuthor"
-					},
-					{
-						"firstName": "Salvatore",
-						"lastName": "Settis",
+						"firstName": "Rolf",
+						"lastName": "Hurschmann",
 						"creatorType": "reviewedAuthor"
 					}
 				],
@@ -161,13 +152,15 @@ var testCases = [
 				"seeAlso": [],
 				"attachments": [
 					{
-						"title": "Review of: The Classical Tradition",
+						"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2"
 						"mimeType": "text/html"
 					}
 				],
-				"title": "Review of: The Classical Tradition",
+				"publicationTitle": "Bryn Mawr Classical Review",
+				"journalAbbreviation": "BMCR"
+				"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
 				"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
-				"date": "2013/01/44",
+				"date": "2013/01",
 				"libraryCatalog": "Bryn Mawr Classical Review",
 				"accessDate": "CURRENT_TIMESTAMP",
 				"shortTitle": "Review of"

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-04-09 17:08:00"
+	"lastUpdated": "2016-04-10 14:58:41"
 }
 
 /*
@@ -148,19 +148,29 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://bmcr.brynmawr.edu/2013/2013-01-04.html",
+		"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
 		"items": [
 			{
 				"itemType": "journalArticle",
 				"creators": [
 					{
- 						"firstName": "Keely Elizabeth",
- 						"lastName": "Heuer",
- 						"creatorType": "author"
+						"firstName": "Christina S.",
+						"lastName": "Kraus",
+						"creatorType": "author"
 					},
 					{
-						"firstName": "Rolf",
-						"lastName": "Hurschmann",
+						"firstName": "Anthony",
+						"lastName": "Grafton",
+						"creatorType": "reviewedAuthor"
+					},
+					{
+						"firstName": "Glenn W.",
+						"lastName": "Most",
+						"creatorType": "reviewedAuthor"
+					},
+					{
+						"firstName": "Salvatore",
+						"lastName": "Settis",
 						"creatorType": "reviewedAuthor"
 					}
 				],
@@ -169,14 +179,14 @@ var testCases = [
 				"seeAlso": [],
 				"attachments": [
 					{
-						"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
+						"title": "Review of: The Classical Tradition",
 						"mimeType": "text/html"
 					}
 				],
 				"publicationTitle": "Bryn Mawr Classical Review",
 				"journalAbbreviation": "BMCR",
-				"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
-				"url": "http://bmcr.brynmawr.edu/2013/2013-01-04.html",
+				"title": "Review of: The Classical Tradition",
+				"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
 				"date": "2013/01",
 				"libraryCatalog": "Bryn Mawr Classical Review",
 				"accessDate": "CURRENT_TIMESTAMP",

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -152,12 +152,12 @@ var testCases = [
 				"seeAlso": [],
 				"attachments": [
 					{
-						"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2"
+						"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
 						"mimeType": "text/html"
 					}
 				],
 				"publicationTitle": "Bryn Mawr Classical Review",
-				"journalAbbreviation": "BMCR"
+				"journalAbbreviation": "BMCR",
 				"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
 				"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
 				"date": "2013/01",

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-04-07 18:37:51"
+	"lastUpdated": "2016-04-07 21:36:13"
 }
 
 function detectWeb(doc, url) {

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,8 +9,25 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-04-07 21:36:13"
+	"lastUpdated": "2016-04-09 17:08:00"
 }
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+	Copyright © 2016 Michael Berkowitz and John Muccigrosso
+	This file is part of Zotero.
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+	***** END LICENSE BLOCK *****
+*/
 
 function detectWeb(doc, url) {
 	if (url.match(/by_reviewer/) || url.match(/by_author/) || url.match(/recent.html/) || url.match(/\/\d{4}\/$/)) {

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2015-06-02 10:52:41"
+	"lastUpdated": "2016-04-07 18:37:51"
 }
 
 function detectWeb(doc, url) {

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -148,7 +148,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
+		"url": "http://bmcr.brynmawr.edu/2013/2013-01-04.html",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -176,7 +176,7 @@ var testCases = [
 				"publicationTitle": "Bryn Mawr Classical Review",
 				"journalAbbreviation": "BMCR",
 				"title": "Review of: Hamburg, Museum für Kunst und Gewerbe, Band 2: Unteritalisch rotfigure Keramik. Corpus vasorum antiquorum. Deutschland, Bd. 91; Hamburg Bd. 2",
-				"url": "http://bmcr.brynmawr.edu/2013/2013-01-44.html",
+				"url": "http://bmcr.brynmawr.edu/2013/2013-01-04.html",
 				"date": "2013/01",
 				"libraryCatalog": "Bryn Mawr Classical Review",
 				"accessDate": "CURRENT_TIMESTAMP",

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-08-22 17:38:09"
+	"lastUpdated": "2016-08-23 05:51:18"
 }
 
 /*
@@ -32,7 +32,7 @@
 function detectWeb(doc, url) {
 	if (url.search(/by_reviewer|by_author|recent\.html|\/\d{4}\/(indexb?\.html)?$/) != -1) {
 		return "multiple";
-	} else if (url.match(/[\d\-]+\.html$/) && ZU.xpathText(doc, '//h3/i')) {
+	} else if (url.search(/\d\.html$/)>-1 && ZU.xpathText(doc, '//h3/i')) {
 		return "journalArticle";
 	}
 }

--- a/Bryn Mawr Classical Review.js
+++ b/Bryn Mawr Classical Review.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-08-22 13:37:21"
+	"lastUpdated": "2016-08-22 17:38:09"
 }
 
 /*
@@ -30,7 +30,7 @@
 */
 
 function detectWeb(doc, url) {
-	if (url.search(/by_reviewer|by_author|recent\.html|\/\d{4}\/(index\.html)?$/) != -1) {
+	if (url.search(/by_reviewer|by_author|recent\.html|\/\d{4}\/(indexb?\.html)?$/) != -1) {
 		return "multiple";
 	} else if (url.match(/[\d\-]+\.html$/) && ZU.xpathText(doc, '//h3/i')) {
 		return "journalArticle";
@@ -41,8 +41,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//*[@id="indexcontent"]//li//a');
-	Z.debug(rows.length);
+	var rows = ZU.xpath(doc, '//*[@id="indexcontent" or @id="twocol-mainContent"]//li//a');
 	for (var i=0; i<rows.length; i++) {
 		var href = rows[i].href;
 		var title = ZU.trimInternal(rows[i].textContent);
@@ -78,7 +77,6 @@ function scrape(doc, url) {
 	
 	var title = ZU.xpathText(doc, '//h3/i');
 	item.title = "Review of: " + Zotero.Utilities.trimInternal(title);
-	var title = title.replace("(", "\\(").replace(")", "\\)");
 	
 	var author = ZU.xpathText(doc, '//b[contains(text(), "Reviewed by")]');
 	if (author) {
@@ -107,11 +105,24 @@ function scrape(doc, url) {
 		}
 	}
 
-	//The BMCR ID contains the 4-digit year, 2 digit month and a increasing number
-	var m = url.match(/(\d{4})-(\d{2})-(\d{2})/);//this should work for 1999f
+	//The BMCR ID for 1998ff contains the 4-digit year, 2-digit month and an increasing number.
+	//The BMCR ID for 1994-1998 contains the 2-digit year, 1- or 2-digit month and an increasing number.
+	//The BMCR ID for 1990-1993 is different.
+	var m = url.match(/(\d{4})\/(\d{2,4})[\-\.](\d{1,2})[\-\.](\d{2})/);
 	if (m) {
-		item.extra = "BMCR ID: " + m[1] + "." + m[2] + "." + m[3];
-		item.date = m[1] + "-" + m[2];
+		item.extra = "BMCR ID: " + m[2] + "." + m[3] + "." + m[4];
+		if (m[1]>=1994) {
+			if (m[2].length==2) {
+				m[2] = "19" + m[2];
+			}
+			if (m[3].length==1) {
+				m[3] = "0" + m[3];
+			}
+			item.date = m[2] + "-" + m[3];
+		}
+		if (m[1]<=1993) {
+			item.date = m[1];
+		}
 	}
 	
 	item.publicationTitle = "Bryn Mawr Classical Review";
@@ -258,6 +269,40 @@ var testCases = [
 				"attachments": [
 					{
 						"title": "Review of: Epic Traditions in the Contemporary World. The Poetics of Community",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://bmcr.brynmawr.edu/1998/98.1.04.html",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Review of: Athens and Persians in the Fifth Century BC: A Study in Cultural Receptivity.",
+				"creators": [
+					{
+						"firstName": "Margaret C.",
+						"lastName": "Miller",
+						"creatorType": "reviewedAuthor"
+					}
+				],
+				"date": "1998-01",
+				"ISSN": "1055-7660",
+				"extra": "BMCR ID: 98.1.04",
+				"journalAbbreviation": "BMCR",
+				"libraryCatalog": "Bryn Mawr Classical Review",
+				"publicationTitle": "Bryn Mawr Classical Review",
+				"shortTitle": "Review of",
+				"url": "http://bmcr.brynmawr.edu/1998/98.1.04.html",
+				"attachments": [
+					{
+						"title": "Review of: Athens and Persians in the Fifth Century BC: A Study in Cultural Receptivity.",
 						"mimeType": "text/html"
 					}
 				],


### PR DESCRIPTION
This is the continuation of #1045 : 
 * adapted the `detectWeb`
 * restructure the `doWeb`
 * use `ZU.xpath` and `ZU.xpathText` instead of `doc.evaluate`
 * try to use a more stable method for `reviewAuthors`
 * use `url` directly for extracting `date`
 * save the BMCR ID in `extra`

I tested it quite extensively and it seems to be stable now.