### PR TITLE
Allow subdomains in Wiley Online Library.js

### DIFF
--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -2,14 +2,14 @@
 	"translatorID": "fe728bc9-595a-4f03-98fc-766f1d8d0936",
 	"label": "Wiley Online Library",
 	"creator": "Sean Takats, Michael Berkowitz, Avram Lyon and Aurimas Vinckevicius",
-	"target": "^https?://(besjournals\\.)?onlinelibrary\\.wiley\\.com[^/]*/(book|doi|toc|advanced/search|search-web/cochrane|cochranelibrary/search|o/cochrane/(clcentral|cldare|clcmr|clhta|cleed|clabout)/articles/.+/sect0\\.html)",
+	"target": "^https?://(\\w+\\.)?onlinelibrary\\.wiley\\.com[^/]*/(book|doi|toc|advanced/search|search-web/cochrane|cochranelibrary/search|o/cochrane/(clcentral|cldare|clcmr|clhta|cleed|clabout)/articles/.+/sect0\\.html)",
 	"minVersion": "3.1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-05-10 18:59:07"
+	"lastUpdated": "2018-05-21 15:05:09"
 }
 
 /*


### PR DESCRIPTION
For example:
* https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.15206
* https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/1365-2664.12762

Second case was already covered in #1644 but this fix here now
also allows now any other possible subdomain.

This solves #1663.