### PR TITLE
Fix ScienceDirect PDF downloads

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -84,9 +84,9 @@ function getPDFLink(doc, onDone) {
 		try {
 			pdfLink.click();
 			intermediateURL = attr(doc, '.PdfDropDownMenu li a', 'href');
-			var clickEvent = document.createEvent('MouseEvents');
+			var clickEvent = doc.createEvent('MouseEvents');
 			clickEvent.initEvent('mousedown', true, true);
-			document.dispatchEvent(clickEvent);
+			doc.dispatchEvent(clickEvent);
 		}
 		catch (e) {
 			Zotero.debug(e, 2);

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -9,8 +9,11 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-06-22 16:54:54"
+	"lastUpdated": "2017-07-28 00:42:47"
 }
+
+// attr()/text() v2
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null}
 
 function detectWeb(doc, url) {
 	if (!doc.body.textContent.trim()) return;
@@ -48,26 +51,51 @@ function detectWeb(doc, url) {
 	}
 }
 
-function getPDFLink(doc) {
-	var pdfLink = ZU.xpathText(doc, '//div[@id="articleToolbar"]//a[@id="pdfLink" and not(@title="Purchase PDF")]/@href');
-	if (!pdfLink) {
-		pdfLink = ZU.xpathText(doc, '//div[@class="extendedPdfBox"]//a[@id="pdfLink" and not(@title="Purchase PDF")]/@href');
+function getPDFLink(doc, onDone) {
+	// No PDF access ("Get Full Text Elsewhere" or "Check for this article elsewhere")
+	if (doc.querySelector('.accessContent') || doc.querySelector('.access-options-link-text')) {
+		Zotero.debug("PDF is not available");
+		onDone();
+		return;
 	}
-	if (!pdfLink) {
-		pdfLink = ZU.xpathText(doc, '//div[@class="PdfEmbed"]/object/@data');
+	
+	// Some pages still have the PDF link available
+	var pdfURL = attr(doc, '#pdfLink', 'href');
+	if (pdfURL) {
+		onDone(pdfURL);
+		return;
 	}
-	if (!pdfLink) {
-		var mainPdf = ZU.xpath(doc, '//div[@id="articleToolbar" or @class="Toolbar"]//a[contains(@href, "main.pdf")]');
-		//we only look at the first match
-		if (mainPdf.length>0) {
-			var classes = mainPdf[0].class || '';
-			//Z.debug(classes);
-			if (mainPdf[0].title!="Purchase PDF" && classes.indexOf('excerptLink')==-1 && classes.indexOf('purchaseSprite')==-1 && classes.indexOf('ref-article-pdf')==-1 && classes.indexOf('cLink')==-1) {
-				pdfLink = mainPdf[0].href;
-			}
+	
+	// For pages that use the new JS drop-down, the DOM doesn't seem to have the intermediate page URL
+	// after the page load, but it's in the initial HTML, so fetch the page again. This is awful, and
+	// we should try to find a better way of getting the URL (which is obviously available to JS in
+	// the page).
+	var url = doc.location.href;
+	//Zotero.debug("Getting HTML from " + url + " for PDF link");
+	ZU.doGet(url, function (html) {
+		// TODO: Switch to HTTP.request() and get a Document from the XHR
+		var dp = new DOMParser();
+		var doc = dp.parseFromString(html, 'text/html');
+		var intermediateURL = attr(doc, '.pdf-download-btn-link', 'href');
+		//Zotero.debug("Intermediate URL: " + intermediateURL);
+		if (intermediateURL) {
+			// Get the PDF URL from the meta refresh on the intermediate page
+			ZU.doGet(intermediateURL, function (html) {
+				doc = dp.parseFromString(html, 'text/html');
+				var pdfURL = attr(doc, 'meta[HTTP-EQUIV="Refresh"]', 'CONTENT');
+				//Zotero.debug("Meta refresh URL: " + pdfURL);
+				if (pdfURL) {
+					// Strip '0;URL='
+					var matches = pdfURL.match(/\d+;URL=(.+)/);
+					pdfURL = matches ? matches[1] : null;
+				}
+				onDone(pdfURL);
+				return;
+			});
+			return;
 		}
-	}
-	return pdfLink;
+		onDone();
+	});
 }
 
 function getISBN(doc) {
@@ -262,13 +290,6 @@ function processRIS(doc, text) {
 			document: doc
 		});
 
-		var pdfLink = getPDFLink(doc);
-		if (pdfLink) item.attachments.push({
-			title: 'ScienceDirect Full Text PDF',
-			url: pdfLink,
-			mimeType: 'application/pdf'
-		});
-
 		//attach supplementary data
 		if (Z.getHiddenPref && Z.getHiddenPref("attachSupplementary")) {
 			try { //don't fail if we can't attach supplementary data
@@ -297,7 +318,16 @@ function processRIS(doc, text) {
 			item.url = "https:" + item.url;
 		}
 
-		item.complete();
+		getPDFLink(doc, function (pdfURL) {
+			if (pdfURL) {
+				item.attachments.push({
+					title: 'ScienceDirect Full Text PDF',
+					url: pdfURL,
+					mimeType: 'application/pdf'
+				});
+			}
+			item.complete();
+		});
 	});
 	translator.translate();
 }

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -61,7 +61,7 @@ function getPDFLink(doc, onDone) {
 	
 	// Some pages still have the PDF link available
 	var pdfURL = attr(doc, '#pdfLink', 'href');
-	if (pdfURL) {
+	if (pdfURL && pdfURL != '#') {
 		onDone(pdfURL);
 		return;
 	}


### PR DESCRIPTION
This loads the intermediate page and extracts the PDF URL from the meta refresh. The most annoying part of this is that the intermediate page URL from the JS drop-down doesn't seem to be in the DOM after the page has loaded, but it's in the initial HTML, so this refetches the HTML. There's probably a way to get the intermediate URL without doing that. (If we were really desperate we could simulate a click, but that's probably not necessary.)

This also uses a new method for determining whether the user has access to the PDF or would get a "Your organization may be charged for transactional access to this non-subscribed article." page (which has a Continue button, but presumably we don't want to touch that).

This could use some testing, particularly for the access-checking part — there may be a better way to test for that, or there may be other versions of that access box. (I didn't want to test for the text strings (e.g., "Get Full Text Elsewhere") because I'm not sure if they're localized.)