### PR TITLE
WIP: expand OSTI...js to DOE Code

### DIFF
--- a/OSTI Energy Citations.js
+++ b/OSTI Energy Citations.js
@@ -2,14 +2,14 @@
 	"translatorID": "0cdc6a07-38cf-4ec1-b9d5-7a3c0cc89b15",
 	"label": "OSTI Energy Citations",
 	"creator": "Michael Berkowitz",
-	"target": "^https?://www\\.osti\\.gov/(energycitations|scitech)",
+	"target": "^https?://www\\.osti\\.gov/(doecode|energycitations|scitech)",
 	"minVersion": "1.0.0b4.r5",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-07-27 10:41:29"
+	"lastUpdated": "2018-03-22 10:52:16"
 }
 
 /*


### PR DESCRIPTION
This is currently just a demo to discuss whether to expand this translator, or whether to write a new one.
After 199a680, using this translator returns a minimal citation:

```json
11:35:26 Returned item:
           {
             "creators": [],
             "notes": [],
             "tags": [],
             "seeAlso": [],
             "attachments": [
               {
                 "title": "Snapshot"
               }
             ],
             "url": "https://www.osti.gov/doecode/biblio/9158",
             "title": "Doe Code: Project Metadata",
             "abstractNote": "XMOF2D [...]",
             "language": "en",
             "libraryCatalog": "www.osti.gov",
             "accessDate": "CURRENT_TIMESTAMP",
             "itemType": "webpage",
             "shortTitle": "Doe Code"
           }
```

The goal here would be to get `"itemType": "computerProgram"`, fill `"creators": []`, etc. to further https://github.com/force11/force11-sciwg/issues/9