### PR TITLE
EM: use canonical URL, use cover_date

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-10-28 17:17:19"
+	"lastUpdated": "2016-11-07 05:17:35"
 }
 
 /*
@@ -40,6 +40,7 @@
 var HIGHWIRE_MAPPINGS = {
 	"citation_title":"title",
 	"citation_publication_date":"date",	//perhaps this is still used in some old implementations
+	"citation_cover_date": "date", //used e.g. by Springer http://link.springer.com/article/10.1023/A:1021669308832
 	"citation_date":"date",
 	"citation_journal_title":"publicationTitle",
 	"citation_journal_abbrev":"journalAbbreviation",
@@ -603,8 +604,12 @@ function addLowQualityMetadata(doc, newItem) {
 	}
 	
 	if(!newItem.url) {
+		newItem.url = ZU.xpathText(doc, '//head/link[@rel="canonical"]/@href');
+	}
+	if(!newItem.url) {
 		newItem.url = doc.location.href;
 	}
+
 	
 	newItem.libraryCatalog = doc.location.host;
 	
@@ -1280,11 +1285,143 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2016-01-09T21:20:00Z",
+				"date": "2016-01-07T08:20:02-05:00",
 				"abstractNote": "Excluding female characters in merchandise is an ongoing pattern.",
 				"url": "http://www.vox.com/2016/1/7/10726296/wheres-rey-star-wars-monopoly",
 				"websiteTitle": "Vox",
 				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A766397&dswid=2797",
+		"items": [
+			{
+				"itemType": "conferencePaper",
+				"title": "Mobility modeling for transport efficiency : Analysis of travel characteristics based on mobile phone data",
+				"creators": [
+					{
+						"firstName": "Vangelis",
+						"lastName": "Angelakis",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "David",
+						"lastName": "Gundlegård",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Clas",
+						"lastName": "Rydergren",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Botond",
+						"lastName": "Rajna",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Katerina",
+						"lastName": "Vrotsou",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Richard",
+						"lastName": "Carlsson",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Julien",
+						"lastName": "Forgeat",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Tracy H.",
+						"lastName": "Hu",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Evan L.",
+						"lastName": "Liu",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Simon",
+						"lastName": "Moritz",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Sky",
+						"lastName": "Zhao",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Yaotian",
+						"lastName": "Zheng",
+						"creatorType": "author"
+					}
+				],
+				"date": "2013",
+				"abstractNote": "Signaling data from the cellular networks can provide a means of analyzing the efficiency of a deployed transportation system and assisting in the formulation of transport models to predict its fut ...",
+				"conferenceName": "Netmob 2013 - Third International Conference on the Analysis of Mobile Phone Datasets, May 1-3, 2013, MIT, Cambridge, MA, USA",
+				"language": "eng",
+				"libraryCatalog": "www.diva-portal.org",
+				"shortTitle": "Mobility modeling for transport efficiency",
+				"url": "http://www.diva-portal.org/smash/record.jsf?pid=diva2:766397",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://link.springer.com/article/10.1023/A:1021669308832",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Why Bohm's Quantum Theory?",
+				"creators": [
+					{
+						"firstName": "H. D.",
+						"lastName": "Zeh",
+						"creatorType": "author"
+					}
+				],
+				"date": "1999/04/01",
+				"DOI": "10.1023/A:1021669308832",
+				"ISSN": "0894-9875, 1572-9524",
+				"abstractNote": "This is a brief reply to S. Goldstein's article “Quantum theory without observers” in Physics Today. It is pointed out that Bohm's pilot wave theory is successful only because it keeps Schrödinger's (",
+				"issue": "2",
+				"journalAbbreviation": "Found Phys Lett",
+				"language": "en",
+				"libraryCatalog": "link.springer.com",
+				"pages": "197-200",
+				"publicationTitle": "Foundations of Physics Letters",
+				"url": "http://link.springer.com/article/10.1023/A:1021669308832",
+				"volume": "12",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
 					{
 						"title": "Snapshot"
 					}

--- a/Springer Link.js
+++ b/Springer Link.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2015-10-11 19:37:31"
+	"lastUpdated": "2016-11-07 05:15:03"
 }
 
 function detectWeb(doc, url) {
@@ -270,7 +270,7 @@ var testCases = [
 				"libraryCatalog": "link.springer.com",
 				"pages": "1-1",
 				"publisher": "Springer Berlin Heidelberg",
-				"rights": "©2008 Springer Berlin Heidelberg",
+				"rights": "©2008 Springer-Verlag Berlin Heidelberg",
 				"series": "Lecture Notes in Computer Science",
 				"seriesNumber": "5302",
 				"url": "http://link.springer.com/chapter/10.1007/978-3-540-88682-2_1",
@@ -338,7 +338,7 @@ var testCases = [
 				"tags": [
 					"Child and School Psychology",
 					"Developmental Psychology",
-					"Education (general)",
+					"Education, general",
 					"Learning & Instruction"
 				],
 				"notes": [],
@@ -374,7 +374,7 @@ var testCases = [
 				"libraryCatalog": "Springer Link",
 				"pages": "531-581",
 				"publisher": "Humana Press",
-				"rights": "©2011 Springer Science+Business Media, LLC",
+				"rights": "©2011 Humana Press",
 				"series": "Methods in Molecular Biology",
 				"seriesNumber": "672",
 				"shortTitle": "What Do We Know?",
@@ -457,7 +457,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2009/02/17",
+				"date": "2009/07/01",
 				"DOI": "10.1007/s10040-009-0439-x",
 				"ISSN": "1431-2174, 1435-0157",
 				"abstractNote": "This paper considers the tidal head fluctuations in a single coastal confined aquifer which extends under the sea for a certain distance. Its submarine outlet is covered by a silt-layer with properties dissimilar to the aquifer. Recently, Li et al. (2007) gave an analytical solution for such a system which neglected the effect of the elastic storage (specific storage) of the outlet-capping. This article presents an analytical solution which generalizes their work by incorporating the elastic storage of the outlet-capping. It is found that if the outlet-capping is thick enough in the horizontal direction, its elastic storage has a significant enhancing effect on the tidal head fluctuation. Ignoring this elastic storage will lead to significant errors in predicting the relationship of the head fluctuation and the aquifer hydrogeological properties. Quantitative analysis shows the effect of the elastic storage of the outlet-capping on the groundwater head fluctuation. Quantitative conditions are given under which the effect of this elastic storage on the aquifer’s tide-induced head fluctuation is negligible. Li, H.L., Li, G.Y., Chen, J.M., Boufadel, M.C. (2007) Tide-induced head fluctuations in a confined aquifer with sediment covering its outlet at the sea floor. [Fluctuations du niveau piézométrique induites par la marée dans un aquifère captif à décharge sous-marine.] Water Resour. Res 43, doi:10.1029/2005WR004724",
@@ -479,16 +479,7 @@ var testCases = [
 						"title": "Snapshot"
 					}
 				],
-				"tags": [
-					"Analytical solutions",
-					"Coastal aquifers",
-					"Elastic storage",
-					"Geology",
-					"Hydrogeology",
-					"Submarine outlet-capping",
-					"Tidal loading efficiency",
-					"Waste Water Technology / Water Pollution Control / Water Management / Aquatic Pollution"
-				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}


### PR DESCRIPTION
Closes https://github.com/zotero/translators/issues/1160
Addresses https://forums.zotero.org/discussion/59197/springer-useing-first-online-instead-of-real-publication-date#latest
Supersedes https://github.com/zotero/translators/pull/1167

Springer, update tests.
@zuphilip -- if you could take a quick look? I'm putting the cover date in 2nd place after citation_date but before citation_publication_date. I think tha's the best call, though we can consider moving it to 1st place.