### PR TITLE
Fix CiteSeer.js, journalTitle might be undefined

### DIFF
--- a/CiteSeer.js
+++ b/CiteSeer.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-09-09 21:34:18"
+	"lastUpdated": "2016-09-13 06:39:17"
 }
 
 /*
@@ -35,7 +35,9 @@
 */
 
 function detectWeb(doc, url) {
-	if (url.indexOf('/search?q') != -1 && getSearchResults(doc).length) {
+	//for running the tests with book examples:
+	//return "book";
+	if ((url.indexOf('/search') != -1 || url.indexOf('/showciting') != -1) && getSearchResults(doc).length) {
 		return "multiple";
 	}
 	if (url.indexOf('/viewdoc/') != -1 && doc.getElementById('bibtex')) {
@@ -53,7 +55,7 @@ function doWeb(doc, url) {
 		var items = {};
 		var titles = getSearchResults(doc);
 		for (var i=0; i<titles.length; i++) {
-			items[titles[i].href] = titles[i].textContent;
+			items[titles[i].href] = titles[i].textContent.trim();
 		}
 		Zotero.selectItems(items, function (items) {
 			if (!items) {
@@ -83,7 +85,7 @@ function scrape(doc, url) {
 		if (item.title == item.title.toUpperCase()) {
 			item.title = ZU.capitalizeTitle(item.title.toLowerCase(), true);
 		}
-		if (item.publicationTitle == item.publicationTitle.toUpperCase()) {
+		if (item.publicationTitle && (item.publicationTitle == item.publicationTitle.toUpperCase())) {
 			item.publicationTitle = ZU.capitalizeTitle(item.publicationTitle.toLowerCase(), true);
 		}
 		item.attachments = [{
@@ -133,6 +135,40 @@ var testCases = [
 				"pages": "15–36",
 				"publicationTitle": "Experimental Mathematics",
 				"volume": "2",
+				"attachments": [
+					{
+						"title": "Citeseer - Snapshot",
+						"mimeType": "text/html"
+					},
+					{
+						"title": "Citeseer - Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.332.356&rank=1",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "The Nature of Statistical Learning Theory",
+				"creators": [
+					{
+						"firstName": "Vladimir N.",
+						"lastName": "Vapnik",
+						"creatorType": "author"
+					}
+				],
+				"date": "1999",
+				"abstractNote": "Statistical learning theory was introduced in the late 1960’s. Until the 1990’s it was a purely theoretical analysis of the problem of function estimation from a given collection of data. In the middle of the 1990’s new types of learning algorithms (called support vector machines) based on the developed theory were proposed. This made statistical learning theory not only a tool for the theoretical analysis but also a tool for creating practical algorithms for estimating multidimensional functions. This article presents a very general overview of statistical learning theory including both theoretical and algorithmic aspects of the theory. The goal of this overview is to demonstrate how the abstract learning theory established conditions for generalization which are more general than those discussed in classical statistical paradigms and how the understanding of these conditions inspired new algorithmic approaches to function estimation problems. A more",
+				"itemID": "Vapnik99thenature",
+				"libraryCatalog": "CiteSeer",
 				"attachments": [
 					{
 						"title": "Citeseer - Snapshot",


### PR DESCRIPTION
 * For books etc. journslTitle is not defined and therefore
   we have to test for that.
 * Add example for a book.
 * Improve multiples slightly.