### PR TITLE
BBC language fix

### DIFF
--- a/BBC.js
+++ b/BBC.js
@@ -174,7 +174,7 @@ function scrape(doc, url) {
 		for (var i in item.tags)
 			item.tags[i] = item.tags[i].charAt(0).toUpperCase()+item.tags[i].substring(1);
 
-		item.language = "en-GB";
+		item.language = ZU.xpathText(doc, '//*/@lang/') or "en-GB";
 
 		if (url.substr(-4)==".stm") {
 			item.title = ZU.xpathText(doc, '//meta[@name="Headline"]/@content');


### PR DESCRIPTION
Language code `en-GB` for the BBC must not be fixed ([as done here](https://github.com/zotero/translators/blob/8203550b89c3288e3e0b5171c6d6db2f937ef72a/BBC.js#L177)), because it uses different languages (examples: [fr](https://www.bbc.com/afrique), [es](https://www.bbc.com/mundo), [pt](https://www.bbc.com/portuguese/), [ru](https://www.bbc.com/russian), ...). Language can be found in the HTML `lang` tag, using the preset only as fallback.

Maybe it works if you replace [that line](https://github.com/zotero/translators/blob/8203550b89c3288e3e0b5171c6d6db2f937ef72a/BBC.js#L177) with:
`
item.language = ZU.xpathText(doc, '//*/@lang/') or "en-GB";
`