### PR TITLE
Add atob as a valid global when linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
 		"ZU": "readonly",
 		"DOMParser": "readonly",
 		"XPathResult": "readonly",
-		"XMLSerializer": "readonly"
+		"XMLSerializer": "readonly",
+		"atob": "readonly"
 	},
 	"rules": {
 		"accessor-pairs": "error",


### PR DESCRIPTION
The linter gave me the following error when linting the Semantic Scholar translator: `   98:35  error    'atob' is not defined                                                 no-undef` (i.e. [here](https://github.com/zotero/translators/blob/f67b9c5e123c518dee463dc2219e3e80e7077a80/Semantic%20Scholar.js#L98)). It's a valid global, so have added it to the linter exceptions. 