### PR TITLE
ci: checkTranslator with a --skip-warn flag

### DIFF
--- a/.ci/checkTranslator.sh
+++ b/.ci/checkTranslator.sh
@@ -123,8 +123,12 @@ usage () { (( $# > 0 )) && err "$*"; err "Usage: $0 <translator.js>"; }
 main() {
 
     # Add './node_modules/.bin to PATH for jsonlint
-    PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/node_modules/.bin:"$PATH"
+    PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/node_modules/.bin:"$PATH"
 
+    if [[ "$1" = "--skip-warn" ]];then
+        SKIP_WARN=true
+        shift
+    fi
     TRANSLATOR="$1"
     TRANSLATOR_BASENAME="$(basename "$TRANSLATOR")"
     [[ -z $TRANSLATOR ]]   && { usage; exit 1; }

--- a/.ci/package.json
+++ b/.ci/package.json
@@ -4,7 +4,7 @@
   "description": "Continuous integration of Zotero translators",
   "main": "index.js",
   "scripts": {
-    "test": "export SKIP_WARN=true ; find .. -maxdepth 1 -name '*.js' -print0|xargs -0 -n1 -P8 ./checkTranslator.sh 2>/dev/null",
+    "test": "find .. -maxdepth 1 -name '*.js' -print0|xargs -0 -n1 -P8 ./checkTranslator.sh --skip-warn",
     "start": "find .. -maxdepth 1 -name '*.js' -print0|xargs -0 -n1 -P1 ./checkTranslator.sh"
   },
   "author": "kba+pz",


### PR DESCRIPTION
This should make it possible to run "npm test" in Windows with cmd.exe instead of a POSIX shell.