### PR TITLE
ORCID does not provide put-codes anymore in the website

### DIFF
--- a/ORCID.js
+++ b/ORCID.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-07-11 15:36:09"
+	"lastUpdated": "2018-10-11 20:21:52"
 }
 
 /*
@@ -36,19 +36,6 @@
 */
 
 
-function getIds(doc,  url) {
-	var rows = ZU.xpath(doc, '//ul[@id="body-work-list"]//li[@orcid-put-code]');
-	var items = {};
-	for (var i=0; i<rows.length; i++) {
-		var id = rows[i].getAttribute("orcid-put-code");
-		var title = ZU.xpathText(rows[i], './/h3/span[@ng-bind="work.title.value"]');
-		items[id] = title;
-	}
-	//Z.debug(items);
-	return items;
-}
-
-
 function detectWeb(doc, url) {
 	//check that orcid can be found
 	var orcid = doc.getElementById("orcid-id");
@@ -56,8 +43,8 @@ function detectWeb(doc, url) {
 		Z.debug("Error: No ORCID found in this page");
 		return false;
 	}
-	//check that work ids can be found
-	if (getIds(doc, url) !== null) {
+	//check that some works are listed on that page
+	if (ZU.xpath(doc, '//ul[@id="body-work-list"]/li') !== null) {
 		return "multiple";
 	}
 }
@@ -66,9 +53,6 @@ function detectWeb(doc, url) {
 function lookupWork(workid, orcid) {
 	var callApi = 'https://pub.orcid.org/v2.0/' + orcid + '/work/' + workid;
 	ZU.doGet(callApi, function(text){
-		//Z.debug(callApi);
-		//Z.debug(text);
-		
 		var translator = Zotero.loadTranslator("import");
 		translator.setTranslator("bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7");//CSL JSON
 		translator.setString(text);
@@ -81,15 +65,35 @@ function lookupWork(workid, orcid) {
 function doWeb(doc, url) {
 	var orcid = doc.getElementById("orcid-id");
 	orcid = orcid.textContent.replace('https://orcid.org/', '');
-	Zotero.selectItems(getIds(doc, url), function (items) {
-		if (!items) {
-			return true;
+	var callApi = 'https://pub.orcid.org/v2.0/' + orcid + '/works';
+	ZU.doGet(callApi, function(text) {
+		// Z.debug(text);
+		var parser = new DOMParser();
+		var doc = parser.parseFromString(text, "application/xml");
+		var namespace = {"work" : "http://www.orcid.org/ns/work"};
+		var items = ZU.xpath(doc, '//work:work-summary', namespace);
+		var putCodes = {};
+		for (let item of items) {
+			let code = item.getAttribute('put-code');
+			let title = ZU.xpathText(item, './work:title', namespace);
+			putCodes[code] = title.trim();
 		}
-		for (var i in items) {
-			lookupWork(i, orcid);
-		}
+		Zotero.selectItems(putCodes, function (items) {
+			if (!items) {
+				return true;
+			}
+			for (var i in items) {
+				lookupWork(i, orcid);
+			}
+		});
 	});
-}/** BEGIN TEST CASES **/
+	// The /works endpoint does currently not support CSL-JSON diretly,
+	// otherwise we could simplify with
+	// ZU.doGet(callApi, function(text) {
+	// }, undefined, undefined, {"Accept" : "application/vnd.citationstyles.csl+json"});
+	
+}
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/ORCID.js
+++ b/ORCID.js
@@ -44,7 +44,7 @@ function detectWeb(doc, url) {
 		return false;
 	}
 	//check that some works are listed on that page
-	if (ZU.xpath(doc, '//ul[@id="body-work-list"]/li') !== null) {
+	if (ZU.xpath(doc, '//ul[@id="body-work-list"]/li').length) {
 		return "multiple";
 	}
 }

--- a/ORCID.js
+++ b/ORCID.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-10-11 20:21:52"
+	"lastUpdated": "2018-10-12 18:52:49"
 }
 
 /*
@@ -70,12 +70,16 @@ function doWeb(doc, url) {
 		// Z.debug(text);
 		var parser = new DOMParser();
 		var doc = parser.parseFromString(text, "application/xml");
-		var namespace = {"work" : "http://www.orcid.org/ns/work"};
-		var items = ZU.xpath(doc, '//work:work-summary', namespace);
+		var namespaces = {
+			"work": "http://www.orcid.org/ns/work",
+			"activities": "http://www.orcid.org/ns/activities"
+		};
+		var items = ZU.xpath(doc, '//activities:group', namespaces);
 		var putCodes = {};
 		for (let item of items) {
-			let code = item.getAttribute('put-code');
-			let title = ZU.xpathText(item, './work:title', namespace);
+			let work = ZU.xpath(item, './work:work-summary', namespaces)[0];
+			let code = work.getAttribute('put-code');
+			let title = ZU.xpathText(work, './/work:title', namespaces);
 			putCodes[code] = title.trim();
 		}
 		Zotero.selectItems(putCodes, function (items) {
@@ -87,12 +91,8 @@ function doWeb(doc, url) {
 			}
 		});
 	});
-	// The /works endpoint does currently not support CSL-JSON diretly,
-	// otherwise we could simplify with
-	// ZU.doGet(callApi, function(text) {
-	// }, undefined, undefined, {"Accept" : "application/vnd.citationstyles.csl+json"});
-	
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{


### PR DESCRIPTION
We need now first an API call to receive the put-codes,
with which we then can do calls for an individual work
in CSL-JSON.

Fix issue reported https://forums.zotero.org/discussion/74029/problem-to-download-publictions-from-orcid-to-zotero