### PR TITLE
Fix semantic scholar translator

### DIFF
--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-05 00:00:22"
+	"lastUpdated": "2018-09-11 19:58:38"
 }
 
 /*
@@ -46,11 +46,9 @@ function detectWeb(doc, url) {
 	if (url.includes('/search') || url.includes('/author/')) {
 		return 'multiple';
 	} else {
-		var citationElement = ZU.xpath(doc, '//cite[contains(@class,"formatted-citation--style-bibtex")]')[0];
-		if (citationElement) {
-			var type = citationElement.textContent.split("{")[0].replace("@", "");
-			return bibtex2zoteroTypeMap[type];
-		}
+		let citation = ZU.xpathText(doc, '//pre[@class="bibtex-citation"]');
+		let type = citation.split('{')[0].replace('@', '');
+		return bibtex2zoteroTypeMap[type];
 	}
 }
 
@@ -76,16 +74,9 @@ function getSearchResults(doc) {
 }
 
 function parseDocument(doc, url) {
-	var citationElement = ZU.xpath(doc, '//cite[contains(@class, "formatted-citation--style-bibtex")]');
+	let citation = ZU.xpathText(doc, '//pre[@class="bibtex-citation"]');
 	
-	if (!citationElement.length) {
-		return;
-	}
-	
-	var citation = citationElement[0].textContent;
-	citation = fixBibtex(citation);
-
-	var translator = Zotero.loadTranslator("import");
+	let translator = Zotero.loadTranslator("import");
 	translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
 	translator.setString(citation);
 	translator.setHandler("itemDone", function (obj, item) {
@@ -137,8 +128,10 @@ function parseDocument(doc, url) {
 			item.DOI = rawData.doiInfo.doi;
 		}
 		
-		if (rawData.keyPhrases) {
-			item.tags = rawData.keyPhrases;
+		if (rawData.entities) {
+			for (let entity of rawData.entities) {
+				item.tags.push(entity.name);
+			}
 		}
 
 		item.complete();
@@ -180,18 +173,11 @@ function fixPageRange(pageRange) {
 		return numbers[0] + '-' + numbers[1];
 	}
 }
-
-function fixBibtex(bibtex) {
-	// There's this issue where some characters with umlauts have unbalanced
-	// braces in the Semantic Scholar BibTeX, which kills the Zotero translator.
-	return bibtex.replace(/{\\\"{([A-Za-z])}[^}]/g, '\{\\"$1\}');
-}
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/TectoMT-Modular-NLP-Framework-Popel-Zabokrtsk%C3%BD/89fbfabca6b605e2b00a9d57880c241c17e84001",
-		"defer": true,
+		"url": "https://www.semanticscholar.org/paper/TectoMT%3A-Modular-NLP-Framework-Popel-Zabokrtsk%C3%BD/e1ea10a288632a4003a4221759bc7f7a2df36208",
 		"items": [
 			{
 				"itemType": "conferencePaper",
@@ -222,25 +208,52 @@ var testCases = [
 						"snapshot": false
 					},
 					{
-						"title": "TectoMT: Modular NLP Framework",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [
 					{
-						"tag": "Abokrtsk"
+						"tag": "Anaphora (linguistics)"
 					},
 					{
-						"tag": "Machine Translation"
+						"tag": "Language-independent specification"
 					},
 					{
-						"tag": "Pipeline"
+						"tag": "Machine translation"
 					},
 					{
-						"tag": "Tectomt"
+						"tag": "Multi-Purpose Viewer"
 					},
 					{
-						"tag": "Treex"
+						"tag": "Named-entity recognition"
+					},
+					{
+						"tag": "Natural language generation"
+					},
+					{
+						"tag": "Natural language processing"
+					},
+					{
+						"tag": "Open-source software"
+					},
+					{
+						"tag": "Parallel text"
+					},
+					{
+						"tag": "Parsing"
+					},
+					{
+						"tag": "Part-of-speech tagging"
+					},
+					{
+						"tag": "Sentence boundary disambiguation"
+					},
+					{
+						"tag": "Text corpus"
+					},
+					{
+						"tag": "Tokenization (data security)"
 					}
 				],
 				"notes": [],
@@ -250,12 +263,12 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/The-spring-in-the-arch-of-the-human-foot-Ker-Bennett/d37500a6a58fd55f0998ad0394bf076484e08fe8",
 		"defer": true,
+		"url": "https://www.semanticscholar.org/paper/The-spring-in-the-arch-of-the-human-foot-Ker-Bennett/8555e05e52e5c04017ca7a9c9da9ed9c39e4f9a0",
 		"items": [
 			{
 				"itemType": "journalArticle",
-				"title": "The spring in the arch of the human foot.",
+				"title": "The spring in the arch of the human foot",
 				"creators": [
 					{
 						"firstName": "Robert F.",
@@ -268,7 +281,7 @@ var testCases = [
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Susan R. S.",
+						"firstName": "S. R.",
 						"lastName": "Bibby",
 						"creatorType": "author"
 					},
@@ -278,14 +291,14 @@ var testCases = [
 						"creatorType": "author"
 					},
 					{
-						"firstName": "R. McNeill",
+						"firstName": "R. McN",
 						"lastName": "Alexander",
 						"creatorType": "author"
 					}
 				],
 				"date": "1987",
-				"abstractNote": "Large mammals, including humans, save much of the energy needed for running by means of elastic structures in their legs and feet. Kinetic and potential energy removed from the body in the first half of the stance phase is stored briefly as elastic strain energy and then returned in the second half by elastic recoil. Thus the animal runs in an analogous fashion to a rubber ball bouncing along. Among the elastic structures involved, the tendons of distal leg muscles have been shown to be important. Here we show that the elastic properties of the arch of the human foot are also important.",
-				"issue": "7000",
+				"DOI": "10.1038/325147a0",
+				"abstractNote": "Large mammals, including humans, save much of the energy needed for running by means of elastic structures in their legs and feet1,2. Kinetic and potential energy removed from the body in the first half of the stance phase is stored briefly as elastic strain energy and then returned in the second half by elastic recoil. Thus the animal runs in an analogous fashion to a rubber ball bouncing along. Among the elastic structures involved, the tendons of distal leg muscles have been shown to be important2,3. Here we show that the elastic properties of the arch of the human foot are also important.",
 				"itemID": "Ker1987TheSI",
 				"libraryCatalog": "Semantic Scholar",
 				"pages": "147-149",
@@ -298,7 +311,11 @@ var testCases = [
 						"snapshot": false
 					}
 				],
-				"tags": [],
+				"tags": [
+					{
+						"tag": "Tendon structure"
+					}
+				],
 				"notes": [],
 				"seeAlso": []
 			}
@@ -306,7 +323,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Foundations-of-Statistical-Natural-Language-Proces-Manning-Sch%C3%BCtze/06fd7d924d499fbc62ccbcc2e458fb6c187bcf6f",
+		"url": "https://www.semanticscholar.org/paper/Foundations-of-Statistical-Natural-Language-Manning-Sch%C3%BCtze/06fd7d924d499fbc62ccbcc2e458fb6c187bcf6f",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -319,44 +336,55 @@ var testCases = [
 					},
 					{
 						"firstName": "Hinrich",
-						"lastName": "Schüze",
+						"lastName": "Schütze",
 						"creatorType": "author"
 					}
 				],
-				"date": "2001",
+				"date": "2000",
 				"DOI": "10.1023/A:1011424425034",
-				"abstractNote": "In 1993, Eugene Charniak published a slim volume entitled Statistical Language Learning. At the time, empirical techniques to natural language processing were on the rise — in that year, Computational Linguistics published a special issue on such methods — and Charniak’s text was the first to treat the emerging field. Nowadays, the revolution has become the establishment; for instance, in 1998, nearly half the papers in Computational Linguistics concerned empirical methods (Hirschberg, 1998). Indeed, Christopher Manning and Hinrich Schütze’s new, by-no-means slim textbook on statistical NLP — strangely, the first since Charniak’s — begins, “The need for a thorough textbook for Statistical Natural Language Processing hardly needs to be argued for”. Indubitably so; the question is, is this it? Foundations of Statistical Natural Language Processing (henceforth FSNLP) is certainly ambitious in scope. True to its name, it contains a great deal of preparatory material, including: gentle introductions to probability and information theory; a chapter on linguistic concepts; and (a most welcome addition) discussion of the nitty-gritty of doing empirical work, ranging from lists of available corpora to indepth discussion of the critical issue of smoothing. Scattered throughout are also topics fundamental to doing good experimental work in general, such as hypothesis testing, cross-validation, and baselines. Along with these preliminaries, FSNLP covers traditional tools of the trade: Markov models, probabilistic grammars, supervised and unsupervised classification, and the vector-space model. Finally, several chapters are devoted to specific problems, among them lexicon acquisition, word sense disambiguation, parsing, machine translation, and information retrieval. (The companion website contains further useful material, including links to programs and a list of errata.) In short, this is a Big Book, and this fact alone already confers some benefits. For the researcher, FSNLP offers the convenience of one-stop shopping: at present, there is no other NLP reference in which standard empirical techniques, statistical tables, definitions of linguistics terms, and elements of information retrieval appear together; furthermore, the text also summarizes and critiques many individual research papers. Similarly, someone teaching a course on statistical NLP will appreciate the large number of topics FSNLP covers, allowing the tailoring of a syllabus to individual interests. And for those entering the field, the book records “folklore” knowledge that is typically acquired only by word of mouth",
-				"itemID": "Manning2001FoundationsOS",
+				"abstractNote": "In 1993, Eugene Charniak published a slim volume entitled Statistical Language Learning. At the time, empirical techniques for natural language processing were on the rise; that year, Computational Linguistics published a special issue on such methods, and Charniak’s text was the first to treat the emerging field. Nowadays, the revolution has become the establishment; in 1998, nearly half the papers in Computational Linguistics concerned empirical methods (Hirschberg 1998). Indeed, Christopher Manning and Hinrich Schütze’s new, by-no-means slim textbook on statistical NLP—strangely, the first since Charniak’s—begins “The need for a thorough textbook for Statistical Natural Language Processing hardly needs to be argued for.” Indubitably so; the question is, is this it? Foundations of Statistical Natural Language Processing (henceforth FSNLP) is certainly ambitious in scope. True to its name, it contains a great deal of preparatory material, including: gentle introductions to probability and information theory; a chapter on linguistic concepts; and (a most welcome addition) discussion of the nitty-gritty of doing empirical work, ranging from lists of available corpora to in-depth discussion of the critical issue of smoothing. Scattered throughout are also topics fundamental to doing good experimental work in general, such as hypothesis testing, cross-validation, and baselines. Along with these preliminaries, FSNLP covers traditional tools of the trade: Markov models, probabilistic grammars, supervised and unsupervised classification, and the vector-space model. Finally, several chapters are devoted to specific problems, among them lexicon acquisition, word sense disambiguation, parsing, machine translation, and information retrieval. (The companion website contains further useful material, including links to programs and a list of errata.) In short, this is a Big Book, and this fact alone confers some benefits. For the researcher, FSNLP offers the convenience of one-stop shopping: at present, there is no other NLP reference in which standard empirical techniques, statistical tables, definitions of linguistic terms, and elements of information retrieval appear together; furthermore, the text also summarizes and critiques many individual research papers. Similarly, someone teaching a course on statistical NLP will appreciate the large number of topics FSNLP covers, allowing the tailoring of a syllabus to individual in-",
+				"itemID": "Manning2000FoundationsOS",
 				"libraryCatalog": "Semantic Scholar",
-				"pages": "80-81",
-				"publicationTitle": "Information Retrieval",
-				"volume": "4",
+				"pages": "277-279",
+				"publicationTitle": "Computational Linguistics",
+				"volume": "26",
 				"attachments": [
 					{
 						"title": "Semantic Scholar Link",
 						"mimeType": "text/html",
 						"snapshot": false
-					},
-					{
-						"title": "Foundations of Statistical Natural Language Processing",
-						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [
 					{
-						"tag": "CFG"
+						"tag": "Algorithm"
 					},
 					{
-						"tag": "F Measure"
+						"tag": "Data compression"
+					},
+					{
+						"tag": "Grams"
+					},
+					{
+						"tag": "Language model"
+					},
+					{
+						"tag": "Linear interpolation"
 					},
 					{
 						"tag": "N-gram"
 					},
 					{
-						"tag": "PCFG"
+						"tag": "Natural language processing"
 					},
 					{
-						"tag": "POS"
+						"tag": "Protologism"
+					},
+					{
+						"tag": "Smoothing"
+					},
+					{
+						"tag": "Stochastic grammar"
 					}
 				],
 				"notes": [],
@@ -366,11 +394,11 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Interleukin-7-mediates-the-homeostasis-of-na%C3%AFve-an-Schluns-Kieper/aee7b854bed51120fe356a5792dfb22fec7cf2ae",
+		"url": "https://www.semanticscholar.org/paper/Interleukin-7-mediates-the-homeostasis-of-na%C3%AFve-and-Schluns-Kieper/aee7b854bed51120fe356a5792dfb22fec7cf2ae",
 		"items": [
 			{
 				"itemType": "journalArticle",
-				"title": "Interleukin-7 mediates the homeostasis of naïe and memory CD8 T cells in vivo",
+				"title": "Interleukin-7 mediates the homeostasis of naïve and memory CD8 T cells in vivo",
 				"creators": [
 					{
 						"firstName": "Kimberly S.",
@@ -408,7 +436,26 @@ var testCases = [
 						"snapshot": false
 					}
 				],
-				"tags": [],
+				"tags": [
+					{
+						"tag": "Chronic Lymphocytic Leukemia"
+					},
+					{
+						"tag": "Homeostasis"
+					},
+					{
+						"tag": "Interleukin-7"
+					},
+					{
+						"tag": "Leukemia, B-Cell"
+					},
+					{
+						"tag": "Memory Disorders"
+					},
+					{
+						"tag": "T-Lymphocyte"
+					}
+				],
 				"notes": [],
 				"seeAlso": []
 			}
@@ -420,7 +467,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "journalArticle",
-				"title": "Primäre Ziliendyskinesie in Öterreich",
+				"title": "Primäre Ziliendyskinesie in Österreich",
 				"creators": [
 					{
 						"firstName": "Irena",
@@ -468,7 +515,65 @@ var testCases = [
 						"snapshot": false
 					}
 				],
-				"tags": [],
+				"tags": [
+					{
+						"tag": "Addison Disease"
+					},
+					{
+						"tag": "Apoptosis"
+					},
+					{
+						"tag": "Bronchiectasis"
+					},
+					{
+						"tag": "Bronchitis, Chronic"
+					},
+					{
+						"tag": "Chronic sinusitis"
+					},
+					{
+						"tag": "Ciliary Motility Disorders"
+					},
+					{
+						"tag": "Dyskinesia, Drug-Induced"
+					},
+					{
+						"tag": "Epilepsy"
+					},
+					{
+						"tag": "Extraction"
+					},
+					{
+						"tag": "Infant, Newborn"
+					},
+					{
+						"tag": "Kartagener Syndrome"
+					},
+					{
+						"tag": "Neoplasms, Unknown Primary"
+					},
+					{
+						"tag": "Osteoarthritis, Spine"
+					},
+					{
+						"tag": "Physical medicine/manipulation"
+					},
+					{
+						"tag": "Recurrent pneumonia"
+					},
+					{
+						"tag": "Situs Inversus"
+					},
+					{
+						"tag": "Surgical Wound Infection"
+					},
+					{
+						"tag": "Surgical operation note:Find:Pt:Outpatient:Doc:Nurse"
+					},
+					{
+						"tag": "Urinary Calculi"
+					}
+				],
 				"notes": [],
 				"seeAlso": []
 			}
@@ -476,143 +581,8 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/The-German-hospital-malnutrition-study-Pirlich-Schuetz/b59a79b2194f5f6d82b06593c23f25f67fbef512",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "The German hospital malnutrition study.",
-				"creators": [
-					{
-						"firstName": "Matthias",
-						"lastName": "Pirlich",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Tatjana",
-						"lastName": "Schuetz",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Kristina",
-						"lastName": "Norman",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Sylvia",
-						"lastName": "Gastell",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Heinrich Josef",
-						"lastName": "Lüke",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Stephan",
-						"lastName": "Bischoff",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Ulrich",
-						"lastName": "Bolder",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "T. M.",
-						"lastName": "Frieling",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Helge",
-						"lastName": "Güdenzoph",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Kristian",
-						"lastName": "Hahn",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "K. W.",
-						"lastName": "Jauch",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Karin",
-						"lastName": "Schindler",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Jügen",
-						"lastName": "Stein",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Dorothee",
-						"lastName": "Volkert",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Arved",
-						"lastName": "Weimann",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Hansjög",
-						"lastName": "Werner",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Christiane",
-						"lastName": "Wolf",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Gudrun",
-						"lastName": "Zücher",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Peter",
-						"lastName": "Bauer",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Herbert",
-						"lastName": "Lochs",
-						"creatorType": "author"
-					}
-				],
-				"date": "2006",
-				"abstractNote": "BACKGROUND & AIMS\nMalnutrition is frequently observed in chronic and severe diseases and associated with impaired outcome. In Germany general data on prevalence and impact of hospital malnutrition are missing.\n\n\nMETHODS\nNutritional state was assessed by subjective global assessment (SGA) and by anthropometric measurements in 1,886 consecutively admitted patients in 13 hospitals (n=1,073, university hospitals; n=813, community or teaching hospitals). Risk factors for malnutrition and the impact of nutritional status on length of hospital stay were analyzed.\n\n\nRESULTS\nMalnutrition was diagnosed in 27.4% of patients according to SGA. A low arm muscle area and arm fat area were observed in 11.3% and 17.1%, respectively. Forty-three % of patients 70 years old were malnourished compared to only 7.8% of patients <30 years. The highest prevalence of malnutrition was observed in geriatric (56.2%), oncology (37.6%), and gastroenterology (32.6%) departments. Multivariate analysis revealed three independent risk factors: higher age, polypharmacy, and malignant disease (all P<0.01). Malnutrition was associated with an 43% increase of hospital stay (P<0.001).\n\n\nCONCLUSIONS\nIn German hospitals every fourth patient is malnourished. Malnutrition is associated with increased length of hospital stay. Higher age, malignant disease and major comorbidity were found to be the main contributors to malnutrition. Adequate nutritional support should be initiated in order to optimize the clinical outcome of these patients.",
-				"issue": "4",
-				"itemID": "Pirlich2006TheGH",
-				"libraryCatalog": "Semantic Scholar",
-				"pages": "563-572",
-				"publicationTitle": "Clinical nutrition",
-				"volume": "25",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "The German hospital malnutrition study.",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/author/Josie-Holmes/27569076",
+		"url": "https://www.semanticscholar.org/author/Jane-Holmes/3023517",
 		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/
-


### PR DESCRIPTION
The semantic scholar website has changed a bit, breaking the xpaths in the translator. Summary of changes:

* Fix BibTeX xPath
* They now call "tags" "entities", so amended for this
* Updated tests accordingly (some of the other data on the website also changed, which the new tests reflect)
* Removed test which had incorrectly parsed data on their side ([link](https://www.semanticscholar.org/paper/The-German-hospital-malnutrition-study.-Pirlich-Schuetz/b59a79b2194f5f6d82b06593c23f25f67fbef512) to paper, see authors `Jürgen Weiner. Benno Stein` conflated)
* Removed fix for BibTeX export having a bracket mismatch -- this is fixed on their end now.

Thanks!