### PR TITLE
Delete palgrave in target of Nature translator

### DIFF
--- a/Nature Publishing Group.js
+++ b/Nature Publishing Group.js
@@ -2,14 +2,14 @@
 	"translatorID": "6614a99-479a-4524-8e30-686e4d66663e",
 	"label": "Nature Publishing Group",
 	"creator": "Aurimas Vinckevicius",
-	"target": "^https?://([^/]+\\.)?(nature\\.com|palgrave-journals\\.com)(:[\\d]+)?(?=/)[^?]*(/(journal|archive|research|topten|search|full|abs)/|/current_issue\\.htm|/most\\.htm|/articles/ncomms)",
+	"target": "^https?://([^/]+\\.)?nature\\.com(:[\\d]+)?(?=/)[^?]*(/(journal|archive|research|topten|search|full|abs)/|/current_issue\\.htm|/most\\.htm|/articles/ncomms)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 200,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-03-10 07:35:31"
+	"lastUpdated": "2017-03-11 22:33:14"
 }
 
 /**


### PR DESCRIPTION
All the Palgrave journals are now moved to springer.com
This solves #1217.