### PR TITLE
Increase text search results count for LoC and GBV

### DIFF
--- a/Gemeinsamer Bibliotheksverbund ISBN.js
+++ b/Gemeinsamer Bibliotheksverbund ISBN.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 8,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-04-13 13:41:00"
+	"lastUpdated": "2018-04-24 13:41:00"
 }
 
 /*
@@ -49,7 +49,7 @@ function doSearch(item) {
 		url = "http://sru.gbv.de/gvk?version=1.1&operation=searchRetrieve&query=pica.isb=" + queryISBN + " AND pica.mat%3DB&maximumRecords=1";
 	}
 	else if (item.query) {
-		url = "http://sru.gbv.de/gvk?version=1.1&operation=searchRetrieve&query=" + encodeURIComponent(item.query) + "&maximumRecords=50";
+		url = "http://sru.gbv.de/gvk?version=1.1&operation=searchRetrieve&query=" + encodeURIComponent(item.query) + "&maximumRecords=100";
 	}
 	
 	//Z.debug(url);

--- a/Library of Congress ISBN.js
+++ b/Library of Congress ISBN.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 8,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-04-13 13:41:00"
+	"lastUpdated": "2018-04-24 13:41:00"
 }
 
 
@@ -31,7 +31,7 @@ function doSearch(item) {
 		url = "http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=bath.ISBN=^" + ZU.cleanISBN(item.ISBN) + "&maximumRecords=1";
 	}
 	else if (item.query) {
-		url = "http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=" + encodeURIComponent(item.query) + "&maximumRecords=50";
+		url = "http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=" + encodeURIComponent(item.query) + "&maximumRecords=100";
 	}
 	
 	ZU.doGet(url, function (text) {


### PR DESCRIPTION
Increases text search results count because LoC and GBV have quite poor result ranking and sometimes the best results doesn't appear in the first 50 results.