### PR TITLE
Prefer latest date in arXiv.org.js [web + search]

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 12,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2019-04-28 01:57:56"
+	"lastUpdated": "2019-08-29 20:49:29"
 }
 
 /*
@@ -44,6 +44,12 @@ function doSearch(item) {
 		+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(item.arXiv);
 	ZU.doGet(url, parseXML);
 }
+
+
+var version;
+// this variable will be set in doWeb and
+// can be used then afterwards in the parseXML
+
 
 function detectWeb(doc, url) {
 	var searchRe = /^https?:\/\/(?:([^.]+\.))?(?:arxiv\.org|xxx\.lanl\.gov)\/(?:find|list|catchup)/;
@@ -109,6 +115,10 @@ function doWeb(doc, url) {
 	}
 	else {
 		var id;
+		var versionMatch = url.match(/v(\d+)(\.pdf)?$/);
+		if (versionMatch) {
+			version = versionMatch[1];
+		}
 		var p = url.indexOf("/pdf/");
 		if (p > -1) {
 			id = url.substring(p + 5, url.length - 4);
@@ -142,7 +152,18 @@ function parseXML(text) {
 
 	newItem.title = getXPathNodeTrimmed(dcMeta, "dc:title", ns);
 	getCreatorNodes(dcMeta, "dc:creator", newItem, "author", ns);
-	newItem.date = getXPathNodeTrimmed(dcMeta, "dc:date", ns);
+	var dates = ZU.xpath(dcMeta, './dc:date', ns)
+		.map(element => element.textContent)
+		.sort();
+	if (dates.length > 0) {
+		if (version && version < dates.length) {
+			newItem.date = dates[version - 1];
+		}
+		else {
+			// take the latest date
+			newItem.date = dates[dates.length - 1];
+		}
+	}
 	
 	
 	var descriptions = ZU.xpath(dcMeta, "./dc:description", ns);
@@ -186,6 +207,9 @@ function parseXML(text) {
 	}
 	
 	newItem.extra = 'arXiv: ' + articleID;
+	if (version) {
+		newItem.extra += '\nversion: ' + version;
+	}
 	
 	newItem.attachments.push({
 		title: 'arXiv:' + articleID + " PDF",
@@ -318,7 +342,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://arxiv.org/abs/astro-ph/0603274",
+		"url": "https://arxiv.org/abs/astro-ph/0603274",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -386,6 +410,7 @@ var testCases = [
 				"abstractNote": "We present optical $WBVR$ and infrared $JHKL$ photometric observations of the Be binary system $\\delta$ Sco, obtained in 2000--2005, mid-infrared (10 and $18 \\mu$m) photometry and optical ($\\lambda\\lambda$ 3200--10500 \\AA) spectropolarimetry obtained in 2001. Our optical photometry confirms the results of much more frequent visual monitoring of $\\delta$ Sco. In 2005, we detected a significant decrease in the object's brightness, both in optical and near-infrared brightness, which is associated with a continuous rise in the hydrogen line strenghts. We discuss possible causes for this phenomenon, which is difficult to explain in view of current models of Be star disks. The 2001 spectral energy distribution and polarization are succesfully modeled with a three-dimensional non-LTE Monte Carlo code which produces a self-consistent determination of the hydrogen level populations, electron temperature, and gas density for hot star disks. Our disk model is hydrostatically supported in the vertical direction and radially controlled by viscosity. Such a disk model has, essentially, only two free parameters, viz., the equatorial mass loss rate and the disk outer radius. We find that the primary companion is surrounded by a small (7 $R_\\star$), geometrically-thin disk, which is highly non-isothermal and fully ionized. Our model requires an average equatorial mass loss rate of $1.5\\times 10^{-9} M_{\\sun}$ yr$^{-1}$.",
 				"extra": "arXiv: astro-ph/0603274",
 				"issue": "2",
+				"journalAbbreviation": "ApJ",
 				"libraryCatalog": "arXiv.org",
 				"pages": "1617-1625",
 				"publicationTitle": "The Astrophysical Journal",
@@ -402,7 +427,9 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Astrophysics"
+					{
+						"tag": "Astrophysics"
+					}
 				],
 				"notes": [
 					{
@@ -578,6 +605,118 @@ var testCases = [
 						"note": "Comment: 17 pages"
 					}
 				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://arxiv.org/abs/1810.04805v1",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+				"creators": [
+					{
+						"firstName": "Jacob",
+						"lastName": "Devlin",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Ming-Wei",
+						"lastName": "Chang",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Kenton",
+						"lastName": "Lee",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Kristina",
+						"lastName": "Toutanova",
+						"creatorType": "author"
+					}
+				],
+				"date": "2018-10-10",
+				"abstractNote": "We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create state-of-the-art models for a wide range of tasks, such as question answering and language inference, without substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1 question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point absolute improvement).",
+				"extra": "arXiv: 1810.04805\nversion: 1",
+				"libraryCatalog": "arXiv.org",
+				"publicationTitle": "arXiv:1810.04805 [cs]",
+				"shortTitle": "BERT",
+				"url": "http://arxiv.org/abs/1810.04805",
+				"attachments": [
+					{
+						"title": "arXiv:1810.04805 PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "arXiv.org Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Computer Science - Computation and Language"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://arxiv.org/abs/1810.04805v2",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+				"creators": [
+					{
+						"firstName": "Jacob",
+						"lastName": "Devlin",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Ming-Wei",
+						"lastName": "Chang",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Kenton",
+						"lastName": "Lee",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Kristina",
+						"lastName": "Toutanova",
+						"creatorType": "author"
+					}
+				],
+				"date": "2019-05-24",
+				"abstractNote": "We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create state-of-the-art models for a wide range of tasks, such as question answering and language inference, without substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1 question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point absolute improvement).",
+				"extra": "arXiv: 1810.04805\nversion: 2",
+				"libraryCatalog": "arXiv.org",
+				"publicationTitle": "arXiv:1810.04805 [cs]",
+				"shortTitle": "BERT",
+				"url": "http://arxiv.org/abs/1810.04805",
+				"attachments": [
+					{
+						"title": "arXiv:1810.04805 PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "arXiv.org Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Computer Science - Computation and Language"
+					}
+				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]


### PR DESCRIPTION
This solves #1992.

However, when you are on the website of the specific
version of the paper, then it will try to find the correct
publication date in the XML and save the version
number as well.