### PR TITLE
[Citavi 5 XML] Handle wrongly sorted collection relations

### DIFF
--- a/Citavi 5 XML.js
+++ b/Citavi 5 XML.js
@@ -12,7 +12,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcsi",
-	"lastUpdated": "2016-12-29 13:57:06"
+	"lastUpdated": "2017-12-09 12:00:14"
 }
 
 /*
@@ -43,6 +43,7 @@
 TEST DATA can be found here:
  - Single reference (162 KB) text: https://gist.github.com/zuphilip/02d6478ace4636e4e090e348443c551e
  - Larger project (1221 KB): https://gist.github.com/zuphilip/76ce89ebbdac0386507b36cff3fd499a
+ - Other project (1,11 MB): https://gist.github.com/anonymous/10fc363b6d79dae897e296a4327aa707
 */
 
 
@@ -336,6 +337,7 @@ function doImport() {
 		var categoryLists = hierarchy[i].textContent.split(";");
 		var referencePoint = categoryLists[0];
 		if (!numbering[referencePoint]) {
+			//in some cases the ordering of these relations is different
 			Z.debug("Warning: Reference point for categorization hierarchy not yet found");
 			Z.debug(categoryLists);
 			continue;
@@ -348,7 +350,11 @@ function doImport() {
 	for (var i=0, n=categories.length; i<n; i++) {
 		var collection = new Zotero.Collection();
 		collection.id = ZU.xpathText(categories[i], './@id');
-		collection.name = numbering[collection.id].substr(2) + ' ' + ZU.xpathText(categories[i], './Name');
+		collection.name = ZU.xpathText(categories[i], './Name');
+		if (numbering[collection.id]) {
+			//add the hierarchy number whenever possible
+			collection.name = numbering[collection.id].substr(2) + ' ' + collection.name;
+		}
 		collection.type = 'collection';
 		collection.children = [];
 		var referenceCategories = ZU.xpath(doc, '//ReferenceCategories/OnetoN[contains(text(), "'+collection.id+'")]');


### PR DESCRIPTION
This is a simple fix which solves the problem that the relactions
between categories are not always ordered correctly. More precisely
it will ignore the hierarchical number in these cases.

This should solve https://forums.zotero.org/discussion/comment/295173#Comment_295173