### PR TITLE
Add newspapers.com.js

### DIFF
--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -2,103 +2,160 @@
 	"translatorID": "22dd8e35-02da-4968-b306-6efe0779a48d",
 	"label": "newspapers.com",
 	"creator": "Peter Binkley",
-	"target": "www.newspapers.com/clip/",
+	"target": "https?://www\\.newspapers\\.com/clip/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "g",
-	"lastUpdated": "2016-12-30 21:05:34"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2017-01-11 03:07:54"
 }
 
-/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2017 Peter Binkley
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
 function detectWeb(doc, url) {  
 	return "newspaperArticle";
 }
-function doWeb(doc, url) { 
-	var namespace = doc.documentElement.namespaceURI;
-	var nsResolver = namespace ? function(prefix) {
-		if (prefix == 'x') return namespace; else return null;
-	} : null;
 
+function doWeb(doc, url) { 
 	var newItem = new Zotero.Item("newspaperArticle");
-	var metaArr = new Object();
+	var metaArr = {};
 	var metaTags = doc.getElementsByTagName("meta");
 	for (var i = 0 ; i < metaTags.length ; i++) {
-		metaArr[metaTags[i].getAttribute("property")] = metaTags[i].getAttribute("content");
+		if (metaTags[i].getAttribute("property")) {
+			metaArr[metaTags[i].getAttribute("property")] = metaTags[i].getAttribute("content");
+		}
 	}
-	/*
-	<meta property="og:title" content="Oct 11 1939 Detroit Free Press bork - on Newspapers.com">
-	*/
-	newItem.title = metaArr["og:title"].replace(/(.+?) -( on)? Newspapers.com/, "$1");
+	newItem.title = ZU.xpathText(doc, "//h1[1]");
 	newItem.url = metaArr["og:url"];
 	
+	/*
+		The user can append the author to the title with a forward slash
+		e.g. "My Day / Eleanor Roosevelt"
+	*/
 	if (newItem.title.indexOf('/') >= 0) {
 		var tokens = newItem.title.split("/");
 		var author = tokens[1];
 		newItem.title = tokens[0].trim();
-	    if (author.match("; ")) {
-	      var authors = author.split("; ");
-	      for (var i in authors) {
-	        newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[i], "author"));
-	      }
-	    } else {
-	      newItem.creators.push(Zotero.Utilities.cleanAuthor(author, "author"));
-	    }
+		// multiple authors are separated with semicolons
+		if (author.match("; ")) {
+		  var authors = author.split("; ");
+		  for (var i in authors) {
+			newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[i], "author"));
+		  }
+		} else {
+		  newItem.creators.push(Zotero.Utilities.cleanAuthor(author, "author"));
+		}
 	}
 
 	/*
-	<span id="spotBody" class="disc-body">bork bork bork</span>
+	<span id="spotBody" class="disc-body">This is the abstract</span>
 	*/
 	newItem.abstractNote = doc.getElementById("spotBody").innerHTML;
 	
 	/*
 	<meta property="og:image" content="https://img0.newspapers.com/img/img?id=97710064&width=557&height=4616&crop=1150_215_589_4971&rotation=0&brightness=0&contrast=0&invert=0&ts=1467779959&h=e478152fd53dd7afc4e72a18c1dad4ea">
 	*/
-	imageurl = metaArr["og:image"];
 	newItem.attachments = [{
-		url: imageurl,
+		url: metaArr["og:image"],
 		title: "Image",
-		mimeType: "image/jpeg"
+		mimeType: "image/jpeg",
+		downloadable: true
 	}];
 	
 	/*
-	<span id="printlocation">
-		<a href="/browse/#hoC0Us-e7">The Evening News (Harrisburg, Pennsylvania)</a> &nbsp;
-		<a href="/browse/#hoC0Us-e77MhXcywhyDn5s2CcpUK9XEjt">28 Jun 1929, Fri</a> &nbsp;
-		<a href="/image/#63217003">Page 13</a>
-	</span>
-
-	or 
-
-	<span id="printlocation">
-<a href="/browse/#hO4iD0U5g">Reno Gazette-Journal (Reno, Nevada)</a> &nbsp;
-<a href="/browse/#hO4iD0U5gKAOus8IgtaE4K1d71AL1Hvf-">21 Oct 1939, Sat</a> &nbsp;
-<a href="/browse/#hO4iD0U5gKAOus8IgtaE4K1d71AL1Hvf-qe4sECZ-">Main Edition</a> &nbsp;
-<a href="/image/#148827895">Page 4</a>
-</span>
+	The #printlocation span contains three or four links, from whose anchor texts
+	we extract metadata:
+		1. Newspaper title, plus location in brackets e.g. "The Evening News (Harrisburg, Pennsylvania)"
+		2. Date e.g. "28 Jun 1929, Fri"
+		3. (optional) Edition e.g. "Main Edition"
+		4. Page e.g. "Page 13"
 	*/
 	
+	var citation = doc.getElementById("printlocation").getElementsByTagName("a");
+	var publication = citation[0].innerHTML;
+	var start = publication.indexOf("(");
+	if (start>-1) {
+		newItem.publication = publication.substr(0, start-1);
+		newItem.place = publication.substr(start+1,publication.length-start-2);
+	}
+	else { // no location given
+		newItem.publication = publication;
+	}
 	
-	citation = doc.getElementById("printlocation").getElementsByTagName("a");
-	publication = citation[0].innerHTML;
-	newItem.place = publication.replace(/.*\((.*)\).*/, "$1");
-	newItem.publicationTitle = publication.replace(/(.*) \(.*/, "$1");
-	
-	date = citation[1].innerHTML;
-	newItem.date = date.replace(/(.*)\,.*/, "$1");
+	var date = citation[1].innerHTML;
+	newItem.date = ZU.strToISO(date);
+	//newItem.date = date.replace(/(.*)\,.*/, "$1"); // remove weekday from end of date
 
-	p = citation[citation.length-1].innerHTML;
+	var p = citation[citation.length-1].innerHTML;
 	newItem.pages = p.substring(p.indexOf(" "));
 
 	if (citation.length > 3) {
-		ed = citation[2].innerHTML;
-		newItem.edition = ed;
+		newItem.edition = citation[2].innerHTML;
 	}
 	
 	newItem.complete();
 }
+
 /** BEGIN TEST CASES **/
-var testCases = []
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/",
+		"items": [
+		   {
+			 "itemType": "newspaperArticle",
+			 "creators": [
+			   {
+				 "firstName": "Eleanor",
+				 "lastName": "Roosevelt",
+				 "creatorType": "author"
+			   }
+			 ],
+			 "notes": [],
+			 "tags": [],
+			 "seeAlso": [],
+			 "attachments": [
+			   {
+				 "title": "Image",
+				 "mimeType": "image/jpeg",
+				 "downloadable": true
+			   }
+			 ],
+			 "title": "My Day",
+			 "url": "https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/",
+			 "publication": "The Akron Beacon Journal",
+			 "place": "Akron, Ohio",
+			 "date": "1939-10-30",
+			 "pages": "15",
+			 "edition": "Main Edition",
+			 "libraryCatalog": "newspapers.com",
+			 "accessDate": "CURRENT_TIMESTAMP"
+		   }
+		]
+	}
+]
 /** END TEST CASES **/
+

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -98,11 +98,11 @@ function doWeb(doc, url) {
 	var publication = citation[0].innerHTML;
 	var start = publication.indexOf("(");
 	if (start>-1) {
-		newItem.publication = publication.substr(0, start-1);
+		newItem.publicationTitle = publication.substr(0, start-1);
 		newItem.place = publication.substr(start+1,publication.length-start-2);
 	}
 	else { // no location given
-		newItem.publication = publication;
+		newItem.publicationTitle = publication;
 	}
 	
 	var date = citation[1].innerHTML;
@@ -146,8 +146,8 @@ var testCases = [
 			 ],
 			 "title": "My Day",
 			 "url": "https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/",
-			 "publication": "The Akron Beacon Journal",
-			 "place": "Akron, Ohio",
+			 "publicationTitle": "The Akron Beacon Journal",
+                         "place": "Akron, Ohio",
 			 "date": "1939-10-30",
 			 "pages": "15",
 			 "edition": "Main Edition",

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -1,0 +1,104 @@
+{
+	"translatorID": "22dd8e35-02da-4968-b306-6efe0779a48d",
+	"label": "newspapers.com",
+	"creator": "Peter Binkley",
+	"target": "www.newspapers.com/clip/",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "g",
+	"lastUpdated": "2016-12-30 21:05:34"
+}
+
+/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
+function detectWeb(doc, url) {  
+	return "newspaperArticle";
+}
+function doWeb(doc, url) { 
+	var namespace = doc.documentElement.namespaceURI;
+	var nsResolver = namespace ? function(prefix) {
+		if (prefix == 'x') return namespace; else return null;
+	} : null;
+
+	var newItem = new Zotero.Item("newspaperArticle");
+	var metaArr = new Object();
+	var metaTags = doc.getElementsByTagName("meta");
+	for (var i = 0 ; i < metaTags.length ; i++) {
+		metaArr[metaTags[i].getAttribute("property")] = metaTags[i].getAttribute("content");
+	}
+	/*
+	<meta property="og:title" content="Oct 11 1939 Detroit Free Press bork - on Newspapers.com">
+	*/
+	newItem.title = metaArr["og:title"].replace(/(.+?) -( on)? Newspapers.com/, "$1");
+	newItem.url = metaArr["og:url"];
+	
+	if (newItem.title.indexOf('/') >= 0) {
+		var tokens = newItem.title.split("/");
+		var author = tokens[1];
+		newItem.title = tokens[0].trim();
+	    if (author.match("; ")) {
+	      var authors = author.split("; ");
+	      for (var i in authors) {
+	        newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[i], "author"));
+	      }
+	    } else {
+	      newItem.creators.push(Zotero.Utilities.cleanAuthor(author, "author"));
+	    }
+	}
+
+	/*
+	<span id="spotBody" class="disc-body">bork bork bork</span>
+	*/
+	newItem.abstractNote = doc.getElementById("spotBody").innerHTML;
+	
+	/*
+	<meta property="og:image" content="https://img0.newspapers.com/img/img?id=97710064&width=557&height=4616&crop=1150_215_589_4971&rotation=0&brightness=0&contrast=0&invert=0&ts=1467779959&h=e478152fd53dd7afc4e72a18c1dad4ea">
+	*/
+	imageurl = metaArr["og:image"];
+	newItem.attachments = [{
+		url: imageurl,
+		title: "Image",
+		mimeType: "image/jpeg"
+	}];
+	
+	/*
+	<span id="printlocation">
+		<a href="/browse/#hoC0Us-e7">The Evening News (Harrisburg, Pennsylvania)</a> &nbsp;
+		<a href="/browse/#hoC0Us-e77MhXcywhyDn5s2CcpUK9XEjt">28 Jun 1929, Fri</a> &nbsp;
+		<a href="/image/#63217003">Page 13</a>
+	</span>
+
+	or 
+
+	<span id="printlocation">
+<a href="/browse/#hO4iD0U5g">Reno Gazette-Journal (Reno, Nevada)</a> &nbsp;
+<a href="/browse/#hO4iD0U5gKAOus8IgtaE4K1d71AL1Hvf-">21 Oct 1939, Sat</a> &nbsp;
+<a href="/browse/#hO4iD0U5gKAOus8IgtaE4K1d71AL1Hvf-qe4sECZ-">Main Edition</a> &nbsp;
+<a href="/image/#148827895">Page 4</a>
+</span>
+	*/
+	
+	
+	citation = doc.getElementById("printlocation").getElementsByTagName("a");
+	publication = citation[0].innerHTML;
+	newItem.place = publication.replace(/.*\((.*)\).*/, "$1");
+	newItem.publicationTitle = publication.replace(/(.*) \(.*/, "$1");
+	
+	date = citation[1].innerHTML;
+	newItem.date = date.replace(/(.*)\,.*/, "$1");
+
+	p = citation[citation.length-1].innerHTML;
+	newItem.pages = p.substring(p.indexOf(" "));
+
+	if (citation.length > 3) {
+		ed = citation[2].innerHTML;
+		newItem.edition = ed;
+	}
+	
+	newItem.complete();
+}
+/** BEGIN TEST CASES **/
+var testCases = []
+/** END TEST CASES **/

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -60,13 +60,9 @@ function doWeb(doc, url) {
 		var author = tokens[1];
 		newItem.title = tokens[0].trim();
 		// multiple authors are separated with semicolons
-		if (author.match("; ")) {
-		  var authors = author.split("; ");
-		  for (var i in authors) {
+		var authors = author.split("; ");
+		for (var i=0; i<authors.length; i++) {
 			newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[i], "author"));
-		  }
-		} else {
-		  newItem.creators.push(Zotero.Utilities.cleanAuthor(author, "author"));
 		}
 	}
 
@@ -81,8 +77,7 @@ function doWeb(doc, url) {
 	newItem.attachments = [{
 		url: metaArr["og:image"],
 		title: "Image",
-		mimeType: "image/jpeg",
-		downloadable: true
+		mimeType: "image/jpeg"
 	}];
 	
 	/*
@@ -140,8 +135,7 @@ var testCases = [
 			 "attachments": [
 			   {
 				 "title": "Image",
-				 "mimeType": "image/jpeg",
-				 "downloadable": true
+				 "mimeType": "image/jpeg"
 			   }
 			 ],
 			 "title": "My Day",


### PR DESCRIPTION
This translator captures clippings from newspapers.com as Zotero newspaper articles. The publication metadata populates these fields:

- publication
- place of publication
- date
- edition
- page

In addition, the title and description fields (which can be filled out manually when creating the clipping) are used to populate the article title and abstract fields. The author may be appended to the title, separated by a forward slash; multiple authors should be separated with semicolons.

Example: [this clipping](https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/) produces this Zotero item (exported as RIS):

``` 
TY  - NEWS
TI  - My Day
AU  - Roosevelt, Eleanor
T2  - The Akron Beacon Journal
CY  - Akron, Ohio
DA  - 1939/10/30/
PY  - 1939
DP  - newspapers.com
ET  - Main Edition
SP  - 15
UR  - https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/
Y2  - 2017/01/02/06:18:49
L4  - https://img0.newspapers.com/img/img?id=228731817&width=557&height=410&crop=281_6269_2333_1749&rotation=0&brightness=0&contrast=0&invert=0&ts=1483337900&h=92988b6d9730ce3cdb952c8487f05676
```

