### PR TITLE
Update CiteSeer to work from PDF paper view

### DIFF
--- a/CiteSeer.js
+++ b/CiteSeer.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-01-28 14:23:28"
+	"lastUpdated": "2018-01-28 16:31:16"
 }
 
 /*
@@ -35,11 +35,11 @@
 */
 
 function detectWeb(doc, url) {
-	//for running the tests with book examples:
-	//return "book";
 	if ((url.includes('/search') || url.includes('/showciting')) && getSearchResults(doc).length) {
 		return "multiple";
 	}
+	//for running the tests with book example
+	if (url == "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.332.356&rank=1") return "book";
 	if ((url.includes('/viewdoc/') && doc.getElementById('bibtex'))
 		|| url.includes('/download?doi=')) {
 		return "journalArticle";
@@ -51,7 +51,7 @@ function getSearchResults(doc) {
 }
 
 function doWeb(doc, url) {
-	var articles = new Array();
+	var articles = [];
 	if (detectWeb(doc, url) == "multiple") {
 		var items = {};
 		var titles = getSearchResults(doc);
@@ -68,6 +68,8 @@ function doWeb(doc, url) {
 			ZU.processDocuments(articles, scrape);
 		});
 	} else if (url.includes('/download?doi=')) {
+		// PDF paper view
+		// e.g. http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.415.9750&rep=rep1&type=pdf
 		let doi = url.match(/\/download\?doi=([^&]*)/);
 		let paperUrl = 'http://citeseerx.ist.psu.edu/viewdoc/summary?doi=' + doi[1];
 		ZU.processDocuments(paperUrl, scrape);

--- a/CiteSeer.js
+++ b/CiteSeer.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-01-28 02:10:41"
+	"lastUpdated": "2018-01-28 14:23:28"
 }
 
 /*
@@ -37,11 +37,11 @@
 function detectWeb(doc, url) {
 	//for running the tests with book examples:
 	//return "book";
-	if ((url.indexOf('/search') != -1 || url.indexOf('/showciting') != -1) && getSearchResults(doc).length) {
+	if ((url.includes('/search') || url.includes('/showciting')) && getSearchResults(doc).length) {
 		return "multiple";
 	}
-	if ((url.indexOf('/viewdoc/') != -1 && doc.getElementById('bibtex'))
-		|| url.indexOf('/download?doi=') != -1) {
+	if ((url.includes('/viewdoc/') && doc.getElementById('bibtex'))
+		|| url.includes('/download?doi=')) {
 		return "journalArticle";
 	}
 }
@@ -67,10 +67,9 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} else if (url.indexOf('/download?doi=') !== -1) {
-		let doi = url.replace('http://citeseerx.ist.psu.edu/viewdoc/download?doi=', '');
-		doi = doi.replace('&rep=rep1', '').replace('&type=pdf', '');
-		let paperUrl = 'http://citeseerx.ist.psu.edu/viewdoc/summary?doi=' + doi;
+	} else if (url.includes('/download?doi=')) {
+		let doi = url.match(/\/download\?doi=([^&]*)/);
+		let paperUrl = 'http://citeseerx.ist.psu.edu/viewdoc/summary?doi=' + doi[1];
 		ZU.processDocuments(paperUrl, scrape);
 	} else {
 		scrape(doc, url);

--- a/CiteSeer.js
+++ b/CiteSeer.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "fa396dd4-7d04-4f99-95e1-93d6f355441d",
 	"label": "CiteSeer",
-	"creator": "Sebastian Karcher",
+	"creator": "Sebastian Karcher, Guy Aglionby",
 	"target": "^https?://citeseerx?\\.ist\\.psu\\.edu",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-09-13 06:39:17"
+	"lastUpdated": "2018-01-28 02:10:41"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2012 Sebastian Karcher
+	Copyright © 2018 Sebastian Karcher, Guy Aglionby
 	This file is part of Zotero.
 
 	Zotero is free software: you can redistribute it and/or modify
@@ -40,7 +40,8 @@ function detectWeb(doc, url) {
 	if ((url.indexOf('/search') != -1 || url.indexOf('/showciting') != -1) && getSearchResults(doc).length) {
 		return "multiple";
 	}
-	if (url.indexOf('/viewdoc/') != -1 && doc.getElementById('bibtex')) {
+	if ((url.indexOf('/viewdoc/') != -1 && doc.getElementById('bibtex'))
+		|| url.indexOf('/download?doi=') != -1) {
 		return "journalArticle";
 	}
 }
@@ -66,6 +67,11 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
+	} else if (url.indexOf('/download?doi=') !== -1) {
+		let doi = url.replace('http://citeseerx.ist.psu.edu/viewdoc/download?doi=', '');
+		doi = doi.replace('&rep=rep1', '').replace('&type=pdf', '');
+		let paperUrl = 'http://citeseerx.ist.psu.edu/viewdoc/summary?doi=' + doi;
+		ZU.processDocuments(paperUrl, scrape);
 	} else {
 		scrape(doc, url);
 	}


### PR DESCRIPTION
As the title says, as the DOI is available in the PDF url we can get the URL for the summary page and grab the information from there.

Thanks and any comments appreciated.