### PR TITLE
Update BibLaTeX translator - nodate, notitle, noauthor

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -15,7 +15,7 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2018-03-03 14:00:00"
+	"lastUpdated": "2018-06-04 15:00:00"
 }
 
 

--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -354,13 +354,13 @@ var citeKeyConversions = {
 		if (item.creators && item.creators[0] && item.creators[0].lastName) {
 			return item.creators[0].lastName.toLowerCase().replace(/ /g, "_").replace(/,/g, "");
 		}
-		return "";
+		return "noauthor";
 	},
 	"t": function (flags, item) {
 		if (item["title"]) {
 			return item["title"].toLowerCase().replace(citeKeyTitleBannedRe, "").split(/\s+/g)[0];
 		}
-		return "";
+		return "notitle";
 	},
 	"y": function (flags, item) {
 		if (item.date) {
@@ -369,7 +369,7 @@ var citeKeyConversions = {
 				return date.year;
 			}
 		}
-		return "????";
+		return "nodate";
 	}
 }
 


### PR DESCRIPTION
BibLaTeX exports a missing date with question marks, BibTeX exports a missing date with _nodate_

I changed the BibLaTeX translator to the same strings as the BibTeX translator.

My original problem is described here: https://forums.zotero.org/discussion/comment/309794