### PR TITLE
Fix patents export for BibLaTeX

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -562,28 +562,26 @@ function encodeFilePathComponent(value) {
 				// see https://tex.stackexchange.com/questions/447383/biblatex-biber-patent-citation-support-based-on-zoterobbl-output/447508
 				if (!item.patentNumber) {
 					writeField("type", "patent");
-				}	else if (item.patentNumber.startsWith("US")) {
-						writeField("type", "patentus");
-						writeField("number", item.patentNumber.replace(/^US/, ""));
+				} else if (item.patentNumber.startsWith("US")) {
+					writeField("type", "patentus");
+					writeField("number", item.patentNumber.replace(/^US/, ""));
 				} else if (item.patentNumber.startsWith("EP")) {
-						writeField("type", "patenteu");
-						writeField("number", item.patentNumber.replace(/^EP/, ""));
+					writeField("type", "patenteu");
+					writeField("number", item.patentNumber.replace(/^EP/, ""));
 				} else if (item.patentNumber.startsWith("GB")) {
-						writeField("type", "patentuk");
-						writeField("number", item.patentNumber.replace(/^GB/, ""));
+					writeField("type", "patentuk");
+					writeField("number", item.patentNumber.replace(/^GB/, ""));
 				} else if (item.patentNumber.startsWith("DE")) {
-						writeField("type", "patentde");
-						writeField("number", item.patentNumber.replace(/^DE/, ""));
+					writeField("type", "patentde");
+					writeField("number", item.patentNumber.replace(/^DE/, ""));
 				} else if (item.patentNumber.startsWith("FR")) {
-						writeField("type", "patentfr");
-						writeField("number", item.patentNumber.replace(/^FR/, ""));
-				}
-				else {
+					writeField("type", "patentfr");
+					writeField("number", item.patentNumber.replace(/^FR/, ""));
+				} else {
 					writeField("type", "patent");
 					writeField("number", item.patentNumber);
 				}
 			}
-			
 
 			if (item.presentationType || item.manuscriptType) {
 				writeField("howpublished", item.presentationType || item.manuscriptType);

--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -15,9 +15,8 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2018-06-04 15:00:00"
+	"lastUpdated": "2018-09-07 17:20:00"
 }
-
 
 //%a = first listed creator surname
 //%y = year
@@ -38,6 +37,7 @@ var fieldMap = {
 	doi: "DOI",
 	series: "series",
 	shorttitle: "shortTitle",
+	holder: "assignee",
 	abstract: "abstractNote",
 	volumes: "numberOfVolumes",
 	version: "version",
@@ -310,7 +310,7 @@ function mapEscape(character) {
 	return alwaysMap[character];
 }
 
-// a little substitution function for BibTeX keys, where we don't want LaTeX 
+// a little substitution function for BibTeX keys, where we don't want LaTeX
 // escaping, but we do want to preserve the base characters
 
 function tidyAccents(s) {
@@ -421,7 +421,7 @@ function creatorCheck(item, ctype) {
 		//
 		// no matter what, we want to make sure we exclude
 		// " # % ' ( ) , = { } ~ and backslash
-		// however, we want to keep the base characters 
+		// however, we want to keep the base characters
 
 		basekey = tidyAccents(basekey);
 		basekey = basekey.replace(citeKeyCleanRe, "");
@@ -498,9 +498,9 @@ function encodeFilePathComponent(value) {
 			//e.g. where fieldname translation is dependent upon type, or special transformations
 			//has to be made
 
-			//all kinds of numbers
-			if (item.reportNumber || item.seriesNumber || item.patentNumber || item.billNumber || item.episodeNumber || item.number) {
-				writeField("number", item.reportNumber || item.seriesNumber || item.patentNumber || item.billNumber || item.episodeNumber || item.number);
+			//all kinds of numbers except patents, which need post-processing
+			if (item.reportNumber || item.seriesNumber || item.billNumber || item.episodeNumber || item.number && !item.patentNumber) {
+				writeField("number", item.reportNumber || item.seriesNumber || item.billNumber || item.episodeNumber || item.number);
 			}
 
 			//split numeric and nonnumeric issue specifications (for journals) into "number" and "issue"
@@ -558,7 +558,32 @@ function encodeFilePathComponent(value) {
 				writeField("type", "phdthesis");
 			} else if (item.manuscriptType || item.thesisType || item.websiteType || item.presentationType || item.reportType || item.mapType) {
 				writeField("type", item.manuscriptType || item.thesisType || item.websiteType || item.presentationType || item.reportType || item.mapType);
+			} else if (item.itemType == "patent") {
+				// see https://tex.stackexchange.com/questions/447383/biblatex-biber-patent-citation-support-based-on-zoterobbl-output/447508
+				if (!item.patentNumber) {
+					writeField("type", "patent");
+				}	else if (item.patentNumber.startsWith("US")) {
+						writeField("type", "patentus");
+						writeField("number", item.patentNumber.replace(/^US/, ""));
+				} else if (item.patentNumber.startsWith("EP")) {
+						writeField("type", "patenteu");
+						writeField("number", item.patentNumber.replace(/^EP/, ""));
+				} else if (item.patentNumber.startsWith("GB")) {
+						writeField("type", "patentuk");
+						writeField("number", item.patentNumber.replace(/^GB/, ""));
+				} else if (item.patentNumber.startsWith("DE")) {
+						writeField("type", "patentde");
+						writeField("number", item.patentNumber.replace(/^DE/, ""));
+				} else if (item.patentNumber.startsWith("FR")) {
+						writeField("type", "patentfr");
+						writeField("number", item.patentNumber.replace(/^FR/, ""));
+				}
+				else {
+					writeField("type", "patent");
+					writeField("number", item.patentNumber);
+				}
 			}
+			
 
 			if (item.presentationType || item.manuscriptType) {
 				writeField("howpublished", item.presentationType || item.manuscriptType);
@@ -628,7 +653,7 @@ function encodeFilePathComponent(value) {
 						creatorString = creatorString.replace(/ (and) /gi, ' {$1} ');
 					}
 
-					if (creator.creatorType == "author" || creator.creatorType == "interviewer" || creator.creatorType == "director" || creator.creatorType == "programmer" || creator.creatorType == "artist" || creator.creatorType == "podcaster" || creator.creatorType == "presenter") {
+					if (creator.creatorType == "author" || creator.creatorType == "interviewer" || creator.creatorType == "inventor" || creator.creatorType == "director" || creator.creatorType == "programmer" || creator.creatorType == "artist" || creator.creatorType == "podcaster" || creator.creatorType == "presenter") {
 						author += " and " + creatorString;
 					} else if (creator.creatorType == "bookAuthor") {
 						bookauthor += " and " + creatorString;
@@ -636,8 +661,6 @@ function encodeFilePathComponent(value) {
 						commentator += " and " + creatorString;
 					} else if (creator.creatorType == "editor") {
 						editor += " and " + creatorString;
-					} else if (creator.creatorType == "inventor") {
-						holder += " and " + creatorString;
 					} else if (creator.creatorType == "translator") {
 						translator += " and " + creatorString;
 					} else if (creator.creatorType == "seriesEditor") { //let's call them redacors


### PR DESCRIPTION
See https://tex.stackexchange.com/questions/447383/biblatex-biber-patent-citation-support-based-on-zoterobbl-output/447508?noredirect=1#comment1128794_447508

In short:
1) Inventors should export as authors; holders are assignees
2) There should be a type which ideally also reflects where the patent was granted -- we do this via the prefix of the patent number, which then gets removed.