### PR TITLE
Only use one of citation_author, citation_authors

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-10-07 16:46:47"
+	"lastUpdated": "2018-11-01 19:46:46"
 }
 
 /*
@@ -383,9 +383,10 @@ function importRDF(doc, url) {
 function addHighwireMetadata(doc, newItem) {
 	// HighWire metadata
 	processFields(doc, newItem, HIGHWIRE_MAPPINGS);
-
-	var authorNodes = getContent(doc, 'citation_author')
-						.concat(getContent(doc, 'citation_authors'));
+	var authorNodes = getContent(doc, 'citation_author');
+	if (authorNodes.length == 0) {
+		authorNodes = getContent(doc, 'citation_authors');
+	}
 	//save rdfCreators for later
 	var rdfCreators = newItem.creators;
 	newItem.creators = [];

--- a/MDPI Journals.js
+++ b/MDPI Journals.js
@@ -9,9 +9,8 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-12-27 12:49:31"
+	"lastUpdated": "2018-11-01 20:19:32"
 }
-
 
 /*
 	MDPI Translator
@@ -82,6 +81,17 @@ function scrape(doc, url) {
 	translator.setDocument(doc);
 	translator.setHandler('itemDone', function(obj, item) {
 		if (!item.abstractNote) item.abstractNote = item.extra;
+		// prefer citation_authors if present for the initials
+		let authors = attr(doc, 'meta[name="citation_authors"]', 'content');
+		if (authors) {
+			let i=0;
+			for (let author of authors.split(';')) {
+				if (author.includes(item.creators[i].lastName)) {
+					item.creators[i] = ZU.cleanAuthor(author, "author", true);
+				}
+				i++;
+			}
+		}
 		delete item.extra;
 		item.complete();
 	});
@@ -96,10 +106,11 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.mdpi.com/2076-3387/3/3/32",
+		"url": "https://www.mdpi.com/2076-3387/3/3/32",
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "Autonomy, Conformity and Organizational Learning",
 				"creators": [
 					{
 						"firstName": "Nobuyuki",
@@ -112,17 +123,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [],
-				"tags": [
-					"organizational learning",
-					"exploration",
-					"exploitation",
-					"complexity",
-					"turbulence",
-					"NK landscape",
-					"ambidexterity"
-				],
-				"seeAlso": [],
+				"date": "2013-07-05",
+				"DOI": "10.3390/admsci3030032",
+				"abstractNote": "There is often said to be a tension between the two types of organizational learning activities, exploration and exploitation. The argument goes that the two activities are substitutes, competing for scarce resources when firms need different capabilities and management policies. We present another explanation, attributing the tension to the dynamic interactions among search, knowledge sharing, evaluation and alignment within organizations. Our results show that successful organizations tend to bifurcate into two types: those that always promote individual initiatives and build organizational strengths on individual learning and those good at assimilating the individual knowledge base and exploiting shared knowledge. Straddling the two types often fails. The intuition is that an equal mixture of individual search and assimilation slows down individual learning, while at the same time making it difficult to update organizational knowledge because individuals’ knowledge base is not sufficiently homogenized. Straddling is especially inefficient when the operation is sufficiently complex or when the business environment is sufficiently turbulent.",
+				"issue": "3",
+				"language": "en",
+				"libraryCatalog": "www.mdpi.com",
+				"pages": "32-52",
+				"publicationTitle": "Administrative Sciences",
+				"rights": "http://creativecommons.org/licenses/by/3.0/",
+				"url": "https://www.mdpi.com/2076-3387/3/3/32",
+				"volume": "3",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -132,35 +143,31 @@ var testCases = [
 						"title": "Snapshot"
 					}
 				],
-				"title": "Autonomy, Conformity and Organizational Learning",
-				"publicationTitle": "Administrative Sciences",
-				"rights": "http://creativecommons.org/licenses/by/3.0/",
-				"volume": "3",
-				"issue": "3",
-				"number": "3",
-				"patentNumber": "3",
-				"pages": "32-52",
-				"publisher": "Multidisciplinary Digital Publishing Institute",
-				"institution": "Multidisciplinary Digital Publishing Institute",
-				"company": "Multidisciplinary Digital Publishing Institute",
-				"label": "Multidisciplinary Digital Publishing Institute",
-				"distributor": "Multidisciplinary Digital Publishing Institute",
-				"date": "2013-07-05",
-				"DOI": "10.3390/admsci3030032",
-				"reportType": "Article",
-				"letterType": "Article",
-				"manuscriptType": "Article",
-				"mapType": "Article",
-				"thesisType": "Article",
-				"websiteType": "Article",
-				"presentationType": "Article",
-				"postType": "Article",
-				"audioFileType": "Article",
-				"language": "en",
-				"url": "http://www.mdpi.com/2076-3387/3/3/32",
-				"abstractNote": "There is often said to be a tension between the two types of organizational learning activities, exploration and exploitation. The argument goes that the two activities are substitutes, competing for scarce resources when firms need different capabilities and management policies. We present another explanation, attributing the tension to the dynamic interactions among search, knowledge sharing, evaluation and alignment within organizations. Our results show that successful organizations tend to bifurcate into two types: those that always promote individual initiatives and build organizational strengths on individual learning and those good at assimilating the individual knowledge base and exploiting shared knowledge. Straddling the two types often fails. The intuition is that an equal mixture of individual search and assimilation slows down individual learning, while at the same time making it difficult to update organizational knowledge because individuals’ knowledge base is not sufficiently homogenized. Straddling is especially inefficient when the operation is sufficiently complex or when the business environment is sufficiently turbulent.",
-				"libraryCatalog": "www.mdpi.com",
-				"accessDate": "CURRENT_TIMESTAMP"
+				"tags": [
+					{
+						"tag": "NK landscape"
+					},
+					{
+						"tag": "ambidexterity"
+					},
+					{
+						"tag": "complexity"
+					},
+					{
+						"tag": "exploitation"
+					},
+					{
+						"tag": "exploration"
+					},
+					{
+						"tag": "organizational learning"
+					},
+					{
+						"tag": "turbulence"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	},
@@ -168,6 +175,100 @@ var testCases = [
 		"type": "web",
 		"url": "http://www.mdpi.com/search?q=preference&journal=algorithms&volume=&authors=&section=&issue=&article_type=&special_issue=&page=&search=Search",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.mdpi.com/1420-3049/23/10/2454",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Measuring Artificial Sweeteners Toxicity Using a Bioluminescent Bacterial Panel",
+				"creators": [
+					{
+						"firstName": "Dorin",
+						"lastName": "Harpaz",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Loo Pin",
+						"lastName": "Yeo",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Francesca",
+						"lastName": "Cecchini",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Trish H. P.",
+						"lastName": "Koon",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Ariel",
+						"lastName": "Kushmaro",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Alfred I. Y.",
+						"lastName": "Tok",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Robert S.",
+						"lastName": "Marks",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Evgeni",
+						"lastName": "Eltzov",
+						"creatorType": "author"
+					}
+				],
+				"date": "2018-09-25",
+				"DOI": "10.3390/molecules23102454",
+				"abstractNote": "Artificial sweeteners have become increasingly controversial due to their questionable influence on consumers&rsquo; health. They are introduced in most foods and many consume this added ingredient without their knowledge. Currently, there is still no consensus regarding the health consequences of artificial sweeteners intake as they have not been fully investigated. Consumption of artificial sweeteners has been linked with adverse effects such as cancer, weight gain, metabolic disorders, type-2 diabetes and alteration of gut microbiota activity. Moreover, artificial sweeteners have been identified as emerging environmental pollutants, and can be found in receiving waters, i.e., surface waters, groundwater aquifers and drinking waters. In this study, the relative toxicity of six FDA-approved artificial sweeteners (aspartame, sucralose, saccharine, neotame, advantame and acesulfame potassium-k (ace-k)) and that of ten sport supplements containing these artificial sweeteners, were tested using genetically modified bioluminescent bacteria from E. coli. The bioluminescent bacteria, which luminesce when they detect toxicants, act as a sensing model representative of the complex microbial system. Both induced luminescent signals and bacterial growth were measured. Toxic effects were found when the bacteria were exposed to certain concentrations of the artificial sweeteners. In the bioluminescence activity assay, two toxicity response patterns were observed, namely, the induction and inhibition of the bioluminescent signal. An inhibition response pattern may be observed in the response of sucralose in all the tested strains: TV1061 (MLIC = 1 mg/mL), DPD2544 (MLIC = 50 mg/mL) and DPD2794 (MLIC = 100 mg/mL). It is also observed in neotame in the DPD2544 (MLIC = 2 mg/mL) strain. On the other hand, the induction response pattern may be observed in its response in saccharin in TV1061 (MLIndC = 5 mg/mL) and DPD2794 (MLIndC = 5 mg/mL) strains, aspartame in DPD2794 (MLIndC = 4 mg/mL) strain, and ace-k in DPD2794 (MLIndC = 10 mg/mL) strain. The results of this study may help in understanding the relative toxicity of artificial sweeteners on E. coli, a sensing model representative of the gut bacteria. Furthermore, the tested bioluminescent bacterial panel can potentially be used for detecting artificial sweeteners in the environment, using a specific mode-of-action pattern.",
+				"issue": "10",
+				"language": "en",
+				"libraryCatalog": "www.mdpi.com",
+				"pages": "2454",
+				"publicationTitle": "Molecules",
+				"rights": "http://creativecommons.org/licenses/by/3.0/",
+				"url": "https://www.mdpi.com/1420-3049/23/10/2454",
+				"volume": "23",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "artificial sweeteners"
+					},
+					{
+						"tag": "bioluminescent bacteria"
+					},
+					{
+						"tag": "environmental pollutants"
+					},
+					{
+						"tag": "gut microbiota"
+					},
+					{
+						"tag": "sport supplements"
+					},
+					{
+						"tag": "toxic effect"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
Generally, we prefer citation_author with individual values
for each author. However in MDPI journals both metadata are
present but the initials are only part of citation_authors.

This fixes #1773.