### PR TITLE
Update jshint

### DIFF
--- a/.ci/jshintrc
+++ b/.ci/jshintrc
@@ -1,4 +1,6 @@
 {
+  "esversion": 6,
   "laxbreak": true,
-  "multistr": true
+  "multistr": true,
+  "shadow": true
 }

--- a/.ci/package.json
+++ b/.ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translators-check",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Continuous integration of Zotero translators",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "url": "https://github.com/zotero/translators/blob/master/.ci/"
   },
   "dependencies": {
-    "jshint": "^2.9.4",
+    "jshint": "^2.9.5",
     "jsonlint": "^1.6.2"
   }
 }


### PR DESCRIPTION
* Update jshint version
* Use ES6 now, e.g. `let`
* Add option `shadow: true` to disable warnings that variables
  are already defined