### PR TITLE
add eslint-fixer for common import-test errors

### DIFF
--- a/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
+++ b/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
@@ -1,6 +1,95 @@
 'use strict';
 
 const translators = require('../translators').cache;
+const astring = require('astring');
+
+function verifyWeb(context, astNode, tc, prefix) {
+	if (tc.items !== 'multiple' && !Array.isArray(tc.items)) {
+		context.report(astNode, `${prefix} needs items`);
+	}
+
+	if (typeof tc.url !== 'string') {
+		context.report(astNode, `${prefix} test needs url`);
+	}
+}
+
+function verifyImport(context, astNode, tc, prefix) {
+	if (!Array.isArray(tc.items)) {
+		context.report(astNode, `${prefix} needs items`);
+	}
+
+	if (typeof tc.input !== 'string') {
+		context.report(astNode, `${prefix} needs a string input`);
+	}
+
+	const items = astNode.properties.find(prop => prop.key.value === 'items').value.elements;
+	for (const itemNode of items) {
+		if (itemNode.type !== 'ObjectExpression') {
+			context.report(itemNode, `${prefix} item must be an object`);
+			continue;
+		}
+
+		const item = JSON.parse(astring.generate(itemNode));
+		const messages = [];
+		for (const prop of ['tags', 'notes', 'attachments', 'seeAlso']) {
+			if (item[prop] && !item[prop].length) {
+				messages.push(`${prefix} remove empty ${prop}`);
+				delete item[prop];
+			}
+		}
+
+		for (const note of (item.notes || [])) {
+			if (note.itemType !== 'note') {
+				messages.push(`${prefix} note must have itemType "note"`);
+				note.itemType = 'note';
+			}
+		}
+
+		for (const creator of (item.creators || [])) {
+			if (creator.fieldMode === 1) {
+				messages.push(`${prefix} fieldMode is obsolete, use "name" to indicate single-field names`);
+				creator.name = creator.lastName;
+				delete creator.lastName;
+				delete creator.fieldMode;
+			}
+		}
+
+		if (item.tags) {
+			item.tags = item.tags.map(function (tag) {
+				if (typeof tag === 'string') {
+					messages.push(`${prefix} tag must be an object, not a string`);
+					return { tag, type: 1 };
+				}
+				else if (typeof tag.type !== 'number') {
+					messages.push(`${prefix} missing "type" on tag`);
+					return { ...tag, type: 1 };
+				}
+				return tag;
+			});
+		}
+
+		// this is a bit cheaty, but I don't feel like walking the entire AST on this, so fix all reported issues in one go
+		let fix = function (fixer) {
+			return fixer.replaceText(itemNode, JSON.stringify(item, null, '\t'));
+		};
+		for (const message of messages) {
+			context.report({ node: itemNode, message, fix });
+			fix = undefined; // the first fixer will take care of all of them at once
+		}
+	}
+}
+
+function verifySearch(context, astNode, tc, prefix) {
+	if (!Array.isArray(tc.items)) {
+		context.report(astNode, `${prefix} needs items`);
+	}
+
+	const term = Object.keys(tc.input || {}).join('/');
+	const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject'];
+	if (!expected.includes(term)) {
+		context.report(astNode, `${prefix} has search term '${term}', expected one of ${expected.join(', ')}`);
+	}
+}
 
 module.exports = {
 	meta: {
@@ -10,6 +99,7 @@ module.exports = {
 			description: 'disallow invalid test input',
 			category: 'Possible Errors',
 		},
+		fixable:	'code',
 	},
 
 	create: function (context) {
@@ -26,56 +116,28 @@ module.exports = {
 
 				if (!translator.testCases || translator.testCases.error) return; // regular js or no test cases
 
-				let caseNo = -1;
-				for (const testCase of translator.testCases.parsed) {
-					caseNo += 1;
-					const prefix = `test case${testCases[caseNo] ? '' : ' ' + (caseNo + 1)}`;
-					const loc = testCases[caseNo] ? testCases[caseNo].loc.start : { start: { line: translator.testCases.start, column: 1 } };
-
-					if (!['web', 'import', 'search'].includes(testCase.type)) {
-						context.report({
-							message: `${prefix} has invalid type "${testCase.type}"`,
-							loc,
-						});
+				for (const astNode of testCases) {
+					if (astNode.type !== 'ObjectExpression') {
+						context.report(astNode, `test case is not a test case object`);
 						continue;
 					}
 
-					if (!(Array.isArray(testCase.items) || (testCase.type === 'web' && testCase.items === 'multiple'))) {
-						context.report({
-							message: `${prefix} of type "${testCase.type}" needs items`,
-							loc,
-						});
-					}
+					const testCase = JSON.parse(astring.generate(astNode));
+					const prefix = `${testCase.type || 'unspecified'} test case`;
 
-					if (testCase.type === 'web' && typeof testCase.url !== 'string') {
-						context.report({
-							message: `${prefix} of type "${testCase.type}" test needs url`,
-							loc,
-						});
-					}
-
-					if (['import', 'search'].includes(testCase.type) && !testCase.input) {
-						context.report({
-							message: `${prefix} of type "${testCase.type}" needs a string input`,
-							loc,
-						});
-					}
-					else if (testCase.type === 'import' && typeof testCase.input !== 'string') {
-						context.report({
-							message: `${prefix} of type "${testCase.type}" needs input`,
-							loc,
-						});
-					}
-					else if (testCase.type === 'search') {
-						// console.log(JSON.stringify(testCase.input))
-						const term = Object.keys(testCase.input).join('/');
-						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject'];
-						if (!expected.includes(term)) {
-							context.report({
-								message: `${prefix} of type "${testCase.type}" has search term '${term}', expected one of ${expected.join(', ')}`,
-								loc,
-							});
-						}
+					switch (testCase.type) {
+					case 'web':
+						verifyWeb(context, astNode, testCase, prefix);
+						break;
+					case 'import':
+						verifyImport(context, astNode, testCase, prefix);
+						break;
+					case 'search':
+						verifySearch(context, astNode, testCase, prefix);
+						break;
+					default:
+						context.report(astNode, `${prefix} has invalid type "${testCase.type}"`);
+						break;
 					}
 				}
 			}

--- a/.ci/eslint-plugin-zotero-translator/package.json
+++ b/.ci/eslint-plugin-zotero-translator/package.json
@@ -12,6 +12,7 @@
 		"teslint": "./bin/teslint.js"
 	},
 	"dependencies": {
+		"astring": "^1.4.0",
 		"commander": "^2.19.0",
 		"find-root": "^1.1.0",
 		"recursive-readdir-synchronous": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,12 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
+		"astring": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.4.0.tgz",
+			"integrity": "sha512-mk4x+B6yYSLp4c8jZhLtb8B6DzLRaACJI7VT69hpgZlQgUD58sKXRggPmr8h+/v5opjo+TvD6gCoSjLXB1/a/Q==",
+			"dev": true
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -262,6 +268,7 @@
 			"version": "file:.ci/eslint-plugin-zotero-translator",
 			"dev": true,
 			"requires": {
+				"astring": "^1.4.0",
 				"commander": "^2.19.0",
 				"find-root": "^1.1.0",
 				"recursive-readdir-synchronous": "0.0.4",


### PR DESCRIPTION
add eslint-fixer for common import-test errors. Many (perhaps most) existing import translators have tests that don't conform to what the translation-server import test expect.