### PR TITLE
Update The Chronicle of Higher Education.js

### DIFF
--- a/The Chronicle of Higher Education.js
+++ b/The Chronicle of Higher Education.js
@@ -2,14 +2,14 @@
 	"translatorID": "1e6d1529-246f-4429-84e2-1f1b180b250d",
 	"label": "The Chronicle of Higher Education",
 	"creator": "Simon Kornblith, Avram Lyon",
-	"target": "^https?://chronicle\\.com/",
+	"target": "^https?://(www\\.)?chronicle\\.com/",
 	"minVersion": "2.1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2015-12-13 17:20:38"
+	"lastUpdated": "2017-04-09 14:53:05"
 }
 
 /*


### PR DESCRIPTION
Add `www.` to start of target. Leaving it optional in case the site drops it in the future.