### PR TITLE
Fix beck-online.js if no copyright info is given

### DIFF
--- a/beck-online.js
+++ b/beck-online.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2018-09-08 12:20:47"
+	"lastUpdated": "2018-09-11 07:17:21"
 }
 
 /*
@@ -270,7 +270,7 @@ function scrapeBook(doc, url) {
 	}
 	item.ISBN = text(doc, '#titelseitetext .__beck_titelei_impressum_isbn');
 	item.rights = text(doc, '#titelseitetext .__beck_titelei_impressum_p');
-	if (item.rights.includes("Beck")) {
+	if (item.rights && item.rights.includes("Beck")) {
 		item.publisher = "Verlag C. H. Beck";
 		item.place = "München";
 	}


### PR DESCRIPTION
e.g. https://beck-online.beck.de/?vpath=bibdata%2Fkomm%2FScheAnwHdb_5%2Fcont%2FScheAnwHdb%2Ehtm