### PR TITLE
Fix incorrect type returned for ResearchGate

### DIFF
--- a/ResearchGate.js
+++ b/ResearchGate.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-10-15 14:15:09"
+	"lastUpdated": "2018-01-28 01:52:07"
 }
 
 /*
@@ -47,6 +47,7 @@ function detectWeb(doc, url) {
 			//for logged in users (yes, really...)
 			type = text(doc, 'b[data-reactid]');
 		}
+		type = type.replace('(PDF Available)', '').trim();
 		switch(type) {
 			case "Data"://until we have a data itemType
 			case "Article":


### PR DESCRIPTION
The inclusion of `(PDF Available)` in the text that the translator was using to determine type was causing it to fail, so I have fixed this. No failing test added as the existing one for URL `https://www.researchgate.net/publication/315673297_Linguistic_Landscape_Bibliography_on_Zotero` was already failing.

Any comments welcome. I think using the RIS data is still a valid approach -- the BibTeX export they provide isn't any more reliable.

Thanks :)