### PR TITLE
Fixed Bookmarks.js HTML character references in title.

### DIFF
--- a/Bookmarks.js
+++ b/Bookmarks.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-06-03 11:41:00"
+	"lastUpdated": "2017-12-17 17:43:00"
 }
 
 /*

--- a/Bookmarks.js
+++ b/Bookmarks.js
@@ -126,7 +126,7 @@ function doImport() {
 					}
 					
 					openItem = new Zotero.Item("webpage");
-					openItem.title = title;
+					openItem.title = ZU.unescapeHTML(title);
 					openItem.itemID = openItem.id = itemID++;
 					if(collection) collection.children.push(openItem);
 					


### PR DESCRIPTION
Importing bookmarks in Zotero left symbols like `&amp;` and `&#39;` in title. This fix changes them to the original character.

This issue was discussed here: https://github.com/zotero/translators/issues/1485