### PR TITLE
Update Die Zeit.js

### DIFF
--- a/Die Zeit.js
+++ b/Die Zeit.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-04-07 03:18:26"
+	"lastUpdated": "2016-09-12 05:37:03"
 }
 
 /*
@@ -61,7 +61,7 @@ function getSearchResults(doc, checkOnly) {
 		rows = doc.getElementsByClassName('teaser-small__container');
 	}
 	for (var i=0; i<rows.length; i++) {
-		var href = ZU.xpathText(rows[i], './/a/@href');
+		var href = ZU.xpathText(rows[i], '(.//a/@href)[1]');
 		var title = ZU.trimInternal( ZU.xpathText(rows[i], './/a/h4|.//a[span]') );
 		if (!href || !title) continue;
 		if (checkOnly) return true;
@@ -119,7 +119,7 @@ function scrape(doc, url){
 		}
 	}
 	
-	var section = doc.getElementsByClassName("primary-nav__link--current");
+	var section = doc.getElementsByClassName("nav__ressorts-link--current");
 	if (section.length > 0) {
 		newItem.section = section[0].textContent;
 	}


### PR DESCRIPTION
There are some problems with multiples from the page http://www.zeit.de/2009/11/index (somehow it does not affect the search page): If I select one item and try to run the `scrape` function, the following error occurs:
```
07:46:31 Translation using Die Zeit failed: 
         string => Error: Permission denied to access property "textContent"
         stack => scrape@Die Zeit:99:7
         
         url => http://www.zeit.de/2009/11/index
         downloadAssociatedFiles => true
         automaticSnapshots => true
```
If we skip this step, then also the `doc.getElementsByClassName` is throwing an permission error.

@dstillman Do you have any idea what is going on here? I guess that it is related to this document wrapping things...

