### PR TITLE
https URLs fixes: The Guardian and JSTOR

### DIFF
--- a/The Guardian.js
+++ b/The Guardian.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-04-26 07:58:02"
+	"lastUpdated": "2018-08-11 14:15:22"
 }
 
 /*
@@ -97,7 +97,12 @@ function scrape(doc, url) {
 			}
 		}
 		item.language = "en-GB";
-		var serie = ZU.xpathText(doc, '(//a[contains(@class, "content__series-label__link")])[1]');
+		// og:url does not preserve https prefixes, so use canonical link until fixed
+		var canonical = doc.querySelector('link[rel="canonical"]');
+		if (canonical) {
+			item.url = canonical.href;
+		}
+		var serie = ZU.xpathText(doc, '(//a[contains(@class, "content__label__link")])[1]');
 		if (serie=="The Observer") {
 			item.publicationTitle = "The Observer";
 			item.ISSN = "0029-7712";
@@ -142,17 +147,25 @@ var testCases = [
 				"libraryCatalog": "www.theguardian.com",
 				"publicationTitle": "The Guardian",
 				"section": "World news",
-				"url": "http://www.theguardian.com/world/2013/mar/05/hugo-chavez-dies-cuba",
+				"url": "https://www.theguardian.com/world/2013/mar/05/hugo-chavez-dies-cuba",
 				"attachments": [
 					{
 						"title": "Snapshot"
 					}
 				],
 				"tags": [
-					"Americas",
-					"Hugo Chávez",
-					"Venezuela",
-					"World news"
+					{
+						"tag": "Americas"
+					},
+					{
+						"tag": "Hugo Chávez"
+					},
+					{
+						"tag": "Venezuela"
+					},
+					{
+						"tag": "World news"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -196,24 +209,46 @@ var testCases = [
 				"publicationTitle": "The Guardian",
 				"section": "World news",
 				"shortTitle": "Revealed",
-				"url": "http://www.theguardian.com/world/2013/mar/06/pentagon-iraqi-torture-centres-link",
+				"url": "https://www.theguardian.com/world/2013/mar/06/pentagon-iraqi-torture-centres-link",
 				"attachments": [
 					{
 						"title": "Snapshot"
 					}
 				],
 				"tags": [
-					"Americas",
-					"David Petraeus",
-					"El Salvador",
-					"Iraq",
-					"Middle East and North Africa",
-					"Nicaragua",
-					"Torture",
-					"US foreign policy",
-					"US military",
-					"US news",
-					"World news"
+					{
+						"tag": "Americas"
+					},
+					{
+						"tag": "David Petraeus"
+					},
+					{
+						"tag": "El Salvador"
+					},
+					{
+						"tag": "Iraq"
+					},
+					{
+						"tag": "Middle East and North Africa"
+					},
+					{
+						"tag": "Nicaragua"
+					},
+					{
+						"tag": "Torture"
+					},
+					{
+						"tag": "US foreign policy"
+					},
+					{
+						"tag": "US military"
+					},
+					{
+						"tag": "US news"
+					},
+					{
+						"tag": "World news"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -241,20 +276,34 @@ var testCases = [
 				"libraryCatalog": "www.theguardian.com",
 				"publicationTitle": "The Guardian",
 				"section": "World news",
-				"url": "http://www.theguardian.com/world/2013/feb/26/football-heaven-god-play",
+				"url": "https://www.theguardian.com/world/2013/feb/26/football-heaven-god-play",
 				"attachments": [
 					{
 						"title": "Snapshot"
 					}
 				],
 				"tags": [
-					"Africa",
-					"Eric Cantona",
-					"Football",
-					"George Best",
-					"Religion",
-					"South Africa",
-					"World news"
+					{
+						"tag": "Africa"
+					},
+					{
+						"tag": "Eric Cantona"
+					},
+					{
+						"tag": "Football"
+					},
+					{
+						"tag": "George Best"
+					},
+					{
+						"tag": "Religion"
+					},
+					{
+						"tag": "South Africa"
+					},
+					{
+						"tag": "World news"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -283,20 +332,34 @@ var testCases = [
 				"publicationTitle": "The Guardian",
 				"section": "Media",
 				"shortTitle": "Peter Oborne",
-				"url": "http://www.theguardian.com/media/2015/feb/18/peter-oborne-daily-telegraph-newspaper-unprecedented",
+				"url": "https://www.theguardian.com/media/2015/feb/18/peter-oborne-daily-telegraph-newspaper-unprecedented",
 				"attachments": [
 					{
 						"title": "Snapshot"
 					}
 				],
 				"tags": [
-					"Barclay Brothers",
-					"Daily Telegraph",
-					"Media",
-					"Murdoch MacLennan",
-					"National newspapers",
-					"Newspapers",
-					"Newspapers & magazines"
+					{
+						"tag": "Barclay Brothers"
+					},
+					{
+						"tag": "Daily Telegraph"
+					},
+					{
+						"tag": "Media"
+					},
+					{
+						"tag": "Murdoch MacLennan"
+					},
+					{
+						"tag": "National newspapers"
+					},
+					{
+						"tag": "Newspapers"
+					},
+					{
+						"tag": "Newspapers & magazines"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -319,38 +382,132 @@ var testCases = [
 				"publicationTitle": "The Observer",
 				"section": "Books",
 				"shortTitle": "Christmas gifts 2011",
-				"url": "http://www.theguardian.com/books/2011/nov/27/christmas-gifts-2011-books-tree",
+				"url": "https://www.theguardian.com/books/2011/nov/27/christmas-gifts-2011-books-tree",
 				"attachments": [
 					{
 						"title": "Snapshot"
 					}
 				],
 				"tags": [
-					"Alan Hollinghurst",
-					"Art and design",
-					"Best books of the year",
-					"Biography",
-					"Books",
-					"Business and finance",
-					"Caitlin Moran",
-					"Charles Dickens",
-					"Christopher Hitchens",
-					"Comics and graphic novels",
-					"Culture",
-					"Fiction",
-					"Food and drink",
-					"Health",
-					"History",
-					"Julian Barnes",
-					"Magazines",
-					"Magnum",
-					"Poetry",
-					"Private Eye",
-					"Robert Harris",
-					"Science and nature",
-					"Thrillers",
-					"Tina Fey",
-					"mind and body"
+					{
+						"tag": "Alan Hollinghurst"
+					},
+					{
+						"tag": "Art and design books"
+					},
+					{
+						"tag": "Best books of the year"
+					},
+					{
+						"tag": "Biography books"
+					},
+					{
+						"tag": "Books"
+					},
+					{
+						"tag": "Business and finance books"
+					},
+					{
+						"tag": "Caitlin Moran"
+					},
+					{
+						"tag": "Charles Dickens"
+					},
+					{
+						"tag": "Christopher Hitchens"
+					},
+					{
+						"tag": "Comics and graphic novels"
+					},
+					{
+						"tag": "Culture"
+					},
+					{
+						"tag": "Fiction"
+					},
+					{
+						"tag": "Food and drink books"
+					},
+					{
+						"tag": "Health"
+					},
+					{
+						"tag": "History books"
+					},
+					{
+						"tag": "Julian Barnes"
+					},
+					{
+						"tag": "Magazines"
+					},
+					{
+						"tag": "Magnum"
+					},
+					{
+						"tag": "Poetry"
+					},
+					{
+						"tag": "Private Eye"
+					},
+					{
+						"tag": "Robert Harris"
+					},
+					{
+						"tag": "Science and nature books"
+					},
+					{
+						"tag": "Thrillers"
+					},
+					{
+						"tag": "Tina Fey"
+					},
+					{
+						"tag": "mind and body books"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.theguardian.com/books/2018/may/27/bullshit-jobs-a-theory-david-graeber-review-laboured-rant",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Bullshit Jobs: A Theory review – laboured rant about the world of work",
+				"creators": [
+					{
+						"firstName": "Andrew",
+						"lastName": "Anthony",
+						"creatorType": "author"
+					}
+				],
+				"date": "2018-05-27T08:00:20.000Z",
+				"ISSN": "0029-7712",
+				"abstractNote": "David Graeber’s snarky study of the meaningless nature of modern employment adds little to our understanding of it",
+				"language": "en-GB",
+				"libraryCatalog": "www.theguardian.com",
+				"publicationTitle": "The Observer",
+				"section": "Books",
+				"shortTitle": "Bullshit Jobs",
+				"url": "https://www.theguardian.com/books/2018/may/27/bullshit-jobs-a-theory-david-graeber-review-laboured-rant",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Books"
+					},
+					{
+						"tag": "Culture"
+					},
+					{
+						"tag": "Economics"
+					}
 				],
 				"notes": [],
 				"seeAlso": []

--- a/Wired.js
+++ b/Wired.js
@@ -1,0 +1,300 @@
+{
+	"translatorID": "f054a3d9-d705-4d2e-a96a-258508bebba3",
+	"label": "Wired",
+	"creator": "czar",
+	"target": "^https?://(www\\.)?wired\\.(com|co\\.uk)",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2018-08-11 14:19:06"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2018 czar
+	http://en.wikipedia.org/wiki/User_talk:Czar
+	
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+// attr()/text() v2 per https://github.com/zotero/translators/issues/1277
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
+
+
+function detectWeb(doc, url) {
+	if (/\/(\d{4}\/\d{2}|story|article)\//.test(url)) {
+		return "magazineArticle";
+	} else if (/\/(category|tag|topic)\/|search\/?\?q=|wired\.com\/?$|wired\.co\.uk\/?$/.test(url) && getSearchResults(doc, true)) {
+		return "multiple";
+	}
+}
+
+
+function scrape(doc, url) {
+	var translator = Zotero.loadTranslator('web');
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48'); // embedded metadata
+	translator.setDocument(doc);
+	
+	translator.setHandler('itemDone', function (obj, item) {
+		item.itemType = "magazineArticle";
+		if (url.includes("wired.co.uk/article")) {
+			item.publicationTitle = "Wired UK";
+			item.ISSN = "1357-0978";
+			item.date = Zotero.Utilities.strToISO(text(doc,'div.a-author__article-date')); // use LSON-LD when implemented in EM
+		} else { // if not wired.co.uk
+			item.publicationTitle = "Wired";
+			item.ISSN = "1059-1028";
+			item.date = attr(doc,'meta[name="DisplayDate"], meta[name="parsely-pub-date"]','content');
+			item.creators = [];
+			var authorMetadata = attr(doc,'meta[name="Author"], meta[name="parsely-author"]','content');
+			if (authorMetadata) {
+				item.creators.push(ZU.cleanAuthor(authorMetadata, "author"));
+			}
+			if (item.tags) { // catch volume/issue if in tags
+				var match = null;
+				for (let tag of item.tags) {
+					match = tag.match(/^(\d{2})\.(\d{2})$/);
+					if (match) {
+						item.volume = match[1];
+						item.issue = parseInt(match[2]);
+						item.tags.splice(item.tags.indexOf(tag),1);
+						break;
+					}
+				}
+			}
+		}
+		item.complete();
+	});
+	translator.getTranslatorObject(function(trans) {
+		trans.doWeb(doc, url);
+	});
+}
+
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('div.card-component h2, li.archive-item-component h2, section.c-card-section article.c-card h3');
+	var links = doc.querySelectorAll('.card-component__description > a:first-of-type, li.archive-item-component > a:first-of-type, section.c-card-section article.c-card > a');
+	for (let i=0; i<rows.length; i++) {
+		let href = links[i].href;
+		let title = ZU.trimInternal(rows[i].textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+
+function doWeb(doc, url) {
+	switch (detectWeb(doc, url)) {
+		case "multiple":
+			Zotero.selectItems(getSearchResults(doc, false), function (items) {
+				if (!items) {
+					return true;
+				}
+				var articles = [];
+				for (var i in items) {
+					articles.push(i);
+				}
+				ZU.processDocuments(articles, scrape);
+			});
+			break;
+		case "magazineArticle":
+			scrape(doc, url);
+			break;
+	}
+}
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.wired.com/2011/03/ff_kickstarter/",
+		"items": [
+			{
+				"itemType": "magazineArticle",
+				"title": "How Kickstarter Became a Lab for Daring Prototypes and Ingenious Products",
+				"creators": [
+					{
+						"firstName": "Carlye",
+						"lastName": "Adler",
+						"creatorType": "author"
+					}
+				],
+				"date": "2011-03-18",
+				"ISSN": "1059-1028",
+				"abstractNote": "A group of modern makers kick-started a website for passion projects and patrons.",
+				"issue": 4,
+				"language": "en-US",
+				"libraryCatalog": "www.wired.com",
+				"publicationTitle": "Wired",
+				"url": "https://www.wired.com/2011/03/ff_kickstarter/",
+				"volume": "19",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Kickstarter"
+					},
+					{
+						"tag": "Startups"
+					},
+					{
+						"tag": "features"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.com/story/in-defense-of-the-vegan-hot-dog/",
+		"items": [
+			{
+				"itemType": "magazineArticle",
+				"title": "In Defense of the Vegan Hot Dog",
+				"creators": [
+					{
+						"firstName": "Emily",
+						"lastName": "Dreyfuss",
+						"creatorType": "author"
+					}
+				],
+				"date": "2018-07-04T14:00:00.000Z",
+				"ISSN": "1059-1028",
+				"abstractNote": "One carnivore's advice: When a tofu dog snuggles up to your tube steak on the grill, don’t be a jerk about it.",
+				"libraryCatalog": "www.wired.com",
+				"publicationTitle": "Wired",
+				"url": "https://www.wired.com/story/in-defense-of-the-vegan-hot-dog/",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Cooking and Recipes"
+					},
+					{
+						"tag": "Food and Drink"
+					},
+					{
+						"tag": "grilling"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.com/tag/kickstarter/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.com/category/culture/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.com/search/?q=kickstarter&page=1&sort=score",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.co.uk/article/olafur-eliasson-little-sun-charge",
+		"items": [
+			{
+				"itemType": "magazineArticle",
+				"title": "Olafur Eliasson is Kickstarting a solar-powered phone charger",
+				"creators": [
+					{
+						"firstName": "James",
+						"lastName": "Temperton",
+						"creatorType": "author"
+					}
+				],
+				"date": "2015-09-03",
+				"ISSN": "1357-0978",
+				"abstractNote": "A high-performance, solar-powered phone charger designed by artist Olafur Eliasson and engineer Frederik Ottesen has raised more than €40,000 (£29,100) on Kickstarter",
+				"libraryCatalog": "www.wired.co.uk",
+				"publicationTitle": "Wired UK",
+				"url": "https://www.wired.co.uk/article/olafur-eliasson-little-sun-charge",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Design"
+					},
+					{
+						"tag": "Smartphones"
+					},
+					{
+						"tag": "Solar Power"
+					},
+					{
+						"tag": "Technology"
+					},
+					{
+						"tag": "Wired Video"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.com/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.co.uk/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.co.uk/topic/culture",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.wired.co.uk/search?q=kickstarter",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/


### PR DESCRIPTION
Noticed that a Wikipedia bot was correcting some `http` links to `https` from my citations so I checked and realized that the translators were not preserving the `https` properly from the link URLs

The Guardian and JSTOR use `https` stable URLs but their respective OpenGraph and RIS data use the outdated `http`. Until they catch up, this fix saves the correct `https` URL to the citation. It also:
- rewrites JSTOR's multi, which would break on journal issue ToCs, e.g., https://www.jstor.org/stable/i250748 (covers search and issue ToCs but test if I'm missing edge cases)
-  fixes a test on Wired, which should normally save `https` links
- fixes _The Observer_ detection, which was broken