### PR TITLE
:white_check_mark: Add CI-check for updating timestamp

### DIFF
--- a/.ci/helper.sh
+++ b/.ci/helper.sh
@@ -18,4 +18,16 @@ grepTranslatorId () {
     fi
 }
 
+grepLastUpdated () {
+    if [[ -n "$1" ]];then
+        grep -r '"lastUpdated"' "$@" | sed -e 's/^.*lastUpdated": //' -e 's/ /T/' -e 's/"//g' | xargs -i date -d {} +%s
+    fi
+}
+
+gitGrepLastUpdated () {
+    if [[ -n "$1" ]];then
+        git grep '"lastUpdated"' master "$@" | sed -e 's/^.*lastUpdated": //' -e 's/ /T/' -e 's/"//g' | xargs -i date -d {} +%s
+    fi
+}
+
 # vim: ft=sh

--- a/A Contra Corriente.js
+++ b/A Contra Corriente.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-02-02 12:25:00"
+	"lastUpdated": "2016-08-18 20:51:04"
 }
 
 /*
@@ -80,7 +80,7 @@ function doWeb(doc, url) {
 }
 
 function scrape(doc, url) {
-	var urlBibtex = url.replace('/article/view/', '/rt/captureCite/');
+	urlBibtex = url.replace('/article/view/', '/rt/captureCite/');
 	if (!/\/article\/view\/.+\/.+/.test(url)) {
 		urlBibtex += '/0';
 	}

--- a/A Contra Corriente.js
+++ b/A Contra Corriente.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2016-08-18 20:51:04"
+	"lastUpdated": "2019-02-02 12:25:00"
 }
 
 /*

--- a/A Contra Corriente.js
+++ b/A Contra Corriente.js
@@ -80,7 +80,7 @@ function doWeb(doc, url) {
 }
 
 function scrape(doc, url) {
-	urlBibtex = url.replace('/article/view/', '/rt/captureCite/');
+	var urlBibtex = url.replace('/article/view/', '/rt/captureCite/');
 	if (!/\/article\/view\/.+\/.+/.test(url)) {
 		urlBibtex += '/0';
 	}


### PR DESCRIPTION
All modified files in a pull requests are tested whether their timestamp (i.e. `lastUpdated` value) changed. If there is a modified translator w/o a different timestamp, then this new tests on travis will fail.

Usually a translator is changed in the pull request and therefore one should also update the timstamp to a newer one. However, it is also possible that the master branch moved further in the meantime and therefore the more recent translator is now in the master branch when compared to the ones in a pull request. Therefore, I only test for a different timestamp and not, that the one in the PR is newer than the one in the master branch (that caused some wrong failed tests when I tried that first).

Sometimes we only update test cases or similar small things, where we don't update the timestamp on purpose. We can still do this, but now have just to ignore the failed travis test w.r.t. to this.