### PR TITLE
Open Journal Systems: Get metadata for articles in galley view (need for OJS 3)

### DIFF
--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -23,7 +23,7 @@ function detectWeb(doc, url) {
 function doWeb(doc, url) {
 	// In OJS 3, up to at least version 3.1.1-2, the PDF view does not
 	// include metadata, so we must get it from the article landing page.
-	var urlParts = doc.location.href.match(/(.+\/article\/view\/)([^/]+)\/[^/]+/);
+	var urlParts = url.match(/(.+\/article\/view\/)([^/]+)\/[^/]+/);
 	if (urlParts) { //PDF view
 		ZU.processDocuments(urlParts[1] + urlParts[2], scrape);
 	} else { //Article view

--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -74,7 +74,6 @@ function doWeb(doc, url) {
 		var pdfUrl = doc.querySelector("a.obj_galley_link.pdf");
 		//add linked PDF if there isn't one listed in the header
 		if (!pdfAttachment && pdfUrl) { 
-			Z.debug("hereherehere");
 			item.attachments.push({
 				title: "Full Text PDF",
 				mimeType: "application/pdf",

--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-06-18 22:34:25"
+	"lastUpdated": "2018-10-04 03:01:31"
 }
 
 function detectWeb(doc, url) {
 	var pkpLibraries = ZU.xpath(doc, '//script[contains(@src, "/lib/pkp/js/")]');
 	if ( ZU.xpathText(doc, '//a[@id="developedBy"]/@href') == 'http://pkp.sfu.ca/ojs/' ||	//some sites remove this
-		pkpLibraries.length >= 10) {
+		pkpLibraries.length >= 1) {
 		return 'journalArticle';
 	}
 }
@@ -61,11 +61,25 @@ function doWeb(doc, url) {
 			item.abstractNote = ZU.xpathText(doc, '//div[@id="articleAbstract"]/div[1]');
 		}
 		
+		var pdfAttachment = false;
+		
 		//some journals link to a PDF view page in the header, not the PDF itself
 		for (var i=0; i<item.attachments.length; i++) {
 			if (item.attachments[i].mimeType == 'application/pdf') {
+				pdfAttachment = true;
 				item.attachments[i].url = item.attachments[i].url.replace(/\/article\/view\//, '/article/download/');
 			}
+		}
+		
+		var pdfUrl = doc.querySelector("a.obj_galley_link.pdf");
+		//add linked PDF if there isn't one listed in the header
+		if (!pdfAttachment && pdfUrl) { 
+			Z.debug("hereherehere");
+			item.attachments.push({
+				title: "Full Text PDF",
+				mimeType: "application/pdf",
+				url: pdfUrl.href.replace(/\/article\/view\//, '/article/download/')
+			});
 		}
 
 		item.complete();
@@ -720,6 +734,45 @@ var testCases = [
 					"storytelling",
 					"vanderbilt"
 				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://jms.uwinnipeg.ca/index.php/jms/article/view/1369",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Mennonites in Unexpected Places: Sociologist and Settler in Latin America",
+				"creators": [
+					{
+						"firstName": "Ben",
+						"lastName": "Nobbs-Thiessen",
+						"creatorType": "author"
+					}
+				],
+				"date": "2012-12-18",
+				"ISSN": "08245053",
+				"language": "en",
+				"libraryCatalog": "jms.uwinnipeg.ca",
+				"pages": "203-224",
+				"publicationTitle": "Journal of Mennonite Studies",
+				"rights": "Copyright (c)",
+				"shortTitle": "Mennonites in Unexpected Places",
+				"url": "http://jms.uwinnipeg.ca/index.php/jms/article/view/1369",
+				"volume": "28",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					},
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}

--- a/Open Journal Systems.js
+++ b/Open Journal Systems.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-10-04 03:01:31"
+	"lastUpdated": "2018-10-12 17:46:47"
 }
 
 function detectWeb(doc, url) {
@@ -21,6 +21,17 @@ function detectWeb(doc, url) {
 }
 
 function doWeb(doc, url) {
+	// In OJS 3, up to at least version 3.1.1-2, the PDF view does not
+	// include metadata, so we must get it from the article landing page.
+	var urlParts = doc.location.href.match(/(.+\/article\/view\/)([^/]+)\/[^/]+/);
+	if (urlParts) { //PDF view
+		ZU.processDocuments(urlParts[1] + urlParts[2], scrape);
+	} else { //Article view
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, url) {
 	//use Embeded Metadata
 	var trans = Zotero.loadTranslator('web');
 	trans.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
@@ -85,7 +96,6 @@ function doWeb(doc, url) {
 	});
 
 	trans.translate();
-
 }
 /** BEGIN TEST CASES **/
 var testCases = [
@@ -769,6 +779,46 @@ var testCases = [
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://journals.sfu.ca/jmde/index.php/jmde_1/article/view/100/115",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "The Value of Evaluation Standards: A Comparative Assessment",
+				"creators": [
+					{
+						"firstName": "Robert",
+						"lastName": "Picciotto",
+						"creatorType": "author"
+					}
+				],
+				"date": "2007/12/18",
+				"ISSN": "1556-8180",
+				"issue": "3",
+				"language": "en",
+				"libraryCatalog": "journals.sfu.ca",
+				"pages": "30-59",
+				"publicationTitle": "Journal of MultiDisciplinary Evaluation",
+				"rights": "Copyright (c)",
+				"shortTitle": "The Value of Evaluation Standards",
+				"url": "http://journals.sfu.ca/jmde/index.php/jmde_1/article/view/100",
+				"volume": "2",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot"
 					}
 				],
 				"tags": [],

--- a/RDF.js
+++ b/RDF.js
@@ -13,7 +13,7 @@
 	"inRepository": true,
 	"translatorType": 1,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-05-08 19:39:38"
+	"lastUpdated": "2018-10-04 02:07:05"
 }
 
 /*
@@ -513,6 +513,7 @@ function detectType(newItem, node, ret) {
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
+                case 'text.serial.journal':
 					t.dc = 'journalArticle';
 					break;
 				case 'newsitem':
@@ -861,7 +862,7 @@ function importItem(newItem, node) {
 		var creatorType = possibleCreatorTypes[i];
 		if (creatorType == "author") {
 			creators = getFirstResults(node, [n.bib+"authors", n.so+"author",
-				n.so+"creator", n.dc+"creator", n.dc1_0+"creator",
+				n.so+"creator", n.dc+"creator", n.dc+"creator.PersonalName", n.dc1_0+"creator",
 				n.dcterms+"creator", n.eprints+"creators_name",
 				n.dc+"contributor", n.dc1_0+"contributor", n.dcterms+"contributor"]);
 		} else if (creatorType == "editor" || creatorType == "contributor") {
@@ -921,12 +922,12 @@ function importItem(newItem, node) {
 	
 	// volume
 	newItem.volume = getFirstResults([container, node, containerPublicationVolume, containerPeriodical], [n.prism+"volume", n.prism2_0+"volume", n.prism2_1+"volume",
-			n.eprints+"volume", n.bibo+"volume", n.dcterms+"citation.volume", n.so+"volumeNumber"], true);
+			n.eprints+"volume", n.bibo+"volume", n.dc+"source.Volume", n.dcterms+"citation.volume", n.so+"volumeNumber"], true);
 	
 	// issue
 	if (container) {
 		newItem.issue = getFirstResults([container, node], [n.prism+"number", n.prism2_0+"number", n.prism2_1+"number",
-			n.eprints+"number", n.bibo+"issue", n.dcterms+"citation.issue", n.so+"issueNumber"], true);
+			n.eprints+"number", n.bibo+"issue", n.dc+"source.Issue", n.dcterms+"citation.issue", n.so+"issueNumber"], true);
 	}
 
 	// these mean the same thing
@@ -938,7 +939,7 @@ function importItem(newItem, node) {
 	newItem.versionNumber = newItem.edition;
 	
 	// pages
-	newItem.pages = getFirstResults(node, [n.bib+"pages", n.eprints+"pagerange", n.prism2_0+"pageRange", n.prism2_1+"pageRange", n.bibo+"pages", n.so+"pagination"], true);
+	newItem.pages = getFirstResults(node, [n.bib+"pages", n.eprints+"pagerange", n.prism2_0+"pageRange", n.prism2_1+"pageRange", n.bibo+"pages", n.dc+"identifier.pageNumber", n.so+"pagination"], true);
 	if (!newItem.pages) {
 		var pages = [];
 		var spage = getFirstResults(node, [n.prism+"startingPage", n.prism2_0+"startingPage", n.prism2_1+"startingPage", n.bibo+"pageStart", n.dcterms+"relation.spage", n.so+"pageStart"], true),
@@ -1065,8 +1066,8 @@ function importItem(newItem, node) {
 		}
 	}
 	
-	// ISSN, if encoded per PRISM (DC uses "identifier")
-	newItem.ISSN = getFirstResults([container, node, containerPeriodical, containerPublicationVolume], [n.prism+"issn", n.prism2_0+"issn", n.prism2_1+"issn", n.eprints+"issn", n.bibo+"issn",
+	// ISSN, if encoded per PRISM
+	newItem.ISSN = getFirstResults([container, node, containerPeriodical, containerPublicationVolume], [n.prism+"issn", n.prism2_0+"issn", n.prism2_1+"issn", n.eprints+"issn", n.bibo+"issn", n.dc+"source.ISSN",
 		n.prism+"eIssn", n.prism2_0+"eIssn", n.prism2_1+"eIssn", n.bibo+"eissn", n.so+"issn"], true) || newItem.ISSN;
 	// ISBN from PRISM or OG
 	newItem.ISBN = getFirstResults((container ? container : node), [n.prism2_1+"isbn", n.bibo+"isbn", n.bibo+"isbn13", n.bibo+"isbn10", n.book+"isbn", n.so+"isbn"], true) || newItem.ISBN;

--- a/RDF.js
+++ b/RDF.js
@@ -513,7 +513,7 @@ function detectType(newItem, node, ret) {
 				case 'journalitem':
 				case 'journalarticle':
 				case 'submittedjournalarticle':
-                case 'text.serial.journal':
+				case 'text.serial.journal':
 					t.dc = 'journalArticle';
 					break;
 				case 'newsitem':


### PR DESCRIPTION
In Open Journal Systems an article will have a landing page, which might link to galleys of the article in one or more formats (e.g., PDF, HTML). In OJS 2 the galley-view page included full metadata about the article; in OJS 3 it does not. I believe this is an inadvertent omission, although I haven't delved into the OJS version history to verify this. 

I updated the OJS translator to fetch the metadata from the article landing page. It does this regardless of the OJS version, since a) I didn't initially realize that this was specifically an OJS 3 issue, and b) it makes for simpler code. (One could load the 'web' translator in doWeb(), translate, and test for an element like item.volume to see if fetching the landing page is necessary.) 

I have also opened an issue about this with OJS (https://github.com/pkp/pkp-lib/issues/4141). If it gets addressed on that end, and this pull request is accepted, we could be in a position where the OJS translator is doing extra work to accommodate for a small percentage of OJS installs. (It seems like the majority "in the wild" are still on OJS 2.) 


