### PR TITLE
Restart ASCE translator

### DIFF
--- a/ASCE.js
+++ b/ASCE.js
@@ -44,9 +44,10 @@ function getTitles(doc) {
 }
 
 function detectWeb(doc, url) {
-/*	if (url.match(/\/doi\/abs\/10\.|\/doi\/full\/10\./)) {
+	if (url.match(/\/doi\/abs\/10\.|\/doi\/full\/10\./)) {
 		return "journalArticle";
-	} else if(url.match(/\/action\/doSearch\?|\/toc\//))
+	} 
+	/* else if(url.match(/\/action\/doSearch\?|\/toc\//))
 		{
 		return "multiple";
 		} */


### PR DESCRIPTION
Currently, the ASCE translator is turned off, due to some bugs on "multiple" pages. However, the "article" page translates well. So I strongly recommend to restart this translator by annotating the "multiple" related things, and keep the "article" related things for a temporary use.