### PR TITLE
silently fail detect for MODS

### DIFF
--- a/MODS.js
+++ b/MODS.js
@@ -321,7 +321,15 @@ var ns = "http://www.loc.gov/mods/v3",
 	xns = { m: ns };
 
 function detectImport() {
-	var doc = Zotero.getXML().documentElement;
+	let doc;
+	try {
+		doc = Zotero.getXML().documentElement;
+	}
+	catch (err) {
+		// most likely just not XML
+		return false;
+	}
+
 	if (!doc) {
 		return false;
 	}

--- a/MODS.js
+++ b/MODS.js
@@ -15,7 +15,7 @@
 	"inRepository": true,
 	"translatorType": 3,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-03-30 09:05:38"
+	"lastUpdated": "2019-05-20 09:05:38"
 }
 
 


### PR DESCRIPTION
MODS doesn't catch the error in detectImport so it puts an error in the log for every detect. Not a major issue in the grand scheme of things but it pollutes my test logs (which do a lot of imports) pretty severely.