### PR TITLE
TEI: Use Better BibTeX citation key if available

### DIFF
--- a/TEI.js
+++ b/TEI.js
@@ -19,7 +19,7 @@
 		"Full TEI Document": false,
 		"Export Collections": false
 	},
-	"lastUpdated": "2017-11-18 10:45:00"
+	"lastUpdated": "2019-01-22 09:47:00"
 }
 
 // ********************************************************************
@@ -182,7 +182,7 @@ function generateItem(item, teiDoc) {
 
 	if (Zotero.getOption("Generate XML IDs")) {
 		if (!generatedItems[item.uri]) {
-			var xmlid = item.citekey || genXMLId(item); // use Better BibTeX for Zotero citation key if available
+			var xmlid = item.citationKey || genXMLId(item); // use Better BibTeX for Zotero citation key if available
 			bibl.setAttributeNS(ns.xml, "xml:id", xmlid);
 			exportedXMLIds[xmlid] = bibl;
 		} else {

--- a/TEI.js
+++ b/TEI.js
@@ -182,7 +182,7 @@ function generateItem(item, teiDoc) {
 
 	if (Zotero.getOption("Generate XML IDs")) {
 		if (!generatedItems[item.uri]) {
-			var xmlid = genXMLId(item);
+			var xmlid = item.citekey || genXMLId(item); // use Better BibTeX for Zotero citation key if available
 			bibl.setAttributeNS(ns.xml, "xml:id", xmlid);
 			exportedXMLIds[xmlid] = bibl;
 		} else {


### PR DESCRIPTION
This will use the citation key generated by Better BibTeX for Zotero as the `xml:id` if it is available. If that add-on is not enabled, this change has no effect. Solution from @retorquere in <https://github.com/retorquere/zotero-better-bibtex/issues/1124>.