### PR TITLE
use marcxml for importing metadata from BSB OpacPlus

### DIFF
--- a/BayerischeStaatsbibliothekOpacPlus.js
+++ b/BayerischeStaatsbibliothekOpacPlus.js
@@ -1,0 +1,37 @@
+{
+	"translatorID": "6b09b92d-f47e-4573-8a00-74245f7c6c5e",
+	"label": "Bayerische Staatsbibliothek (OpacPlus)",
+	"creator": "bkroll",
+	"target": "^https://opacplus.bsb-muenchen.de/metaopac/singleHit.do.*",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "g",
+	"lastUpdated": "2017-07-02 19:51:29"
+}
+
+function detectWeb(doc, url) {
+	mediaTypeIcon = doc.getElementById("mediaTypeIcon");
+	mediaTypeNode = mediaTypeIcon.getElementsByTagName("img");
+	mediaType = mediaTypeNode[0].getAttribute("alt");
+
+	if (mediaType == "Buch") {
+		return "book";
+	}
+}
+
+/** get MarcXml representation from opac dataset and use MarcXml translator **/
+function doWeb(doc, url) {
+	marcxmlLinkNode = doc.getElementById("marcLink");
+	marcxmlLinkString = marcxmlLinkNode.getAttribute("href");
+	Zotero.Utilities.doGet("https://opacplus.bsb-muenchen.de" + marcxmlLinkString, translateMarcxml);
+}
+
+function translateMarcxml(marcxmlString, responseObject, responseUrl) {
+	var marcxmlTranslator = Zotero.loadTranslator("import");
+	marcxmlTranslator.setTranslator("edd87d07-9194-42f8-b2ad-997c4c7deefd");
+	marcxmlTranslator.setString(marcxmlString);
+	marcxmlTranslator.translate();
+}


### PR DESCRIPTION
Just a few lines to use the MarcXML data provided through the OPACplus of Bavarian State Library instead of COinS which usually provides more detailed results and avoids punctuation problems if books have a main title and a subtitle.

This is my first try at writing Zotero translators, so any suggestions for improvements would be helpful. I'm looking forward to expand the translator for other media types or listings as well, if time permits.