### PR TITLE
Wiley: PDFs not saved

### DIFF
--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-10-01 20:37:08"
+	"lastUpdated": "2019-10-01 20:54:57"
 }
 
 /*
@@ -29,6 +29,9 @@
    You should have received a copy of the GNU Affero General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+// attr()/text() v2
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
 
 function fixCase(authorName) {
 	if (typeof authorName != 'string') return authorName;
@@ -181,9 +184,11 @@ function scrapeEM(doc, url, pdfUrl) {
 			if (pdfUrl) {
 				ZU.doGet(pdfUrl, function (text) {
 					if (text) {
-						let m = text.match(/<object[^>]*data="([^"]+)" type="application\/pdf"[^>]*>/i);
-						if (m) {
-							pdfUrl = ZU.unescapeHTML(m[1]);
+						let parser = new DOMParser();
+						let doc = parser.parseFromString(text, 'text/html');
+						let url = attr(doc, 'object[type="application/pdf"]', 'data');
+						if (url) {
+							pdfUrl = ZU.unescapeHTML(url);
 							Z.debug('PDF URL: ' + pdfUrl);
 						}
 						else {
@@ -361,9 +366,11 @@ function scrapeBibTeX(doc, url, pdfUrl) {
 			) {
 				ZU.doGet(pdfUrl, function (text) {
 					if (text) {
-						let m = text.match(/<object[^>]*data="([^"]+)" type="application\/pdf"[^>]*>/i);
-						if (m) {
-							pdfUrl = ZU.unescapeHTML(m[1]);
+						let parser = new DOMParser();
+						let doc = parser.parseFromString(text, 'text/html');
+						let url = attr(doc, 'object[type="application/pdf"]', 'data');
+						if (url) {
+							pdfUrl = ZU.unescapeHTML(url);
 							Z.debug('PDF URL: ' + pdfUrl);
 						}
 						else {

--- a/Wiley Online Library.js
+++ b/Wiley Online Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-10-01 20:54:57"
+	"lastUpdated": "2019-10-02 00:10:12"
 }
 
 /*
@@ -178,38 +178,22 @@ function scrapeEM(doc, url, pdfUrl) {
 				n--;
 			}
 		}
-
+		
 		if (!pdfUrl) {
-			pdfUrl = ZU.xpathText(doc, '//meta[@name="citation_pdf_url"]/@content');
+			pdfUrl = attr(doc, 'meta[name="citation_pdf_url"]', "content");
 			if (pdfUrl) {
-				ZU.doGet(pdfUrl, function (text) {
-					if (text) {
-						let parser = new DOMParser();
-						let doc = parser.parseFromString(text, 'text/html');
-						let url = attr(doc, 'object[type="application/pdf"]', 'data');
-						if (url) {
-							pdfUrl = ZU.unescapeHTML(url);
-							Z.debug('PDF URL: ' + pdfUrl);
-						}
-						else {
-							// Maybe this was the real PDF URL, but probably not
-							Z.debug('Could not determine PDF URL');
-						}
-					}
-					item.attachments.push({
-						url: pdfUrl,
-						title: 'Full Text PDF',
-						mimeType: 'application/pdf'
-					});
-					item.complete();
-				});
-			} else {
-				item.complete();
+				pdfUrl = pdfUrl.replace('/pdf/', '/pdfdirect/');
+				Z.debug("PDF URL: " + pdfUrl);
 			}
-		} else {
-			item.attachments.push({url: pdfUrl, title: 'Full Text PDF', mimeType: 'application/pdf'});
-			item.complete();
 		}
+		if (pdfUrl) {
+			item.attachments.push({
+				url: pdfUrl,
+				title: 'Full Text PDF',
+				mimeType: 'application/pdf'
+			});
+		}
+		item.complete();
 	});
 	
 	translator.getTranslatorObject(function(em) {
@@ -358,43 +342,21 @@ function scrapeBibTeX(doc, url, pdfUrl) {
 				mimeType: 'text/html'
 			}];
 
-			if (!pdfUrl &&
-				(pdfUrl =
-					ZU.xpathText(doc,'(//meta[@name="citation_pdf_url"]/@content)[1]')
-					|| ZU.xpathText(doc, '(//a[@class="pdfLink"]/@href)[1]')
-				)
-			) {
-				ZU.doGet(pdfUrl, function (text) {
-					if (text) {
-						let parser = new DOMParser();
-						let doc = parser.parseFromString(text, 'text/html');
-						let url = attr(doc, 'object[type="application/pdf"]', 'data');
-						if (url) {
-							pdfUrl = ZU.unescapeHTML(url);
-							Z.debug('PDF URL: ' + pdfUrl);
-						}
-						else {
-							// Maybe this was the real PDF URL, but probably not
-							Z.debug('Could not determine PDF URL');
-						}
-					}
-					item.attachments.push({
-						url: pdfUrl,
-						title: 'Full Text PDF',
-						mimeType: 'application/pdf'
-					});
-					item.complete();
-				});
-			} else {
+			if (!pdfUrl) {
+				pdfUrl = attr(doc, 'meta[name="citation_pdf_url"]', "content");
 				if (pdfUrl) {
-					item.attachments.push({
-						url: pdfUrl,
-						title: 'Full Text PDF',
-						mimeType: 'application/pdf'
-					});
+					pdfUrl = pdfUrl.replace('/pdf/', '/pdfdirect/');
+					Z.debug("PDF URL: " + pdfUrl);
 				}
-				item.complete();
 			}
+			if (pdfUrl) {
+				item.attachments.push({
+					url: pdfUrl,
+					title: 'Full Text PDF',
+					mimeType: 'application/pdf'
+				});
+			}
+			item.complete();
 		});
 
 		translator.translate();


### PR DESCRIPTION
This fixes #2004 (see https://github.com/zotero/translators/issues/2004#issuecomment-537209815), but I don't know if other pages are still using iframes. If so, we can restore some of the older logic.

We can clean up this logic soon when we have `DOMParser` and `async`/`await`.