### PR TITLE
One more SD PDF fix

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-03 17:33:23"
+	"lastUpdated": "2018-03-03 23:33:23"
 }
 
 // attr()/text() v2
@@ -65,6 +65,7 @@ function getPDFLink(doc, onDone) {
 	
 	// Some pages still have the PDF link available
 	var pdfURL = attr(doc, '#pdfLink', 'href');
+	if (!pdfURL) pdfURL = attr(doc, '[name="citation_pdf_url', 'content');
 	if (pdfURL && pdfURL != '#') {
 		parseIntermediatePDFPage(pdfURL, onDone);
 		return;


### PR DESCRIPTION
it looks like we now have the PDF URL in the metaheader and can just use that, saving a ton of unnecessary calls and also making this work where it previously didn't (e.g. https://www.sciencedirect.com/science/article/pii/S1053811917307280?via%3Dihub still didn't work for me previously)