### PR TITLE
Update translator for Open Journal Systems

### DIFF
--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -74,7 +74,6 @@ function doWeb(doc, url) {
 		var pdfUrl = doc.querySelector("a.obj_galley_link.pdf");
 		//add linked PDF if there isn't one listed in the header
 		if (!pdfAttachment && pdfUrl) { 
-			Z.debug("hereherehere");
 			item.attachments.push({
 				title: "Full Text PDF",
 				mimeType: "application/pdf",

--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-06-18 22:34:25"
+	"lastUpdated": "2018-10-04 03:01:31"
 }
 
 function detectWeb(doc, url) {
 	var pkpLibraries = ZU.xpath(doc, '//script[contains(@src, "/lib/pkp/js/")]');
 	if ( ZU.xpathText(doc, '//a[@id="developedBy"]/@href') == 'http://pkp.sfu.ca/ojs/' ||	//some sites remove this
-		pkpLibraries.length >= 10) {
+		pkpLibraries.length >= 1) {
 		return 'journalArticle';
 	}
 }
@@ -61,11 +61,25 @@ function doWeb(doc, url) {
 			item.abstractNote = ZU.xpathText(doc, '//div[@id="articleAbstract"]/div[1]');
 		}
 		
+		var pdfAttachment = false;
+		
 		//some journals link to a PDF view page in the header, not the PDF itself
 		for (var i=0; i<item.attachments.length; i++) {
 			if (item.attachments[i].mimeType == 'application/pdf') {
+				pdfAttachment = true;
 				item.attachments[i].url = item.attachments[i].url.replace(/\/article\/view\//, '/article/download/');
 			}
+		}
+		
+		var pdfUrl = doc.querySelector("a.obj_galley_link.pdf");
+		//add linked PDF if there isn't one listed in the header
+		if (!pdfAttachment && pdfUrl) { 
+			Z.debug("hereherehere");
+			item.attachments.push({
+				title: "Full Text PDF",
+				mimeType: "application/pdf",
+				url: pdfUrl.href.replace(/\/article\/view\//, '/article/download/')
+			});
 		}
 
 		item.complete();
@@ -720,6 +734,45 @@ var testCases = [
 					"storytelling",
 					"vanderbilt"
 				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://jms.uwinnipeg.ca/index.php/jms/article/view/1369",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Mennonites in Unexpected Places: Sociologist and Settler in Latin America",
+				"creators": [
+					{
+						"firstName": "Ben",
+						"lastName": "Nobbs-Thiessen",
+						"creatorType": "author"
+					}
+				],
+				"date": "2012-12-18",
+				"ISSN": "08245053",
+				"language": "en",
+				"libraryCatalog": "jms.uwinnipeg.ca",
+				"pages": "203-224",
+				"publicationTitle": "Journal of Mennonite Studies",
+				"rights": "Copyright (c)",
+				"shortTitle": "Mennonites in Unexpected Places",
+				"url": "http://jms.uwinnipeg.ca/index.php/jms/article/view/1369",
+				"volume": "28",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					},
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}

--- a/RDF.js
+++ b/RDF.js
@@ -13,7 +13,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-05-08 19:39:38"
+	"lastUpdated": "2018-10-04 02:07:05"
 }
 
 /*
@@ -513,6 +513,7 @@ function detectType(newItem, node, ret) {
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
+                case 'text.serial.journal':
 					t.dc = 'journalArticle';
 					break;
 				case 'newsitem':
@@ -861,7 +862,7 @@ function importItem(newItem, node) {
 		var creatorType = possibleCreatorTypes[i];
 		if (creatorType == "author") {
 			creators = getFirstResults(node, [n.bib+"authors", n.so+"author",
-				n.so+"creator", n.dc+"creator", n.dc1_0+"creator",
+				n.so+"creator", n.dc+"creator", n.dc+"creator.PersonalName", n.dc1_0+"creator",
 				n.dcterms+"creator", n.eprints+"creators_name",
 				n.dc+"contributor", n.dc1_0+"contributor", n.dcterms+"contributor"]);
 		} else if (creatorType == "editor" || creatorType == "contributor") {
@@ -921,12 +922,12 @@ function importItem(newItem, node) {
 	
 	// volume
 	newItem.volume = getFirstResults([container, node, containerPublicationVolume, containerPeriodical], [n.prism+"volume", n.prism2_0+"volume", n.prism2_1+"volume",
-			n.eprints+"volume", n.bibo+"volume", n.dcterms+"citation.volume", n.so+"volumeNumber"], true);
+			n.eprints+"volume", n.bibo+"volume", n.dc+"source.Volume", n.dcterms+"citation.volume", n.so+"volumeNumber"], true);
 	
 	// issue
 	if (container) {
 		newItem.issue = getFirstResults([container, node], [n.prism+"number", n.prism2_0+"number", n.prism2_1+"number",
-			n.eprints+"number", n.bibo+"issue", n.dcterms+"citation.issue", n.so+"issueNumber"], true);
+			n.eprints+"number", n.bibo+"issue", n.dc+"source.Issue", n.dcterms+"citation.issue", n.so+"issueNumber"], true);
 	}
 
 	// these mean the same thing
@@ -938,7 +939,7 @@ function importItem(newItem, node) {
 	newItem.versionNumber = newItem.edition;
 	
 	// pages
-	newItem.pages = getFirstResults(node, [n.bib+"pages", n.eprints+"pagerange", n.prism2_0+"pageRange", n.prism2_1+"pageRange", n.bibo+"pages", n.so+"pagination"], true);
+	newItem.pages = getFirstResults(node, [n.bib+"pages", n.eprints+"pagerange", n.prism2_0+"pageRange", n.prism2_1+"pageRange", n.bibo+"pages", n.dc+"identifier.pageNumber", n.so+"pagination"], true);
 	if (!newItem.pages) {
 		var pages = [];
 		var spage = getFirstResults(node, [n.prism+"startingPage", n.prism2_0+"startingPage", n.prism2_1+"startingPage", n.bibo+"pageStart", n.dcterms+"relation.spage", n.so+"pageStart"], true),
@@ -1065,8 +1066,8 @@ function importItem(newItem, node) {
 		}
 	}
 	
-	// ISSN, if encoded per PRISM (DC uses "identifier")
-	newItem.ISSN = getFirstResults([container, node, containerPeriodical, containerPublicationVolume], [n.prism+"issn", n.prism2_0+"issn", n.prism2_1+"issn", n.eprints+"issn", n.bibo+"issn",
+	// ISSN, if encoded per PRISM
+	newItem.ISSN = getFirstResults([container, node, containerPeriodical, containerPublicationVolume], [n.prism+"issn", n.prism2_0+"issn", n.prism2_1+"issn", n.eprints+"issn", n.bibo+"issn", n.dc+"source.ISSN",
 		n.prism+"eIssn", n.prism2_0+"eIssn", n.prism2_1+"eIssn", n.bibo+"eissn", n.so+"issn"], true) || newItem.ISSN;
 	// ISBN from PRISM or OG
 	newItem.ISBN = getFirstResults((container ? container : node), [n.prism2_1+"isbn", n.bibo+"isbn", n.bibo+"isbn13", n.bibo+"isbn10", n.book+"isbn", n.so+"isbn"], true) || newItem.ISBN;

--- a/RDF.js
+++ b/RDF.js
@@ -513,7 +513,7 @@ function detectType(newItem, node, ret) {
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
-                case 'text.serial.journal':
+				case 'text.serial.journal':
 					t.dc = 'journalArticle';
 					break;
 				case 'newsitem':


### PR DESCRIPTION
This update brings compatibility with recent versions of Open Journal Systems. 

Two small changes were made to the actual OJS translator:
* Only one `<script>` link containing `/lib/pkp/js` is required for detectWeb(). One is all I had in my live example. (Previously it expected >= 10.)
* The new code looks for an `<a>` link to the PDF view if a PDF attachment is not linked in the header.

Most of the changes are located in RDF.js, adding Dublin Core elements and values that are used by OJS. Some of these might be used by other systems, but at least one -- using "Text.Serial.Journal" as the default value for DC.Type -- appears unique to OJS. DC.Creator.PersonalName is also not commonly used elsewhere. The need for these changes seems to date to OJS moving metadata to plugins two years ago (pkp/pkp-lib#1815). It was probably not noticed by many because most OJS installations have citation_* metadata.