### PR TITLE
[Jahrbuch.js] Add compatibility with Chrome and Safari

### DIFF
--- a/Jahrbuch.js
+++ b/Jahrbuch.js
@@ -8,8 +8,8 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gv",
-	"lastUpdated": "2017-01-01 15:22:27"
+	"browserSupport": "gcsv",
+	"lastUpdated": "2017-11-04 10:50:28"
 }
 
 function detectWeb(doc, url) {


### PR DESCRIPTION
The translator looks fine and I tested it successfully with Chrome as well.

However, the test within Scaffold did not match because of encoding problems. The encoding should be handled in the `doGet` call. @dstillman Can Scaffold handle such `doGet` [calls with a special encoding](https://github.com/zotero/translators/blob/master/Jahrbuch.js#L104) as well?

Relates to https://github.com/zotero/zotero-connectors/issues/197