### PR TITLE
[Zenodo] Prevent mis-importing software as report

### DIFF
--- a/Zenodo.js
+++ b/Zenodo.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-01-22 21:59:40"
+	"lastUpdated": "2018-03-07 14:55:24"
 }
 
 /*
@@ -195,6 +195,11 @@ function scrape(doc, url) {
 
 			if (item.itemType == "document" && zoteroType[type]) {
 				item.itemType = zoteroType[type];
+				
+				//undo the fix for non-existent CSL types, if Zotero supports the original itemType
+				if (detectWeb(doc, url) == "computerProgram") {
+					item.itemType = "computerProgram"
+				}
 			}
 			item.itemID = "";
 			item.complete();
@@ -468,6 +473,61 @@ var testCases = [
 				"notes": [],
 				"seeAlso": []
 			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://zenodo.org/record/1048320",
+		"items": [
+			 {
+             "itemType": "computerProgram"
+             "creators": [
+               {
+                 "lastName": "Carl Boettiger"
+                 "firstName": ""
+                 "creatorType": "author"
+               }
+               {
+                 "lastName": "Maëlle Salmon"
+                 "firstName": ""
+                 "creatorType": "author"
+               }
+               {
+                 "lastName": "Noam Ross"
+                 "firstName": ""
+                 "creatorType": "author"
+               }
+               {
+                 "lastName": "Arfon Smith"
+                 "firstName": ""
+                 "creatorType": "author"
+               }
+               {
+                 "lastName": "Anna Krystalli"
+                 "firstName": ""
+                 "creatorType": "author"
+               }
+             ]
+             "notes": []
+             "tags": []
+             "seeAlso": []
+             "attachments": [
+               {
+                 "title": "Zenodo Snapshot"
+                 "mimeType": "text/html"
+               }
+             ]
+             "title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages"
+         -   "publisher": "Zenodo"
+             "abstractNote": "an R package for generating and working with codemeta"
+             "date": "2017-11-13"
+             "extra": "DOI: 10.5281/zenodo.1048320"
+             "url": "https://zenodo.org/record/1048320"
+             "libraryCatalog": "Zenodo"
+         -   "accessDate": "2018-03-07T13:45:35Z"
+             "shortTitle": "ropensci/codemetar"
+         +   "company": "Zenodo"
+           }
 		]
 	}
 ]

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-07 15:46:59"
+	"lastUpdated": "2018-03-08 08:11:55"
 }
 
 /*
@@ -196,7 +196,8 @@ function scrape(doc, url) {
 		});
 		trans.translate();
 	});
-}/** BEGIN TEST CASES **/
+}
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-07 14:55:24"
+	"lastUpdated": "2018-03-07 15:20:56"
 }
 
 /*
@@ -187,20 +187,7 @@ function scrape(doc, url) {
 			item.url = url;
 			if (abstract) item.abstractNote = abstract;
 
-			//Zenodo uses some non-existent CSL types we're fixing.
-			var zoteroType = {
-				"figure": "artwork",
-	 			"article": "report"
-			};
-
-			if (item.itemType == "document" && zoteroType[type]) {
-				item.itemType = zoteroType[type];
-				
-				//undo the fix for non-existent CSL types, if Zotero supports the original itemType
-				if (detectWeb(doc, url) == "computerProgram") {
-					item.itemType = "computerProgram"
-				}
-			}
+			item.itemType = detectWeb(doc, url)
 			item.itemID = "";
 			item.complete();
 		});

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -518,15 +518,15 @@ var testCases = [
                }
              ]
              "title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages"
-         -   "publisher": "Zenodo"
+             "publisher": "Zenodo"
              "abstractNote": "an R package for generating and working with codemeta"
              "date": "2017-11-13"
              "extra": "DOI: 10.5281/zenodo.1048320"
              "url": "https://zenodo.org/record/1048320"
              "libraryCatalog": "Zenodo"
-         -   "accessDate": "2018-03-07T13:45:35Z"
+             "accessDate": "2018-03-07T13:45:35Z"
              "shortTitle": "ropensci/codemetar"
-         +   "company": "Zenodo"
+             "company": "Zenodo"
            }
 		]
 	}

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -479,55 +479,55 @@ var testCases = [
 		"type": "web",
 		"url": "https://zenodo.org/record/1048320",
 		"items": [
-			 {
-             "itemType": "computerProgram"
-             "creators": [
-               {
-                 "lastName": "Carl Boettiger"
-                 "firstName": ""
-                 "creatorType": "author"
-               }
-               {
-                 "lastName": "Maëlle Salmon"
-                 "firstName": ""
-                 "creatorType": "author"
-               }
-               {
-                 "lastName": "Noam Ross"
-                 "firstName": ""
-                 "creatorType": "author"
-               }
-               {
-                 "lastName": "Arfon Smith"
-                 "firstName": ""
-                 "creatorType": "author"
-               }
-               {
-                 "lastName": "Anna Krystalli"
-                 "firstName": ""
-                 "creatorType": "author"
-               }
-             ]
-             "notes": []
-             "tags": []
-             "seeAlso": []
-             "attachments": [
-               {
-                 "title": "Zenodo Snapshot"
-                 "mimeType": "text/html"
-               }
-             ]
-             "title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages"
-             "publisher": "Zenodo"
-             "abstractNote": "an R package for generating and working with codemeta"
-             "date": "2017-11-13"
-             "extra": "DOI: 10.5281/zenodo.1048320"
-             "url": "https://zenodo.org/record/1048320"
-             "libraryCatalog": "Zenodo"
-             "accessDate": "2018-03-07T13:45:35Z"
-             "shortTitle": "ropensci/codemetar"
-             "company": "Zenodo"
-           }
+			{
+				"itemType": "computerProgram"
+				"creators": [
+					{
+						"lastName": "Carl Boettiger"
+						"firstName": ""
+						"creatorType": "author"
+					}
+					{
+						"lastName": "Maëlle Salmon"
+						"firstName": ""
+						"creatorType": "author"
+					}
+					{
+						"lastName": "Noam Ross"
+						"firstName": ""
+						"creatorType": "author"
+					}
+					{
+						"lastName": "Arfon Smith"
+						"firstName": ""
+						"creatorType": "author"
+					}
+					{
+						"lastName": "Anna Krystalli"
+						"firstName": ""
+						"creatorType": "author"
+					}
+				]
+				"notes": []
+				"tags": []
+				"seeAlso": []
+				"attachments": [
+					{
+						"title": "Zenodo Snapshot"
+						"mimeType": "text/html"
+					}
+				]
+				"title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages"
+				"publisher": "Zenodo"
+				"abstractNote": "an R package for generating and working with codemeta"
+				"date": "2017-11-13"
+				"extra": "DOI: 10.5281/zenodo.1048320"
+				"url": "https://zenodo.org/record/1048320"
+				"libraryCatalog": "Zenodo"
+				"accessDate": "2018-03-07T13:45:35Z"
+				"shortTitle": "ropensci/codemetar"
+				"company": "Zenodo"
+			}
 		]
 	}
 ]

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -190,7 +190,7 @@ function scrape(doc, url) {
 			item.url = url;
 			if (abstract) item.abstractNote = abstract;
 
-			item.itemType = detectWeb(doc, url)
+			item.itemType = detectWeb(doc, url);
 			item.itemID = "";
 			item.complete();
 		});

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -470,52 +470,57 @@ var testCases = [
 		"url": "https://zenodo.org/record/1048320",
 		"items": [
 			{
-				"itemType": "computerProgram"
+				"itemType": "computerProgram",
 				"creators": [
 					{
-						"lastName": "Carl Boettiger"
-						"firstName": ""
-						"creatorType": "author"
-					}
+						"lastName": "Carl Boettiger",
+						"firstName": "",
+						"creatorType": "author",
+						"fieldMode": true
+					},
 					{
-						"lastName": "Maëlle Salmon"
-						"firstName": ""
-						"creatorType": "author"
-					}
+						"lastName": "Maëlle Salmon",
+						"firstName": "",
+						"creatorType": "author",
+						"fieldMode": true
+					},
 					{
-						"lastName": "Noam Ross"
-						"firstName": ""
-						"creatorType": "author"
-					}
+						"lastName": "Noam Ross",
+						"firstName": "",
+						"creatorType": "author",
+						"fieldMode": true
+					},
 					{
-						"lastName": "Arfon Smith"
-						"firstName": ""
-						"creatorType": "author"
-					}
+						"lastName": "Arfon Smith",
+						"firstName": "",
+						"creatorType": "author",
+						"fieldMode": true
+					},
 					{
-						"lastName": "Anna Krystalli"
-						"firstName": ""
-						"creatorType": "author"
+						"lastName": "Anna Krystalli",
+						"firstName": "",
+						"creatorType": "author",
+						"fieldMode": true
 					}
-				]
-				"notes": []
-				"tags": []
-				"seeAlso": []
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
 				"attachments": [
 					{
-						"title": "Zenodo Snapshot"
+						"title": "Zenodo Snapshot",
 						"mimeType": "text/html"
 					}
-				]
-				"title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages"
-				"publisher": "Zenodo"
-				"abstractNote": "an R package for generating and working with codemeta"
-				"date": "2017-11-13"
-				"extra": "DOI: 10.5281/zenodo.1048320"
-				"url": "https://zenodo.org/record/1048320"
-				"libraryCatalog": "Zenodo"
-				"accessDate": "2018-03-07T13:45:35Z"
-				"shortTitle": "ropensci/codemetar"
+				],
+				"title": "ropensci/codemetar: codemetar: Generate CodeMeta Metadata for R Packages",
+				"publisher": "Zenodo",
+				"abstractNote": "an R package for generating and working with codemeta",
+				"date": "2017-11-13",
+				"extra": "DOI: 10.5281/zenodo.1048320",
+				"url": "https://zenodo.org/record/1048320",
+				"libraryCatalog": "Zenodo",
+				"accessDate": "2018-03-07T13:45:35Z",
+				"shortTitle": "ropensci/codemetar",
 				"company": "Zenodo"
 			}
 		]

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -130,7 +130,6 @@ function scrape(doc, url) {
 	ZU.processDocuments(cslURL, function(newDoc){
 		var text = ZU.xpathText(newDoc, '//h3/following-sibling::pre');
 		//Z.debug(text)
-		var type = text.match(/"type": "(.+?)"/)[1];
 		text = text.replace(/publisher_place/, "publisher-place");
 		text = text.replace(/container_title/, "container-title");
 

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -171,10 +171,13 @@ function scrape(doc, url) {
 			//something is odd with zenodo's author parsing to CSL on some pages; fix it
 			//e.g. https://zenodo.org/record/569323
 			for (var i = 0; i< item.creators.length; i++) {
-				if (!item.creators[i].firstName && item.creators[i].lastName.indexOf(",")!=-1) {
-					item.creators[i].firstName = item.creators[i].lastName.replace(/.+?,\s*/, "");
-					item.creators[i].lastName = item.creators[i].lastName.replace(/,.+/, "");
-					item.creators[i].fieldMode = true;
+				if (!item.creators[i].firstName) {
+					if (item.creators[i].lastName.indexOf(",")!=-1) {
+						item.creators[i].firstName = item.creators[i].lastName.replace(/.+?,\s*/, "");
+						item.creators[i].lastName = item.creators[i].lastName.replace(/,.+/, "");
+					} else {
+						item.creators[i].fieldMode = true;
+					}
 				}
 				delete item.creators[i].creatorTypeID;
 			}

--- a/Zenodo.js
+++ b/Zenodo.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-07 15:20:56"
+	"lastUpdated": "2018-03-07 15:46:59"
 }
 
 /*
@@ -175,6 +175,7 @@ function scrape(doc, url) {
 				if (!item.creators[i].firstName && item.creators[i].lastName.indexOf(",")!=-1) {
 					item.creators[i].firstName = item.creators[i].lastName.replace(/.+?,\s*/, "");
 					item.creators[i].lastName = item.creators[i].lastName.replace(/,.+/, "");
+					item.creators[i].fieldMode = true;
 				}
 				delete item.creators[i].creatorTypeID;
 			}


### PR DESCRIPTION
As [discussed in the forum](https://forums.zotero.org/discussion/comment/301116/) this ensures that `Software` items on Zenodo are imported as `computerProgram`, even though along the way, Zenodo is offering a non-CSL item type

### Potential/Remaining isues to discuss

- [x] Scaffold imports the full author names as `lastName`. This could occur in https://github.com/zotero/translators/blame/master/Zenodo.js#L172-L180, but I'm not sure whether or how to adjust that. Or, should I adjust the new test case to expect `lastName` and `firstName` normally?
- [x] Would it be helpful, if Zenodo stopped putting a clearly mis-matching CSL type in the JSON that Zotero parses, and instead send none? If yes, could we then omit both the ["fix"](https://github.com/zotero/translators/blame/master/Zenodo.js#L190-L197) and this "undo"?
- [x] Scaffold added `-` and `+` in the `doWeb` test output (near the bottom in the diff). [Not sure](https://www.mediawiki.org/wiki/Citoid/Creating_Zotero_translators#Write_test_cases) what those mean, but I guess both symbols need to be removed from the JSON block.