### PR TITLE
Adding a translator for idref.fr

### DIFF
--- a/Idref.js
+++ b/Idref.js
@@ -65,7 +65,7 @@ function scrape(doc, url) {
 	
 	translator.setHandler('itemDone', function (obj, item) {
 		Z.debug(item);
-		//item.complete();
+		item.complete();
 	});
 	
 	translator.getTranslatorObject(function(trans) {

--- a/Idref.js
+++ b/Idref.js
@@ -2,62 +2,85 @@
 	"translatorID": "271ee1a5-da86-465b-b3a5-eafe7bd3c156",
 	"label": "Idref",
 	"creator": "Sylvain Machefert",
-	"target": "^https?://www\\.idref\\.fr/.*",
+	"target": "^https?://www\\.idref\\.fr/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "g",
-	"lastUpdated": "2018-02-03 09:39:41"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2018-02-12 13:03:06"
 }
+
+/*
+   IdRef Translator
+   Copyright (C) 2018 Sylvain Machefert - web@geobib.fr
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 function detectWeb(doc, url) { 
 	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]')) {
-		return "multiple";
+		if (Object.keys(getSearchResults(doc)).length) {
+			return "multiple";	
+		}
 	}
+}
+
+function getSearchResults(doc) {
+	var resultsTitle = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_value")]');
+	var resultsHref = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_label")]/a/@href');
 	
+	items = {};
+	for (let i=0; i<resultsTitle.length; i++) {
+		href = resultsHref[i].textContent;
+		// We need to replace the http://www.sudoc.fr/XXXXXX links are they are redirects and aren't handled correctly from subtranslator
+		href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
+
+		if ( (href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) ) {
+			items[href] = resultsTitle[i].textContent;
+		}
+	}
+	return items;
 }
 
 function doWeb(doc, url)
 {
 	if (detectWeb(doc, url) == "multiple") {
-		var resultsTitle = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_value")]');
-		var resultsHref = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_label")]/a/@href');
+		items = getSearchResults(doc);
+	}
 		
-		items = {};
-		for (var i in resultsTitle) {
-			href = resultsHref[i].textContent;
-			// We need to replace the http://www.sudoc.fr/XXXXXX links are they are redirects and aren't handled correctly from subtranslator
-			href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
-			items[href] = resultsTitle[i].textContent;
-			
+	Zotero.selectItems(items, function (selectedItems) {
+		if (!selectedItems) {
+			return true;
 		}
-		
-		Zotero.selectItems(items, function (selectedItems) {
-			if (!selectedItems) {
-				return true;
-			}
-			var articles = [];
-			for (var i in selectedItems) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
-		});
-
-	}	
+		var articles = [];
+		for (var i in selectedItems) {
+			articles.push(i);
+		}
+		ZU.processDocuments(articles, scrape);
+	});
 }
 
 function scrape(doc, url) {
-	Z.debug("scraping : " + url);
 	var translator = Zotero.loadTranslator('web');	
 	
-	if (url.indexOf("archives-ouvertes")!=-1){
+	if (url.includes("archives-ouvertes")){
 		// HAL Archives ouvertes
-		Z.debug("HAL");
 		translator.setTranslator('58ab2618-4a25-4b9b-83a7-80cd0259f896');
-	} else if (url.indexOf("sudoc.abes.fr") != -1) {
-		Z.debug("Sudoc");
+	} else if (url.includes("sudoc.abes.fr")) {
+		// Sudoc
 		translator.setTranslator('1b9ed730-69c7-40b0-8a06-517a89a3a278');
 	} else {
 		Z.debug("Undefined website");

--- a/Idref.js
+++ b/Idref.js
@@ -36,17 +36,15 @@
 */
 
 function detectWeb(doc, url) { 
-	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]')) {
-		if (Object.keys(getSearchResults(doc)).length) {
-			return "multiple";	
-		}
+	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]') && getSearchResults(doc, true)) {
+		return "multiple";	
 	}
 }
 
-function getSearchResults(doc) {
+function getSearchResults(doc, checkOnly) {
 	var resultsTitle = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_value")]');
 	var resultsHref = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_label")]/a/@href');
-	
+	var found = false;
 	items = {};
 	for (let i=0; i<resultsTitle.length; i++) {
 		href = resultsHref[i].textContent;
@@ -54,19 +52,17 @@ function getSearchResults(doc) {
 		href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
 
 		if ( (href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) ) {
+			if (checkOnly) return true;
+			found = true;
 			items[href] = resultsTitle[i].textContent;
 		}
 	}
-	return items;
+	return found ? items : false;
 }
 
 function doWeb(doc, url)
 {
-	if (detectWeb(doc, url) == "multiple") {
-		items = getSearchResults(doc);
-	}
-		
-	Zotero.selectItems(items, function (selectedItems) {
+	Zotero.selectItems(getSearchResults(doc, false), function (selectedItems) {
 		if (!selectedItems) {
 			return true;
 		}

--- a/Idref.js
+++ b/Idref.js
@@ -13,22 +13,27 @@
 }
 
 /*
-   IdRef Translator
-   Copyright (C) 2018 Sylvain Machefert - web@geobib.fr
+	***** BEGIN LICENSE BLOCK *****
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+	Copyright © 2018 Sylvain Machefert
+	
+	This file is part of Zotero.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
 
 function detectWeb(doc, url) { 
 	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]')) {

--- a/Idref.js
+++ b/Idref.js
@@ -1,0 +1,74 @@
+{
+	"translatorID": "271ee1a5-da86-465b-b3a5-eafe7bd3c156",
+	"label": "Idref",
+	"creator": "Sylvain Machefert",
+	"target": "^https?://www\\.idref\\.fr/",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "g",
+	"lastUpdated": "2018-01-12 10:00:51"
+}
+
+function detectWeb(doc, url) { 
+	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]')) {
+		return "multiple";
+	}
+	
+}
+
+function doWeb(doc, url)
+{
+	if (detectWeb(doc, url) == "multiple") {
+		var hits = {};
+		var urls = [];
+		var title;
+		var link;
+		var resultsTitle = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_value")]');
+		var resultsHref = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_label")]/a/@href');
+		
+		itemsList = [];
+		for (var i in resultsTitle) {
+			itemsList[resultsHref[i].textContent] = resultsTitle[i].textContent;
+		}
+		
+		Zotero.selectItems(itemsList, function (items) {
+			if (!items) {
+				return true;
+			}
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrape);
+		});
+
+	}	
+}
+
+function scrape(doc, url) {
+	Z.debug("scraping : " + url);
+	var translator = Zotero.loadTranslator('web');	
+	
+	if (url.indexOf("archives-ouvertes")!=-1){
+		// HAL Archives ouvertes
+		Z.debug("HAL");
+		translator.setTranslator('58ab2618-4a25-4b9b-83a7-80cd0259f896');
+	} else if (url.indexOf("sudoc.fr") != -1) {
+		Z.debug("Sudoc");
+		translator.setTranslator('1b9ed730-69c7-40b0-8a06-517a89a3a278');
+	} else {
+		Z.debug("Undefined website");
+	}
+	
+	translator.setHandler('itemDone', function (obj, item) {
+		Z.debug(item);
+		//item.complete();
+	});
+	
+	translator.getTranslatorObject(function(trans) {
+		trans.doWeb(doc, url);
+	});
+}

--- a/Idref.js
+++ b/Idref.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "g",
-	"lastUpdated": "2018-01-13 21:39:39"
+	"lastUpdated": "2018-02-03 09:39:41"
 }
 
 function detectWeb(doc, url) { 
@@ -72,3 +72,12 @@ function scrape(doc, url) {
 		trans.doWeb(doc, url);
 	});
 }
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.idref.fr/199676100",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/


### PR DESCRIPTION
Hello,
[idref.fr](http://www.idref.fr) is the website allowing to get information about authorities (identifiers) available in various French catalogs (mainly [SUDOC](http://www.sudoc.abes.fr/) and [HAL](https://hal.archives-ouvertes.fr/) for the moment). These linked catalogs already have existing translators so this translator is mainly calling the correct one based on the list of items existing on a page. 

Currently the translator is working as expected ([https://www.idref.fr/199676100](https://www.idref.fr/199676100) for example), but I have not been able to run the populated test, I imagine that this is related to the way I call selectItems but I have not been able to understand what the issue is), I hope the Zotero team will be able to fix this slight issue before merging.

Happy to update my code if any advice is given regarding things that would not be done according to Zotero's expectations.