### PR TITLE
Add "http:" in url in ScienceDirect.js if missing

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-01-22 22:31:49"
+	"lastUpdated": "2017-01-25 18:29:16"
 }
 
 function detectWeb(doc, url) {
@@ -278,6 +278,10 @@ function processRIS(doc, text) {
 		}
 		if (item.ISBN && !ZU.cleanISBN(item.ISBN)) delete item.ISBN;
 		if (item.ISSN && !ZU.cleanISSN(item.ISSN)) delete item.ISSN;
+		
+		if (item.url && item.url.substr(0,2) == "//") {
+			item.url = "http:" + item.url;
+		}
 
 		item.complete();
 	});

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -280,7 +280,7 @@ function processRIS(doc, text) {
 		if (item.ISSN && !ZU.cleanISSN(item.ISSN)) delete item.ISSN;
 		
 		if (item.url && item.url.substr(0,2) == "//") {
-			item.url = "http:" + item.url;
+			item.url = "https:" + item.url;
 		}
 
 		item.complete();


### PR DESCRIPTION
This information comes directly from the RIS data by ScienceDirect
and we can correct this before saving the item.

e.g. http://www.sciencedirect.com/science/article/pii/B9780857095138500182