### PR TITLE
[CrossRef] Fix conference publication title, place, and conference name lookup

### DIFF
--- a/CrossRef.js
+++ b/CrossRef.js
@@ -240,9 +240,9 @@ function processCrossRef(xmlOutput) {
 		metadataXML = ZU.xpath(itemXML, 'c:proceedings_metadata', ns);
 		seriesXML = ZU.xpath(metadataXML, 'c:proceedings_metadata', ns);
 
-		item.publicationTitle = ZU.xpathText(metadataXML, 'c:publisher/c:proceedings_title', ns);
-		item.place = ZU.xpathText(metadataXML, 'c:event_metadata/c:conference_location', ns);
-		item.conferenceName = ZU.xpathText(metadataXML, 'c:event_metadata/c:conference_name', ns);
+		item.publicationTitle = ZU.xpathText(metadataXML, 'c:proceedings_title', ns);
+		item.place = ZU.xpathText(itemXML, 'c:event_metadata/c:conference_location', ns);
+		item.conferenceName = ZU.xpathText(itemXML, 'c:event_metadata/c:conference_name', ns);
 	}
 
 	else if((itemXML = ZU.xpath(doiRecord, 'c:crossref/c:database', ns)).length) {

--- a/CrossRef.js
+++ b/CrossRef.js
@@ -9,7 +9,7 @@
 	"priority": 90,
 	"inRepository": true,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2018-04-19 05:16:03"
+	"lastUpdated": "2018-08-13 12:17:00"
 }
 
 /* CrossRef uses unixref; documentation at http://www.crossref.org/schema/documentation/unixref1.0/unixref.html */
@@ -481,6 +481,59 @@ var testCases = [
 				"libraryCatalog": "CrossRef"
 			}
 		]
+	},
+	{
+		"type": "search",
+		"input": {
+			"DOI":"10.1109/ISSCC.2017.7870285"
+		},
+		"items": [
+			{
+				"itemType": "conferencePaper",
+				"creators": [
+					{
+						"creatorType": "author",
+						"firstName": "Pen-Jui",
+						"lastName": "Peng"
+					},
+					{
+						"creatorType": "author",
+						"firstName": "Jeng-Feng",
+						"lastName": "Li"
+					},
+					{
+						"creatorType": "author",
+						"firstName": "Li-Yang",
+						"lastName": "Chen"
+					},
+					{
+						"creatorType": "author",
+						"firstName": "Jri",
+						"lastName": "Lee"
+					}
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [],
+				"publicationTitle": "2017 IEEE International Solid-State Circuits Conference (ISSCC)",
+				"place": "San Francisco, CA, USA",
+				"conferenceName": "2017 IEEE International Solid- State Circuits Conference - (ISSCC)",
+				"abstractNote": null,
+				"language": null,
+				"ISBN": "978-1-5090-3758-2",
+				"ISSN": null,
+				"publisher": "IEEE",
+				"edition": null,
+				"volume": null,
+				"date": "2/2017",
+				"pages": "110-111",
+				"DOI": "10.1109/ISSCC.2017.7870285",
+				"url": "http://ieeexplore.ieee.org/document/7870285/",
+				"title": "6.1 A 56Gb/s PAM-4/NRZ transceiver in 40nm CMOS"
+			}
+		]
 	}
 ]
 /** END TEST CASES **/
+


### PR DESCRIPTION
This fixes the lookup of publication title, place and conference name lookup for conference publications using CrossRef.

Perhaps adding a test case for such `conferencePublication` types is in order, but I can't get Scaffold to run the tests for the Crossref translator. The relevant XML structure was derived from [this example](http://www.crossref.org/openurl/?pid=zter:zter321&url_ver=Z39.88-2004&&rft_id=info:doi/10.1109/ISSCC.2017.7870285&noredirect=true&format=unixref). 