### PR TITLE
Handle Newsbeat for BBC

### DIFF
--- a/BBC.js
+++ b/BBC.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-08-20 19:58:56"
+	"lastUpdated": "2017-04-02 07:33:14"
 }
 
 /*
@@ -112,6 +112,12 @@ function scrape(doc, url) {
 				item.date = date.toISOString();
 			} else {
 				item.date = ZU.xpathText(doc, '//meta[@property="rnews:datePublished"]/@content');
+				if(!item.date) {
+					item.date = ZU.xpathText(doc, '//p[@class="timestamp"]');
+					if (item.date) {
+						item.date = ZU.strToISO(item.date);
+					}
+				}
 			}
 		}
 		
@@ -132,6 +138,18 @@ function scrape(doc, url) {
 				}
 				item.creators.push(ZU.cleanAuthor(authors[i], "author"));
 			}
+		}
+		else
+		{
+			var authorString = ZU.xpathText(doc, '//p[@class="byline"]');
+			var title = ZU.xpathText(doc, '//em[@class="title"]');
+			if (authorString) {
+				authorString = authorString.replace(title, '').replace('By', '');
+				var authors = authorString.split('&');
+				for (var i=0; i<authors.length; i++) {
+					item.creators.push(ZU.cleanAuthor(authors[i], "author"));
+				}
+			}	
 		}
 		
 		item.language = "en-GB";

--- a/BBC.js
+++ b/BBC.js
@@ -55,28 +55,16 @@ function detectWeb(doc, url) {
 }
 
 function getSearchResults(doc, checkOnly) {
-	var namespace = doc.documentElement.namespaceURI;
-	var nsResolver = namespace ? function(prefix) {
-	if (prefix == 'x') return namespace; else return null;
-	} : null;
-
 	var items = {};
 	var found = false;
 	var rows = ZU.xpath(doc, '//a[h3[@class="title-link__title"]]');
 	//for NewsBeat
-	if(!rows.length)
-	{
-		var rows = ZU.xpath(doc, '//article/div[h1[@itemprop="headline"]]');
-		var hrefs =  doc.evaluate('//article/div/h1/a/@href', doc, nsResolver, XPathResult.ANY_TYPE, null);
+	if(!rows.length) {
+		var rows = ZU.xpath(doc, '//article/div/h1[@itemprop="headline"]/a');
 	}
 	for (var i = 0; i<rows.length; i++) {
 		var href = rows[i].href;
 		var title = ZU.trimInternal(rows[i].textContent);
-		//for NewsBeat
-		if(href == null)
-		{
-			var href = hrefs.iterateNext().value
-		}
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;

--- a/BBC.js
+++ b/BBC.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-04-02 07:33:14"
+	"lastUpdated": "2017-04-06 11:12:55"
 }
 
 /*
@@ -46,6 +46,8 @@ function detectWeb(doc, url) {
 		}
 		return "newspaperArticle";
 	}
+	if(url.indexOf("/newsbeat/article") != -1)
+		return "blogPost";
 	if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
@@ -151,6 +153,8 @@ function scrape(doc, url) {
 				}
 			}	
 		}
+		if(!item.section)
+			item.section = ZU.xpathText(doc, '//p[@class="topic"]/a//text()[not(parent::span)]');
 		
 		item.language = "en-GB";
 		
@@ -304,6 +308,40 @@ var testCases = [
 				"publicationTitle": "BBC News",
 				"section": "Magazine",
 				"url": "http://www.bbc.com/news/magazine-36287752",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://www.bbc.co.uk/search?q=harry+potter",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "http://www.bbc.co.uk/newsbeat/article/32129457/will-new-music-streaming-service-tidal-make-the-waves-artists-want",
+		"items": [
+			{
+				"itemType": "blogPost",
+				"title": "Will new music streaming service Tidal make the waves artists want?",
+				"creators": [
+					{
+						"firstName": "Chi Chi",
+						"lastName": "Izundu",
+						"creatorType": "author"
+					}
+				],
+				"date": "2015-03-31",
+				"abstractNote": "Big names in the world of music made it known that they wanted a change when they all stood on stage on Monday and announced the relaunch of streaming service Tidal.",
+				"language": "en-GB",
+				"url": "http://www.bbc.co.uk/newsbeat/article/32129457/will-new-music-streaming-service-tidal-make-the-waves-artists-want",
 				"attachments": [
 					{
 						"title": "Snapshot"


### PR DESCRIPTION
This is with reference to issues reported at https://phabricator.wikimedia.org/T94663
I want to update BBC translator so that it handles Newsbeat.
I want help in writing regex for http://www.bbc.co.uk/newsbeat
Articles on Newsbeat can't be marked as newspaper articles and giving them type as blog posts also don't suit much. I want suggestions on what should I return in detectWeb.