### PR TITLE
Correctly set the id number of an item selected in the sidebar

### DIFF
--- a/HeinOnline.js
+++ b/HeinOnline.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2016-08-10 09:29:21"
+	"lastUpdated": "2018-04-27 02:53:31"
 }
 
 /*
@@ -103,15 +103,22 @@ function translateCOinS(COinS) {
 
 // Build URL for RIS, and for PDF if available
 function scrapePage(doc, url) {
-	var risPopupURL = getXPathStr("href", doc, '//form[@id="pagepicker"]//a[contains(@href, "PrintRequest")][1]');
-	if (risPopupURL) {
-		// If page has RIS, use that
-		var docParams = extractQueryValues(risPopupURL);
+	// We need the id= and the handle= of the current target item.
+	// From that, we can build URL for RIS.
+
+	// Check for an RIS popup link in the page.
+	var risPopupLink = getXPathStr("href", doc, '//form[@id="pagepicker"]//a[contains(@href, "PrintRequest")][1]');
+	if (risPopupLink) {
+		// Get the id from pageSelect.
+		var pageID = doc.getElementById("pageSelect").value;
+		// Get other parameters from the page URL.
+		var docParams = extractQueryValues(url);
+		// Compose the RIS link.
 		var risURL = docParams.base 
-			+ "CitationFile?handle=" + docParams.handle 
-			+ "&div=" + docParams.div 
-			+ "&id=" + docParams.id 
+			+ "CitationFile?kind=ris&handle=" + docParams.handle 
+			+ "&id=" + pageID 
 			+ "&base=js";
+		// updatediv apparently gives us a page that will refresh itself to the PDF.
 		var pdfPageURLs = doc.getElementsByClassName("updatediv");
 		ZU.doGet(risURL, function(ris) {
 			if (pdfPageURLs) {
@@ -176,7 +183,7 @@ function doWeb (doc,url) {
 			ZU.processDocuments(urls, scrapePage);
 		});
 	} else {
-		scrapePage(doc);
+		scrapePage(doc, url);
 	}
 }
 


### PR DESCRIPTION
This pull request addresses #1639, and one of two issues involved in a report to the [Zotero Forum](https://forums.zotero.org/discussion/71243/available-for-beta-testing-zotero-connector-target-selector#latest).

The issue addressed here is a straight-up bug in the translator, in code that I wrote. Single-item saves worked fine on the initial visit to a page, but retrieved incorrect metadata after selecting another item from the left-hand ToC listing in the page. I apparently didn't manually test that action when I wrote the translator, and it has lurked in there for yonks until a librarian called us on it.

The second issue is identified by @dstillman in the tracker issue and forum thread linked above.