### PR TITLE
[checkTranslator.sh] Warn about unnecassary indexOf()

### DIFF
--- a/.ci/checkTranslator.sh
+++ b/.ci/checkTranslator.sh
@@ -23,6 +23,7 @@ declare -a ERROR_CHECKS=(
 declare -a WARN_CHECKS=(
     "badLicense"
     "problematicJS"
+    "unnecessaryIndexOf"
 )
 
 #-----------------------------------------------------------------------
@@ -89,6 +90,14 @@ deprecatedForEach () {
     fi
 }
 
+unnecessaryIndexOf () {
+    if grep -qE '\.indexOf(.*) *(=+ *-1|!=+ *-1|> *-1|>= *0|< *0)' "$TRANSLATOR";then
+        warn "Unnecessary '.indexOf()', use '.includes()' instead:"
+        grep -nE '\.indexOf(.*) *(=+ *-1|!=+ *-1|> *-1|>= *0|< *0)' "$TRANSLATOR"
+        return 1
+    fi
+}
+
 badLicense () {
     if ! grep -q "GNU Affero General Public License" "$TRANSLATOR";then
         warn "Must be AGPL licensed"
@@ -112,7 +121,7 @@ problematicJS () {
         | sed '/BEGIN TEST/,$ d' \
         | jshint --config="$SCRIPT_DIR"/jshintrc --reporter=unix -)
     if (( $? > 0 ));then
-        warn "JSHint shows issues with this code"
+        warn "JSHint shows issues with this code:"
         warn "$jshint_error"
         return 1
     fi


### PR DESCRIPTION
E.g.
```
$ ./.ci/checkTranslator.sh zotero.org.js
# WARN:  zotero.org.js :Must be AGPL licensed
# WARN:  zotero.org.js :JSHint shows issues with this code:
# WARN:  zotero.org.js :stdin:44:90: Missing semicolon.
# WARN:  zotero.org.js :
# WARN:  zotero.org.js :1 error
# WARN:  zotero.org.js :Unnecessary '.indexOf()', use '.includes()' instead:
73:             || url.indexOf('/collectionKey/') != -1
75:             || url.indexOf('/tag/') != -1 )
ok - zotero.org.js (Warnings: badLicense problematicJS unnecessaryIndexOf)
```