### PR TITLE
Fix Galegroup

### DIFF
--- a/Gale Databases.js
+++ b/Gale Databases.js
@@ -15,7 +15,7 @@
 /*
 	***** BEGIN LICENSE BLOCK *****
 	
-	Galegroup Translator - Copyright © 2012 Sebastian Karcher 
+	Galegroup Translator - Copyright © 2018 Sebastian Karcher 
 	This file is part of Zotero.
 	
 	Zotero is free software: you can redistribute it and/or modify
@@ -137,7 +137,7 @@ function doWeb(doc, url) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://go.galegroup.com.libezproxy2.syr.edu/ps/retrieve.do?tabID=T002&resultListType=RESULT_LIST&searchResultsType=SingleTab&searchType=BasicSearchForm&currentPosition=8&docId=GALE%7CA213083272&docType=Report&sort=Relevance&contentSegment=&prodId=PROF&contentSet=GALE%7CA213083272&searchId=R1&userGroupName=nysl_ce_syr&inPS=true",
+		"url": "http://go.galegroup.com/ps/retrieve.do?tabID=T002&resultListType=RESULT_LIST&searchResultsType=SingleTab&searchType=BasicSearchForm&currentPosition=8&docId=GALE%7CA213083272&docType=Report&sort=Relevance&contentSegment=&prodId=PROF&contentSet=GALE%7CA213083272&searchId=R1&userGroupName=nysl_ce_syr&inPS=true",
 		"items": [
 			{
 				"itemType": "magazineArticle",
@@ -163,7 +163,7 @@ var testCases = [
 				"pages": "122+",
 				"publicationTitle": "Counselor Education and Supervision",
 				"shortTitle": "Improving a counselor education Web site through usability testing",
-				"url": "http://link.galegroup.com.libezproxy2.syr.edu/apps/doc/A213083272/PROF?u=nysl_ce_syr&sid=PROF&xid=a8973dd8",
+				"url": "http://link.galegroup.com/apps/doc/A213083272/PROF?u=nysl_ce_syr&sid=PROF&xid=a8973dd8",
 				"volume": "49",
 				"attachments": [
 					{

--- a/Gale Databases.js
+++ b/Gale Databases.js
@@ -65,7 +65,7 @@ function detectWeb(doc, url) {
 
 function composeAttachment(doc, url) {
 	var pdfurl = attr(doc, '#docTools-pdf a', 'href');
-	if(pdfurl) {
+	if (pdfurl) {
 		return {
 			url: pdfurl,
 			title: "Full Text PDF",
@@ -79,19 +79,19 @@ function composeAttachment(doc, url) {
 
 function parseRis(text, attachment) {
 	text = text.trim();
-	//gale puts issue numbers in M1
+	// gale puts issue numbers in M1
 	text = text.replace(/M1\s*\-/g, "IS  -");
-	//L2 is probably meant to be UR, but we can ignore it altogether
+	// L2 is probably meant to be UR, but we can ignore it altogether
 	text = text.replace(/^L2\s+-.+\n/gm, '');
-	//we can map copyright notes via CR
+	// we can map copyright notes via CR
 	text = text.replace(/^N1(?=\s+-\s+copyright)/igm, 'CR');
-	//Z.debug(text);
+	// Z.debug(text);
 	
 	var translator = Zotero.loadTranslator("import");
 	translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
 	translator.setString(text);
 	translator.setHandler("itemDone", function (obj, item) {
-		if(attachment) item.attachments.push(attachment);
+		if (attachment) item.attachments.push(attachment);
 		item.complete();
 	});
 	translator.translate();
@@ -106,7 +106,7 @@ function scrape(doc, url) {
 	var productName = attr(doc, 'input.citationToolsData', 'data-productname');
  
 	var documentData = '{"docId":"' + docId +'","documentUrl":"' + documentUrl + '","productName":"' + productName + '"}';
-	var post = "citationFormat=RIS&documentData=" +encodeURIComponent(documentData).replace(/%20/g, "+");
+	var post = "citationFormat=RIS&documentData=" + encodeURIComponent(documentData).replace(/%20/g, "+");
 	var attachment = composeAttachment(doc, url);
 	// Z.debug(post)
 	ZU.doPost(postURL, post, function(text){
@@ -116,7 +116,7 @@ function scrape(doc, url) {
 }
 
 function doWeb(doc, url) {
-	if(detectWeb(doc, url) == "multiple") {
+	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
 			if (!items) {
 				return true;

--- a/Gale Databases.js
+++ b/Gale Databases.js
@@ -45,9 +45,7 @@ function getSearchResults(doc, checkOnly) {
 		rows = doc.querySelectorAll('ul.SearchResultsList p.subTitle a.title');
 	}
 	for (var i=0; i<rows.length; i++) {
-		// Adjust if required, use Zotero.debug(rows) to check
 		var href = rows[i].href;
-		// Adjust if required, use Zotero.debug(rows) to check
 		var title = ZU.trimInternal(rows[i].textContent);
 		if (!href || !title) continue;
 		if (checkOnly) return true;

--- a/Gale Databases.js
+++ b/Gale Databases.js
@@ -1,5 +1,5 @@
 {
-	"translatorID": "58ab2618-4a25-4b9b-83a7-80cd0259f896",
+	"translatorID": "e3748cf3-36dc-4816-bf86-95a0b63feb03",
 	"label": "Gale Databases",
 	"creator": "Sebastian Karcher",
 	"target": "^https?://go\\.galegroup\\.com/",

--- a/Gale Databases.js
+++ b/Gale Databases.js
@@ -1,0 +1,197 @@
+{
+	"translatorID": "58ab2618-4a25-4b9b-83a7-80cd0259f896",
+	"label": "Gale Databases",
+	"creator": "Sebastian Karcher",
+	"target": "^https?://go\\.galegroup\\.com/",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2018-09-24 01:37:06"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Galegroup Translator - Copyright © 2012 Sebastian Karcher 
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null}
+
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+
+	var rows = doc.querySelectorAll('ul.SearchResultsList span.title a.documentLink');
+	if (!rows.length) {
+		rows = doc.querySelectorAll('ul.SearchResultsList p.subTitle a.title');
+	}
+	for (var i=0; i<rows.length; i++) {
+		// Adjust if required, use Zotero.debug(rows) to check
+		var href = rows[i].href;
+		// Adjust if required, use Zotero.debug(rows) to check
+		var title = ZU.trimInternal(rows[i].textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+function detectWeb(doc, url) {
+	if (url.includes('/retrieve.do') && text(doc, 'li.docTools-citation')) {
+		return "journalArticle";
+	}
+	
+	else if (getSearchResults(doc, true)) return "multiple";
+}
+
+
+function composeAttachment(doc, url) {
+	var pdfurl = attr(doc, '#docTools-pdf a', 'href');
+	if(pdfurl) {
+		return {
+			url: pdfurl,
+			title: "Full Text PDF",
+			mimeType:'application/pdf'
+		};
+	} else {
+		return {document: doc, title: "Snapshot"};
+	}
+}
+
+
+function parseRis(text, attachment) {
+	text = text.trim();
+	//gale puts issue numbers in M1
+	text = text.replace(/M1\s*\-/g, "IS  -");
+	//L2 is probably meant to be UR, but we can ignore it altogether
+	text = text.replace(/^L2\s+-.+\n/gm, '');
+	//we can map copyright notes via CR
+	text = text.replace(/^N1(?=\s+-\s+copyright)/igm, 'CR');
+	//Z.debug(text);
+	
+	var translator = Zotero.loadTranslator("import");
+	translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
+	translator.setString(text);
+	translator.setHandler("itemDone", function (obj, item) {
+		if(attachment) item.attachments.push(attachment);
+		item.complete();
+	});
+	translator.translate();
+}
+
+
+function scrape(doc, url) {
+	var postURL = "/ps/citationtools/rest/cite/download";
+	
+	var docId = attr(doc, 'input.citationToolsData', 'data-docid');
+	var documentUrl = attr(doc, 'input.citationToolsData', 'data-url');
+	var productName = attr(doc, 'input.citationToolsData', 'data-productname');
+ 
+	var documentData = '{"docId":"' + docId +'","documentUrl":"' + documentUrl + '","productName":"' + productName + '"}';
+	var post = "citationFormat=RIS&documentData=" +encodeURIComponent(documentData).replace(/%20/g, "+");
+	var attachment = composeAttachment(doc, url);
+	// Z.debug(post)
+	ZU.doPost(postURL, post, function(text){
+		// Z.debug(text);
+		parseRis(text, attachment);
+	});
+}
+
+function doWeb(doc, url) {
+	if(detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return true;
+			}
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrape);
+		});
+	} else {
+		scrape(doc, url);
+	}
+}
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "http://go.galegroup.com.libezproxy2.syr.edu/ps/retrieve.do?tabID=T002&resultListType=RESULT_LIST&searchResultsType=SingleTab&searchType=BasicSearchForm&currentPosition=8&docId=GALE%7CA213083272&docType=Report&sort=Relevance&contentSegment=&prodId=PROF&contentSet=GALE%7CA213083272&searchId=R1&userGroupName=nysl_ce_syr&inPS=true",
+		"items": [
+			{
+				"itemType": "magazineArticle",
+				"title": "Improving a counselor education Web site through usability testing: the bibliotherapy education project",
+				"creators": [
+					{
+						"lastName": "McMillen",
+						"firstName": "Paula S.",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Pehrsson",
+						"firstName": "Dale-Elizabeth",
+						"creatorType": "author"
+					}
+				],
+				"date": "December 2009",
+				"ISSN": "00110035",
+				"archive": "Educators Reference Complete",
+				"issue": "2",
+				"language": "English",
+				"libraryCatalog": "Gale",
+				"pages": "122+",
+				"publicationTitle": "Counselor Education and Supervision",
+				"shortTitle": "Improving a counselor education Web site through usability testing",
+				"url": "http://link.galegroup.com.libezproxy2.syr.edu/apps/doc/A213083272/PROF?u=nysl_ce_syr&sid=PROF&xid=a8973dd8",
+				"volume": "49",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Bibliotherapy"
+					},
+					{
+						"tag": "Counseling"
+					},
+					{
+						"tag": "Counselling"
+					},
+					{
+						"tag": "Usability testing"
+					},
+					{
+						"tag": "Web sites (World Wide Web)"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Galegroup.js
+++ b/Galegroup.js
@@ -46,7 +46,7 @@ function getSearchResults(doc) {
 		return results;
 	}
 	
-	//  Ecco
+	// Ecco
 	results = ZU.xpath(doc, '//div[@id="resultsBox"]//li[@class="resrow"]');
 	if (results.length) {
 		results.linkXPath = './/div[@class="pic_Title"]/a';
@@ -72,7 +72,7 @@ function getSearchResults(doc) {
 	}
 	
 
-	//Archives Unbound
+	// Archives Unbound
 	results = ZU.xpath(doc, '//div[@id="resultsTable"]/div');
 	if (results.length) {
 		results.linkXPath = './/span[@class="title"]//a';
@@ -80,7 +80,7 @@ function getSearchResults(doc) {
 		return results;
 	}
 	
-	//Gale NewsVault
+	// Gale NewsVault
 	results = ZU.xpath(doc, '//*[@id="results_list"]/div[contains(@class,"resultList")]');
 	if (results.length) {
 		results.linkXPath = './div[@class="pub_details"]//li[@class="resultInfo"]/p//a';
@@ -158,7 +158,7 @@ function composeRisUrlTDA(url) {
 function composeAttachmentDefault(doc, url) {
 	var pdf = !!(doc.getElementById('pdfLink') || doc.getElementById('docTools-pdf'));
 	var attachment = ZU.xpath(doc, '//*[@id="docTools-download"]/a[./@href]')[0];
-	if (attachment && pdf /* HTML currently pops up a download dialog for HTML attachments */) {
+	if (attachment && pdf ) {
 		url = attachment.href;
 		return {
 			url: url.replace(/#.*/, '').replace(/\/[^\/?]+(?=\?|$)/, '/downloadDocument.do')
@@ -200,13 +200,13 @@ function composeAttachmentTDA(doc, url) {
 
 function parseRis(text, attachment) {
 	text = text.trim();
-	//gale puts issue numbers in M1
+	// gale puts issue numbers in M1
 	text = text.replace(/M1\s*\-/g, "IS  -");
-	//L2 is probably meant to be UR, but we can ignore it altogether
+	// L2 is probably meant to be UR, but we can ignore it altogether
 	text = text.replace(/^L2\s+-.+\n/gm, '');
-	//we can map copyright notes via CR
+	// we can map copyright notes via CR
 	text = text.replace(/^N1(?=\s+-\s+copyright)/igm, 'CR');
-	//Z.debug(text);
+	// Z.debug(text);
 	
 	var translator = Zotero.loadTranslator("import");
 	translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
@@ -286,7 +286,9 @@ function doWeb(doc, url) {
 		
 		processPage(doc, url);
 	}
-}/** BEGIN TEST CASES **/
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/Galegroup.js
+++ b/Galegroup.js
@@ -2,14 +2,14 @@
 	"translatorID": "4ea89035-3dc4-4ae3-b22d-726bc0d83a64",
 	"label": "Galegroup",
 	"creator": "Sebastian Karcher and Aurimas Vinckevicius",
-	"target": "^https?://(find|go)\\.galegroup\\.com",
+	"target": "^https?://go.galegroup\\.com/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
-	"lastUpdated": "2017-01-01 15:20:39"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2018-09-24 00:54:53"
 }
 
 /*
@@ -33,168 +33,52 @@
 	
 	***** END LICENSE BLOCK *****
 */
-function getSearchResults(doc) {
-	//Gale Virtual Reference Library
-	var results = ZU.xpath(doc, '//*[@id="SearchResults"]//section[@class="resultsBody"]/ul/li');
-	if (results.length) {
-		results.linkXPath = './p[@class="subTitle"]/a';
-		Z.debug("Using GVRL");
-		composeAttachment = composeAttachmentGVRL;
-		composeRisUrl = composeRisUrlGVRL;
-		return results;
-	}
-	
-	//Academic OneFile
-	//Academic ASAP
-	results = ZU.xpath(doc, '//div[@id="resultsBox"]//li[@class="resrow"]');
-	if (results.length) {
-		results.linkXPath = './/div[@class="pic_Title"]/a';
-		Z.debug("Academic, but using GVRL");
-		composeAttachment = composeAttachmentGVRL;
-		composeRisUrl = composeRisUrlGVRL;
-		return results;
-	}
-	
-	//LegalTrac
-	results = ZU.xpath(doc, '//*[@id="sr_ul"]/li');
-	if (results.length) {
-		results.linkXPath = './/span[@class="title"]/a';
-		Z.debug("LegalTrac, but using GVRL");
-		composeAttachment = composeAttachmentGVRL;
-		composeRisUrl = composeRisUrlGVRL;
-		return results;
-	}
-	
-	//Literature Resource Center
-	results = ZU.xpath(doc, '//div[@id="resultsTable"]/div');
-	if (results.length) {
-		results.linkXPath = './/span[@class="title"]/a';
-		Z.debug("LRC, but using GVRL");
-		composeAttachment = composeAttachmentGVRL;
-		composeRisUrl = composeRisUrlGVRL;
-		return results;
-	}
-	
-	//Gale NewsVault
-	results = ZU.xpath(doc, '//*[@id="results_list"]/div[contains(@class,"resultList")]');
-	if (results.length) {
-		results.linkXPath = './div[@class="pub_details"]//li[@class="resultInfo"]/p//a';
-		Z.debug("Using GNV");
-		composeAttachment = composeAttachmentGNV;
-		composeRisUrl = composeRisUrlGNV;
-		return results;
-	}
-	
-	/** TODO: **/
-//	//19th century UK periodicals
-//	results = ZU.xpath(doc, '//*[@id="content"]//table[@class="resultstable"]//tr[@class="selectedRow" or @class="unselectedRow"]');
-//	if (results.length) {
-//		results.linkXPath = './/b/a[contains(@href, "retrieve.do")]';
-//		composeAttachment = composeAttachmentUKPC;
-//		composeRisUrl = composeRisUrlUKPC;
-//		return results;
-//	}
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null}
 
-	//Declassified Documents Reference System
-	
-	//"Full Citation" metadata:
-	//  The Making of Modern Law (multiple)
-	//  Sabin Americana 1500-1926
-	
-	//British Newspapers
-	//Burney Collection Newspapers
-	
-	//Eighteenth Cnetury Collection Online
-	//  works, but no PDFs
-	
-	//Biography in Context
-	
-	//Old InfoTrac ?? (various)
-	
-	return [];
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+
+	var rows = doc.querySelectorAll('ul.SearchResultsList span.title a.documentLink');
+	if (!rows.length) {
+		rows = doc.querySelectorAll('ul.SearchResultsList p.subTitle a.title');
+	}
+	for (var i=0; i<rows.length; i++) {
+	    // Adjust if required, use Zotero.debug(rows) to check
+		var href = rows[i].href;
+		// Adjust if required, use Zotero.debug(rows) to check
+		var title = ZU.trimInternal(rows[i].textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
 }
-
 function detectWeb(doc, url) {
-	if (url.indexOf('/newspaperRetrieve.do') != -1) {
-		return "newspaperArticle";
-	}
-	
-	if (url.indexOf('/retrieve.do') != -1
-		|| url.indexOf('/i.do') != -1
-		|| url.indexOf('/infomark.do') != -1) {
-		
-		if (url.indexOf('/ecco/') != -1) return "book";
-		
+	if (url.includes('/retrieve.do')) {
+		// there is no reasonable way to get to real item types
 		return "journalArticle";
 	}
 	
-	if (getSearchResults(doc).length) return "multiple";
+	else if (getSearchResults(doc, true)) return "multiple";
 }
 
-var composeRisUrl;
 
-function composeRisUrlGNV(url) {
-	return url.replace(/#.*/,'').replace(/\/[^\/?]+(?=\?|$)/, '/centralizedGenerateCitation.do')
-		.replace(/\bactionString=[^&]*&?/g, '').replace(/\bcitationFormat=[^&]*&?/g, '')
-		+ '&actionString=FormatCitation&citationFormat=ENDNOTE';
-}
-
-function composeRisUrlGVRL(url) {
-	return url.replace(/#.*/,'').replace(/\/[^\/?]+(?=\?|$)/, '/generateCitation.do')
-		.replace(/\bactionString=[^&]*&?/g, '').replace(/\bcitationFormat=[^&]*&?/g, '')
-		.replace(/\&u=/, "&userGroupName=").replace(/\&id=/, "&docId=") //for bookmarked pages
-		+ '&actionString=FormatCitation&citationFormat=ENDNOTE';
-}
-
-// The Times Digital Archive
-function composeRisUrlTDA(url) {
-	if (url.indexOf('relevancePageBatch=') != -1) {
-		url = url.replace(/\bdocId=[^&]*&?/g, "").replace(/\&relevancePageBatch=/, "&docId=");
-	}
-	return url.replace(/#.*/,'').replace(/\/[^\/?]+(?=\?|$)/, '/generateCitation.do')
-		.replace(/\bactionString=[^&]*&?/g, '').replace(/\bcitationFormat=[^&]*&?/g, '')
-		+ '&actionString=FormatCitation&citationFormat=ENDNOTE';
-}
-
-var composeAttachment;
-
-function composeAttachmentGVRL(doc, url) {
-	var pdf = !!(doc.getElementById('pdfLink') || doc.getElementById('docTools-pdf'));
-	var attachment = ZU.xpath(doc, '//*[@id="docTools-download"]/a[./@href]')[0];
-	if (attachment && pdf /* HTML currently pops up a download dialog for HTML attachments */) {
-		url = attachment.href;
+function composeAttachment(doc, url) {
+	var pdfurl = attr(doc, '#docTools-pdf a', 'href');
+	if(pdfurl) {
 		return {
-			url: url.replace(/#.*/, '').replace(/\/[^\/?]+(?=\?|$)/, '/downloadDocument.do')
-				.replace(/\b(?:actionCmd|downloadFormat)=[^&]*&?/g, '')
-				+ '&actionCmd=DO_DOWNLOAD_DOCUMENT&downloadFormat=' + (pdf?'PDF':'HTML'),
-			title: "Full Text " + (pdf?'PDF':'HTML'),
-			mimeType: pdf?'application/pdf':'text/html'
+			url: pdfurl,
+			title: "Full Text PDF",
+			mimeType:'application/pdf'
 		};
 	} else {
 		return {document: doc, title: "Snapshot"};
 	}
 }
 
-function composeAttachmentGNV(doc, url) {
-	var lowerLimit = ZU.xpathText(doc, '//form[@id="resultsForm"]/input[@name="pdfLowerLimit"]/@value') || '1';
-	var upperLimit = ZU.xpathText(doc, '//form[@id="resultsForm"]/input[@name="pdfHigherLimit"]/@value') || lowerLimit;
-	var numPages = ZU.xpathText(doc, '//form[@id="resultsForm"]/input[@name="noOfPages"]/@value') || (upperLimit - lowerLimit + 1);
-	return {
-		url: url.replace(/#.*/,'').replace(/\/[^\/?]+(?=\?|$)/, '/downloadDocument.do')
-			.replace(/\b(?:scale|orientation|docType|pageIndex|relatedDocId|isIllustration|imageId|aCmnd|recNum|pageRange|noOfPages)=[^&]*&?/g, '')
-			+ '&scale=&orientation=&docType=&pageIndex=1&relatedDocId=&isIllustration=false'
-			+ '&imageId=&aCmnd=PDFFormat&recNum=&' + 'noOfPages=' + numPages + '&pageRange=' + lowerLimit + '-' + upperLimit,
-		title: 'Full Text PDF',
-		mimeType: 'application/pdf'
-	};
-}
-
-function composeAttachmentTDA(doc, url) {
-	if (url.indexOf('relevancePageBatch=') != -1) {
-		url = url.replace(/\bdocId=[^&]*&?/g, "").replace(/\&relevancePageBatch=/, "&docId=");
-	}
-	return composeAttachmentGNV(doc, url);
-}
 
 function parseRis(text, attachment) {
 	text = text.trim();
@@ -210,66 +94,44 @@ function parseRis(text, attachment) {
 	translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
 	translator.setString(text);
 	translator.setHandler("itemDone", function (obj, item) {
-		if (attachment) item.attachments.push(attachment);
+		if(attachment) item.attachments.push(attachment);
 		item.complete();
 	});
 	translator.translate();
 }
 
-function processArticles(articles) {
-	var article;
-	while (article = articles.shift()) {
-		ZU.processDocuments(article, function(doc, url) {
-			processPage(doc, url);
-			processArticles(articles);
-		});
-	}
-}
 
-function processPage(doc, url) {
+function scrape(doc, url) {
+	var postURL = "/ps/citationtools/rest/cite/download";
+	
+	var docId = attr(doc, 'input.citationToolsData', 'data-docid');
+	var documentUrl = attr(doc, 'input.citationToolsData', 'data-url');
+	var productName = attr(doc, 'input.citationToolsData', 'data-productname');
+ 
+	var documentData = '{"docId":"' + docId +'","documentUrl":"' + documentUrl + '","productName":"' + productName + '"}';
+	var post = "citationFormat=RIS&documentData=" +encodeURIComponent(documentData).replace(/%20/g, "+");
 	var attachment = composeAttachment(doc, url);
-	Z.debug(composeRisUrl(url))
-	ZU.doGet(composeRisUrl(url), function(text) {
+	// Z.debug(post)
+	ZU.doPost(postURL, post, function(text){
+		// Z.debug(text);
 		parseRis(text, attachment);
 	});
 }
 
 function doWeb(doc, url) {
-	if (detectWeb(doc, url) == "multiple") {
-		var results = getSearchResults(doc);
-		var items = {};
-		for (var i=0, n=results.length; i<n; i++) {
-			var link = ZU.xpath(results[i], results.linkXPath)[0];
-			if (!link) continue;
-			
-			items[link.href] = ZU.trimInternal(link.textContent);
-		}
-		
-		Zotero.selectItems(items, function (items) {
-			if (!items) return true;
-			
+	if(detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return true;
+			}
 			var articles = [];
 			for (var i in items) {
 				articles.push(i);
 			}
-			processArticles(articles);
+			ZU.processDocuments(articles, scrape);
 		});
 	} else {
-		if (doc.title.indexOf('NewsVault') != -1) {
-			Z.debug("Using GNV");
-			composeAttachment = composeAttachmentGNV;
-			composeRisUrl = composeRisUrlGNV;
-		} else if (doc.title.indexOf('The Times Digital Archive') != -1) {
-			Z.debug("Using TDA");
-			composeAttachment = composeAttachmentTDA;
-			composeRisUrl = composeRisUrlTDA;
-		} else {
-			Z.debug("Using GVRL");
-			composeAttachment = composeAttachmentGVRL;
-			composeRisUrl = composeRisUrlGVRL;
-		}
-		
-		processPage(doc, url);
+		scrape(doc, url);
 	}
 }
 /** BEGIN TEST CASES **/

--- a/Galegroup.js
+++ b/Galegroup.js
@@ -55,7 +55,7 @@ function getSearchResults(doc) {
 		return results;
 	}
 	
-	// Time Literary Supplement 
+	// Time Literary Supplement & Times Digital Archive
 	results = ZU.xpath(doc, '//div[@id="results_list"]/ul[@class="resultsListBox"]');
 	if (results.length) {
 		results.linkXPath = './/p[@class="articleTitle"]//a';
@@ -309,64 +309,5 @@ function doWeb(doc, url) {
 		processPage(doc, url);
 	}
 }/** BEGIN TEST CASES **/
-var testCases = [
-	{
-		"type": "web",
-		"url": "http://go.galegroup.com.libezproxy2.syr.edu/ps/retrieve.do?tabID=T002&resultListType=RESULT_LIST&searchResultsType=SingleTab&searchType=BasicSearchForm&currentPosition=8&docId=GALE%7CA213083272&docType=Report&sort=Relevance&contentSegment=&prodId=PROF&contentSet=GALE%7CA213083272&searchId=R1&userGroupName=nysl_ce_syr&inPS=true",
-		"items": [
-			{
-				"itemType": "magazineArticle",
-				"title": "Improving a counselor education Web site through usability testing: the bibliotherapy education project",
-				"creators": [
-					{
-						"lastName": "McMillen",
-						"firstName": "Paula S.",
-						"creatorType": "author"
-					},
-					{
-						"lastName": "Pehrsson",
-						"firstName": "Dale-Elizabeth",
-						"creatorType": "author"
-					}
-				],
-				"date": "December 2009",
-				"ISSN": "00110035",
-				"archive": "Educators Reference Complete",
-				"issue": "2",
-				"language": "English",
-				"libraryCatalog": "Gale",
-				"pages": "122+",
-				"publicationTitle": "Counselor Education and Supervision",
-				"shortTitle": "Improving a counselor education Web site through usability testing",
-				"url": "http://link.galegroup.com/apps/doc/A213083272/PROF?u=nysl_ce_syr&sid=PROF&xid=a8973dd8",
-				"volume": "49",
-				"attachments": [
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [
-					{
-						"tag": "Bibliotherapy"
-					},
-					{
-						"tag": "Counseling"
-					},
-					{
-						"tag": "Counselling"
-					},
-					{
-						"tag": "Usability testing"
-					},
-					{
-						"tag": "Web sites (World Wide Web)"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	}
-]
+var testCases = []
 /** END TEST CASES **/


### PR DESCRIPTION
This works for all standard Gale databases and is greatly simplified. A 
small subset of Gale looks completely different & it makes little sense 
to put/keep those in the same translator:
- NewsVault
- Archives Unbound
- The Times Digital Archive
- The Times Literary Supplement Historical Archive, 1902-2013
- Eighteenth Century Collections Online

There already is a separate translator for GaleGDC.

No tests -- while there are permalinks, those include the university username...