### PR TITLE
Expand regexp for Nature Communications

### DIFF
--- a/Nature Publishing Group.js
+++ b/Nature Publishing Group.js
@@ -2,14 +2,14 @@
 	"translatorID": "6614a99-479a-4524-8e30-686e4d66663e",
 	"label": "Nature Publishing Group",
 	"creator": "Aurimas Vinckevicius",
-	"target": "^https?://([^/]+\\.)?(nature\\.com|palgrave-journals\\.com)(:[\\d]+)?(?=/)[^?]*(/(journal|archive|research|topten|search|full|abs)/|/current_issue\\.htm|/most\\.htm)",
+	"target": "^https?://([^/]+\\.)?(nature\\.com|palgrave-journals\\.com)(:[\\d]+)?(?=/)[^?]*(/(journal|archive|research|topten|search|full|abs)/|/current_issue\\.htm|/most\\.htm|/articles/ncomms)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 200,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-12-28 15:06:38"
+	"lastUpdated": "2017-03-10 07:35:31"
 }
 
 /**
@@ -2378,7 +2378,7 @@ var testCases = [
 				"libraryCatalog": "www.nature.com",
 				"pages": "6186",
 				"publicationTitle": "Nature Communications",
-				"rights": "© 2016 Macmillan Publishers Limited, part of Springer Nature. All rights reserved.",
+				"rights": "© 2017 Macmillan Publishers Limited, part of Springer Nature. All rights reserved.",
 				"url": "http://www.nature.com/ncomms/2015/150203/ncomms7186/full/ncomms7186.html",
 				"volume": "2",
 				"attachments": [


### PR DESCRIPTION
This was still missing, also the test case was already
there and the last change here fixed the detection for
articles in Nature Communications.

See also https://forums.zotero.org/discussion/64699/site-translator-for-nature-communications