### PR TITLE
Rewrite National Library of Norway for new site

### DIFF
--- a/National Library of Norway.js
+++ b/National Library of Norway.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-12-28 12:25:50"
+	"lastUpdated": "2017-11-29 23:36:00"
 }
 
 /*
@@ -35,40 +35,87 @@
 
 	***** END LICENSE BLOCK *****
 */
-
 function detectWeb(doc, url) {
-	if (url.indexOf("/nbsok/search?") != -1) {
-		return "multiple";
-	} else if (url.indexOf("/nbsok/nb/") != -1) {
-		var mediaTypes = {
-			'Bøker': 'book',
-			'Tidsskrift': 'book', // complete issues or volumes, not articles
-			'Aviser': 'newspaperArticle',
-			'Film': 'videoRecording',
-			'Fjernsyn': 'videoRecording',
-			'Radio': 'radioBroadcast',
-			'Kart': 'map',
-		};
-		var nodes = ZU.xpath(doc, '//input[@id="mediaType"]');
-		if (nodes.length && mediaTypes[nodes[0].value]) {
-			return mediaTypes[nodes[0].value];
+	// The page can change from a search page to a single item page
+	// without loading the whole content as a new website, so we
+	// need to monitor for DOM changes.
+	Z.monitorDOMChanges(ZU.xpath(doc, '//div[contains(@class, "layout-content")]')[0], {childList: true});
+
+	// New UI - search page
+	if (url.includes('nb.no/search?')){
+		return 'multiple';
+	}
+
+	// Old UI – item (these URLs are not yet redirected to the new UI)
+	if (url.includes('nb.no/nbsok/nb/')){
+		var nodes = ZU.xpath(doc, '//meta[@name="dc:type"]');
+		if (nodes.length) {
+			var dcType = nodes[0].getAttribute('content');
+			return mapMediaType(dcType);
 		}
+	}
+
+	// New UI - item
+	if (url.includes('nb.no/items/')){
+		// There is a dc:type meta tag, but it contains values like
+		// "nonfiction" or "Text", so not helpful like before when it contained
+		// material type.
+		return 'book';
 	}
 }
 
 function doWeb(doc, url) {
-	if (detectWeb(doc, url) == "multiple") {
-		var items = ZU.getItemArray(doc, doc, '/nbsok/nb/');
+	if (detectWeb(doc, url) == 'multiple') {
+		var linkItems = ZU.xpath(doc, '//a[contains(@href, "items")]');
+		var items = {};
+		linkItems.forEach(function(linkItem) {
+			var link = linkItem.getAttribute('href');
+
+			// The search result list has two different layouts: 'grid' and 'list'.
+			// The first xpath is for the grid view, the second for the list view.
+			var title = ZU.xpathText(linkItem, './/label[@class="title" or @class="subtitle"]')
+				|| ZU.xpathText(linkItem, './/dd[position() < 4]');
+
+			if (title) {
+				items[link] = title;
+			}
+		});
 		Zotero.selectItems(items, function(items) {
 			if(!items) {
 				return true;
 			}
 			var urls = Object.keys(items);
-			ZU.processDocuments(urls, scrape);
+			ZU.processDocuments(urls, processUrl);
 		});
 	} else {
-		scrape(doc, url);
+		processUrl(doc, url);
 	}
+}
+
+function getIdentifierFromUrl(url) {
+	// New-style URL
+	var matches = url.match(/nb\.no\/items\/([^#?;]+)/);
+	if (matches) {
+		return matches[1];
+	}
+	// Old-style URL
+	matches = url.match(/nb\.no\/nbsok\/nb\/([^#?;]+)/);
+	if (matches) {
+		return matches[1];
+	}
+}
+
+function mapMediaType(mediaType) {
+	var mediaTypes = {
+		'Bøker': 'book',
+		'Tidsskrift': 'book', // complete issues or volumes, not articles
+		'Aviser': 'newspaperArticle',
+		'Film': 'videoRecording',
+		'Fjernsyn': 'videoRecording',
+		'Radio': 'radioBroadcast',
+		'Kart': 'map',
+	};
+	return mediaTypes[mediaType] || 'book';  // default to 'book'
 }
 
 function trimBrackets(obj) {
@@ -98,71 +145,131 @@ function extractNumPages(str) {
 	return numPages.join('; ');
 }
 
-function getRIS(url, cb) {
+function getMODS(url, cb) {
 	ZU.doGet(url, function(text){
-		var translator = Zotero.loadTranslator("import");
-		translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
+		var translator = Zotero.loadTranslator('import');
+		translator.setTranslator('0e2235e7-babf-413c-9acf-f27cce5f059c');
 		translator.setString(text);
-		translator.setHandler("itemDone", function(obj, item) {
+		translator.setHandler('itemDone', function(obj, item) {
 			cb(item);
 		});
 		translator.translate();
 	});
 }
 
-function scrape(doc, url) {
-	var endNote = ZU.xpath(doc, '//a[text()="EndNote"]');
-	getRIS(endNote[0].href, function(item) {
+
+function apiRequest(url, cb) {
+	ZU.doGet(url, function(text){
+		var obj;
+		try {
+			obj = JSON.parse(text);
+		} catch (e) {
+			throw('Failed parsing JSON from ' + url + '.json');
+		}
+		cb(obj);
+	});
+}
+
+function processUrl(doc, url) {
+	var identifier = getIdentifierFromUrl(url);
+	// Note to self: the identifier can be a URN, but also sesamid or other kind of identifier
+	var modsUrl = 'https://api.nb.no/catalog/v1/metadata/' + identifier + '/mods';
+	var apiUrl = 'https://api.nb.no/catalog/v1/items/' + identifier ;
+
+	// Utilize the RIS importer to prepare a mostly complete record
+	getMODS(modsUrl, function(item) {
 		item = trimBrackets(item);
 
-		// Normalize notes
-		item.notes.forEach(function(note) {
-			note.note = note.note
-				.replace(/^<p>/, '').replace(/<\/p>$/, '')  // paragraph tags
-				.replace(/&nbsp;/g, ' ')        // hard spaces
-				.replace(/ +/g, ' ')            // multiple spaces
-				;
-		});
-
-		if (item.numPages) {
-			item.numPages = extractNumPages(item.numPages);
+		// Concat and normalize notes
+		var note = item.notes.map(function(note) { return note.note; })
+			.join('.\n')
+			.replace(/<\/?p>/g, '')   // paragraph tags
+			.replace(/&nbsp;/g, ' ')  // hard spaces
+			.replace(/ +/g, ' ')      // multiple spaces
+		if (note) {
+			item.notes = [{ note: note }];
 		}
-		
+
 		item.date = ZU.strToISO(item.date);
 
-		// Add permalink
-		var container = doc.getElementById('preview_metadata');
-		if (container) {
-			item.url = ZU.xpathText(container, './/a[contains(@href, "urn.nb.no")]');
+		if (item.archiveLocation) {
+			delete item.archiveLocation;
 		}
+		if (item.callNumber) {
+			delete item.callNumber;
+		}
+		item.tags = [];
 
-		item.complete();
+		// Use the (undocumented) JSON api to add some data missing in the RIS export
+		apiRequest(apiUrl, function(apiResponse) {
+
+			var m = apiResponse.metadata;
+
+			item = trimBrackets(item);
+
+			item.numPages = extractNumPages(m.physicalDescription.extent);
+
+
+			if (item.accessDate) {
+				// Better leave this to Zotero
+				delete item.accessDate;
+			}
+
+			if (m.identifiers.urn) {
+				item.url = 'https://urn.nb.no/' + apiResponse.metadata.identifiers.urn;
+			}
+
+			if (m.series && m.series.length) {
+				item.series = m.series[0];
+			}
+
+			if (m.mediaTypes && m.mediaTypes.length) {
+				item.type = mapMediaType(m.mediaTypes[0]);
+			}
+
+			item.complete();
+		});
+
 	});
 }
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://www.nb.no/nbsok/nb/b0426ebe3f16cd56d81959510d52b05b",
+		"url": "https://www.nb.no/items/URN:NBN:no-nb_digibok_2013022624011",
 		"items": [
 			{
-				"itemType": "videoRecording",
-				"title": "Sammenslåing av BP og Amoco - Dagsrevyen 1998.12.31 (6: 9)",
-				"creators": [],
-				"date": "1996-12-31",
+				"itemType": "book",
+				"title": "Memoirs of Lewis Holberg",
+				"creators": [
+					{
+						"lastName": "Holberg",
+						"firstName": "Ludvig",
+						"creatorType": "author"
+					}
+				],
+				"date": "1827",
 				"libraryCatalog": "National Library of Norway",
-				"shortTitle": "Sammenslåing av BP og Amoco - Dagsrevyen 1998.12.31 (6",
-				"url": "http://urn.nb.no/URN:NBN:no-nb_video_11201",
+				"numPages": "vii+289",
+				"place": "London",
+				"publisher": "Hunt and Clarke",
+				"language": "eng; lat",
+				"series": "Autobiography : a collection of the most instructive and amusing lives ever published vol. 12",
+				"url": "https://urn.nb.no/URN:NBN:no-nb_digibok_2013022624011",
 				"attachments": [],
+				"notes": [
+					{
+						"note": "statement of responsibility: written by himself in Latin : and now first translated into English.\nreproduction: Elektronisk reproduksjon [Norge] Nasjonalbiblioteket Digital 2013-03-01"
+					}
+				],
 				"tags": [],
-				"notes": [],
 				"seeAlso": []
 			}
 		]
 	},
 	{
 		"type": "web",
-		"url": "http://www.nb.no/nbsok/nb/a4cd69796dd3312c9780f5982a4a31f1",
+		"url": "https://www.nb.no/items/URN:NBN:no-nb_digibok_2008030304011",
 		"items": [
 			{
 				"itemType": "book",
@@ -172,34 +279,30 @@ var testCases = [
 						"lastName": "Nordset",
 						"firstName": "Bjørg",
 						"creatorType": "author"
+					},
+					{
+						"lastName": "Lesja bondekvinnelag",
+						"fieldMode": 1,
+						"creatorType": "author"
 					}
 				],
 				"date": "1995",
 				"ISBN": "9788291375052",
 				"libraryCatalog": "National Library of Norway",
 				"numPages": "176",
-				"place": "Lesja",
-				"publisher": "Bondekvinnelaget",
+				"publisher": "Snøhetta forl.",
 				"shortTitle": "Mat frå gard og grend",
-				"url": "http://urn.nb.no/URN:NBN:no-nb_digibok_2008030304011",
+				"url": "https://urn.nb.no/URN:NBN:no-nb_digibok_2008030304011",
 				"attachments": [],
-				"tags": [
-					"Foods",
-					"Gudbrandsdalen",
-					"History",
-					"Kokebøker",
-					"Lesja",
-					"Mattradisjoner",
-					"Merkedager",
-					"Preservation",
-					"Religiøse fester"
-				],
 				"notes": [
 					{
-						"note": "Opplagshistorikk: 2. oppl. 1995; 3. oppl. 2001"
+						"note": "statement of responsibility: Lesja bondekvinnelag ; red.: Bjørg Nordset ; [foto: [hovedsakelig] Bjarne Fossøy].\nOpplagshistorikk: 2. oppl. 1995; 3. oppl. 2001.\nreproduction: Elektronisk reproduksjon [Norge] Nasjonalbiblioteket Digital 2009-04-09"
 					}
 				],
-				"seeAlso": []
+				"seeAlso": [],
+				"tags": [],
+				"place": "Lesja",
+				"language": "nob"
 			}
 		]
 	}


### PR DESCRIPTION
A new single page app site was released about a month ago. Unfortunately there's not much to scrape from the site itself anymore, but there's still the RIS export. The internal JSON API also looks promising, but there's been no announcement about the API being intended for public use and there's no documentation, so at least for now, I think the best idea is to stick with the RIS export as the base, and then enrich it with some data from the JSON API that we don't get from the RIS export.

Note: for now the only test cases are "books", since other media types aren't yet identified correctly. When viewing an item page, there is just no metadata in the DOM before you open a small "contents" overlay, and therefore no way to detect the type initially. There are a few meta tags added to head, but at the moment they don't contain the media type. Hopefully that can be changed at some point, but I don't expect anytime soon.