### PR TITLE
Update CNKI translator

### DIFF
--- a/CNKI.js
+++ b/CNKI.js
@@ -1,22 +1,22 @@
 {
 	"translatorID": "5c95b67b-41c5-4f55-b71a-48d5d7183063",
 	"label": "CNKI",
-	"creator": "Aurimas Vinckevicius",
-	"target": "^https?://([^/]+\\.)?cnki\\.net",
+	"creator": "l0o0 linxzh1989@gmail.com",
+	"target": "^https?://kns",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcs",
-	"lastUpdated": "2018-09-08 22:09:39"
+	"lastUpdated": "2019-10-15 03:24:45"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
 	CNKI(China National Knowledge Infrastructure) Translator
-	Copyright © 2013 Aurimas Vinckevicius
+	Copyright © 2013 Aurimas Vinckevicius, updated by Lin Xingzhong linxzh1989@gmail.com
 
 	This file is part of Zotero.
 
@@ -41,32 +41,32 @@
 function getRefworksByID(ids, next) {
 	var postData = "";
 	for (var i=0, n=ids.length; i<n; i++) {
-		postData += ids[i].dbname + "!" + ids[i].filename + "!0!0,";
+		postData += ids[i].dbname + "!" + ids[i].filename + "!1!0,";
 	}
 	postData = "formfilenames=" + encodeURIComponent(postData);
+	postData += '&hid_kLogin_headerUrl=/KLogin/Request/GetKHeader.ashx%3Fcallback%3D%3F';
+	postData += '&hid_KLogin_FooterUrl=/KLogin/Request/GetKHeader.ashx%3Fcallback%3D%3F';
+	postData += '&CookieName=FileNameS';
 	
-	ZU.doPost('http://epub.cnki.net/kns/ViewPage/viewsave.aspx?TablePre=SCDB', postData, function() {
-		ZU.doPost(
-			'http://epub.cnki.net/KNS/ViewPage/SaveSelectedNoteFormat.aspx?type=txt',
-			'CurSaveModeType=REFWORKS',
-			function(text) {
-				//fix item types
-				text = text.replace(/^RT\s+Dissertation\/Thesis/gmi, 'RT Dissertation')
-					//Zotero doesn't do well with mixed line endings. Make everything \n
-					.replace(/\r\n?/g, '\n')
-					//split authors
-					.replace(/^(A[1-4]|U2)\s*([^\r\n]+)/gm, function(m, tag, authors) {
+	ZU.doGet('https://kns.cnki.net/kns/ViewPage/viewsave.aspx?displayMode=Refworks' + '&' +  postData, 
+		function(text) {
+			var parser = new DOMParser();
+			var html = parser.parseFromString(text, "text/html")
+			var text = ZU.xpath(html, "//table[@class='mainTable']//td")[0].innerHTML;
+			var text = text.replace(/<br>/g, '\n');
+			text = text.replace(/^RT\s+Dissertation\/Thesis/gmi, 'RT Dissertation');
+			text = text.replace(/^(A[1-4]|U2)\s*([^\r\n]+)/gm, 
+					function(m, tag, authors) {
 						var authors = authors.split(/\s*[;，,]\s*/); //that's a special comma
 						if (!authors[authors.length-1].trim()) authors.pop();
-						
 						return tag + ' ' + authors.join('\n' + tag + ' ');
-					});
-
-				next(text);
-			}
-		);
-	});
+					}
+				);
+			next(text);
+		}
+	);
 }
+
 
 function getIDFromURL(url) {
 	if (!url) return;
@@ -78,9 +78,17 @@ function getIDFromURL(url) {
 	return {dbname: dbname[1], filename: filename[1], url: url};
 }
 
+// 网络首发期刊信息并不能从URL获取dbname和filename信息
+function getIDFromRef(doc, url){
+	var func = ZU.xpath(doc, '//div[@class="link"]/a')[0].onclick + ''
+	var tmp = func.split(',')[1].split('!');
+	//Z.debug(func + tmp[0].slice(1));
+	return {dbname: tmp[0].slice(1), filename: tmp[1], url: url};
+}
+
 function getIDFromPage(doc, url) {
 	return getIDFromURL(url)
-		|| getIDFromURL(ZU.xpathText(doc, '//div[@class="zwjdown"]/a/@href'));
+		|| getIDFromRef(doc, url);
 }
 
 function getTypeFromDBName(dbname) {
@@ -175,7 +183,7 @@ function doWeb(doc, url) {
 
 function scrape(ids, doc, url, itemInfo) {
 	getRefworksByID(ids, function(text) {
-		Z.debug(text);
+		//Z.debug(text);
 		var translator = Z.loadTranslator('import');
 		translator.setTranslator('1a3506da-a303-4b0a-a1cd-f216e6138d86'); //Refworks
 		text = text.replace(/IS (\d+)\nvo/, "IS $1\nVO");
@@ -238,8 +246,194 @@ function scrape(ids, doc, url, itemInfo) {
 		translator.translate();
 	})
 }
+
+function scrape(ids, doc, url, itemInfo) {
+	getRefworksByID(ids, function(text) {
+		Z.debug(text);
+		var translator = Z.loadTranslator('import');
+		translator.setTranslator('1a3506da-a303-4b0a-a1cd-f216e6138d86'); //Refworks
+		text = text.replace(/IS (\d+)\nvo/, "IS $1\nVO");
+		translator.setString(text);
+		
+		var i = 0;		
+		translator.setHandler('itemDone', function(obj, newItem) {
+			//split names
+			for (var i=0, n=newItem.creators.length; i<n; i++) {
+				var creator = newItem.creators[i];
+				if (creator.firstName) continue;
+				
+				var lastSpace = creator.lastName.lastIndexOf(' ');
+				if (creator.lastName.search(/[A-Za-z]/) !== -1 && lastSpace !== -1) {
+					//western name. split on last space
+					creator.firstName = creator.lastName.substr(0,lastSpace);
+					creator.lastName = creator.lastName.substr(lastSpace+1);
+				} else {
+					//Chinese name. first character is last name, the rest are first name
+					creator.firstName = creator.lastName.substr(1);
+					creator.lastName = creator.lastName.charAt(0);
+				}
+			}
+			
+			if (newItem.abstractNote) {
+				newItem.abstractNote = newItem.abstractNote.replace(/\s*[\r\n]\s*/g, '\n');
+			}
+			
+			//clean up tags. Remove numbers from end
+			for (var i=0, n=newItem.tags.length; i<n; i++) {
+				newItem.tags[i] = newItem.tags[i].replace(/:\d+$/, '');
+			}
+			
+			newItem.title = ZU.trimInternal(newItem.title);
+			if (itemInfo) {
+				var info = itemInfo[newItem.title];
+				if (!info) {
+					Z.debug('No item info for "' + newItem.title + '"');
+				} else {
+					/*if (!info.pdfURL) {
+						Z.debug('No PDF URL passed from multiples page');
+					} else {
+						newItem.attachments.push({
+							title: 'Full Text PDF',
+							mimeType: 'application/pdf',
+							url: info.pdfURL
+						})
+					}*/
+					
+					newItem.url = info.url;
+				}
+			} else {
+				newItem.url = url;
+			}
+			
+			i++;
+			
+			// CN 中国刊物编号，非refworks中的callNumber
+			if (newItem.callNumber){
+				newItem.extra = 'CN ' + newItem.callNumber;
+				newItem.callNumber = "";
+			};
+			
+			newItem.attachments = getAttachments(doc, newItem);
+			
+			newItem.complete();
+			//Z.debug(newItem);
+		});
+		
+		translator.translate();
+	})
+}
+
+
+// pdf 下载链接
+function getPDF(doc) {
+	var pdf = ZU.xpath(doc, "//a[@name='pdfDown']");
+	return pdf.length ? pdf[0].href : false;
+};
+
+// caj 下载链接，学位论文默认是整本下载
+function getCAJ(doc, itemType) {
+	// //div[@id='DownLoadParts']
+	if (itemType == 'thesis') {
+		var caj = ZU.xpath(doc, "//div[@id='DownLoadParts']/a");
+	} else {
+		var caj = ZU.xpath(doc, "//a[@name='cajDown']");
+	}
+	return caj.length ? caj[0].href : false;
+};
+
+// 将pdf, caj 或 网页快照添加到attachments中. 有pdf的优先保存pdf
+function getAttachments(doc, item){
+	attachments = [{
+		url: item.url,
+		title: item.title,
+		mimeType: "text/html",
+		snapshot: true
+		}];
+	var pdfurl = getPDF(doc);
+	var cajurl = getCAJ(doc, item.itemType);
+	//Z.debug('pdf' + pdfurl);
+	//Z.debug('caj' + cajurl);
+	
+	if (pdfurl){
+		attachments.push({
+			title: "Full Text PDF",
+			mimeType: "application/pdf",
+			url: pdfurl});
+	} else if (cajurl) {
+		attachments.push({
+			title: "Full Text CAJ",
+			mimeType: "application/caj",
+			url: cajurl});
+	};
+	
+	return attachments;
+};
+
 /** BEGIN TEST CASES **/
 var testCases = [
+	{
+		"type": "web",
+		"url": "https://kns.cnki.net/KCMS/detail/detail.aspx?dbcode=CMFD&dbname=CMFD201802&filename=1018144727.nh&v=MDU5ODRSTE9lWitkcUZ5bm1VN3ZPVkYyNkZySzhHdGJPcUpFYlBJUjhlWDFMdXhZUzdEaDFUM3FUcldNMUZyQ1U=",
+		"items": [
+			{
+				"itemType": "thesis",
+				"title": "中小企业融资方式的比较与选择",
+				"creators": [
+					{
+						"lastName": "戈",
+						"firstName": "亚妮",
+						"creatorType": "author"
+					}
+				],
+				"date": "2018",
+				"abstractNote": "改革开放后,我国特色社会主义市场经济迅猛发展,经济发展呈现多元化的特点,中小企业的规模如雨后春笋般逐渐成长起来。它们在国民经济中发挥的作用越来越大,所占据的地位也越来越重要。中小企业的发展情况影响着人民的就业问题,以及国家经济发展和国民收入分配问题,从而影响到社会主体市场经济的稳定发展。优化改善中小企业的生存环境,加大资金技术支持帮扶力度,是推动地方经济迅猛发展的创新之路,也是必由之路。然而现阶段来看,在我国中小企业的生存发展举步维艰,很多中小企业在创立之初展现积极的态势,而后几年由于资金、技术等原因无法支撑,以至走到破产的地步。能够长久发展的中小企业如数家珍。这里面有外部环境问题,也有其自身...",
+				"language": "中文;",
+				"libraryCatalog": "CNKI",
+				"thesisType": "硕士",
+				"university": "首都经济贸易大学",
+				"url": "https://kns.cnki.net/KCMS/detail/detail.aspx?dbcode=CMFD&dbname=CMFD201802&filename=1018144727.nh&v=MDU5ODRSTE9lWitkcUZ5bm1VN3ZPVkYyNkZySzhHdGJPcUpFYlBJUjhlWDFMdXhZUzdEaDFUM3FUcldNMUZyQ1U=",
+				"attachments": [
+					{
+						"title": "中小企业融资方式的比较与选择",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
+						"title": "Full Text CAJ",
+						"mimeType": "application/caj"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Compare"
+					},
+					{
+						"tag": "Financing Methods"
+					},
+					{
+						"tag": "SME"
+					},
+					{
+						"tag": "Select"
+					},
+					{
+						"tag": "中小企业"
+					},
+					{
+						"tag": "比较分析"
+					},
+					{
+						"tag": "融资方式"
+					},
+					{
+						"tag": "选择建议"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
 	{
 		"type": "web",
 		"url": "http://kns.cnki.net/KCMS/detail/detail.aspx?dbcode=CJFQ&dbname=CJFDLAST2015&filename=SPZZ201412003&v=MTU2MzMzcVRyV00xRnJDVVJMS2ZidVptRmkva1ZiL09OajNSZExHNEg5WE5yWTlGWjRSOGVYMUx1eFlTN0RoMVQ=",
@@ -282,7 +476,7 @@ var testCases = [
 				"date": "2014",
 				"ISSN": "1000-8713",
 				"abstractNote": "来自中药的水溶性多糖具有广谱治疗和低毒性特点,是天然药物及保健品研发中的重要组成部分。针对中药多糖结构复杂、难以表征的问题,本文以中药黄芪中的多糖为研究对象,采用\"自下而上\"法完成对黄芪多糖的表征。首先使用部分酸水解方法水解黄芪多糖,分别考察了水解时间、酸浓度和温度的影响。在适宜条件(4 h、1.5mol/L三氟乙酸、80℃)下,黄芪多糖被水解为特征性的寡糖片段。接下来,采用亲水作用色谱与质谱联用对黄芪多糖部分酸水解产物进行分离和结构表征。结果表明,提取得到的黄芪多糖主要为1→4连接线性葡聚糖,水解得到聚合度4~11的葡寡糖。本研究对其他中药多糖的表征具有一定的示范作用。",
-				"callNumber": "21-1185/O6",
+				"extra": "21-1185/O6",
 				"issue": "12",
 				"language": "中文;",
 				"libraryCatalog": "CNKI",
@@ -290,7 +484,17 @@ var testCases = [
 				"publicationTitle": "色谱",
 				"url": "http://kns.cnki.net/KCMS/detail/detail.aspx?dbcode=CJFQ&dbname=CJFDLAST2015&filename=SPZZ201412003&v=MTU2MzMzcVRyV00xRnJDVVJMS2ZidVptRmkva1ZiL09OajNSZExHNEg5WE5yWTlGWjRSOGVYMUx1eFlTN0RoMVQ=",
 				"volume": "32",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "基于部分酸水解-亲水作用色谱-质谱的黄芪多糖结构表征",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
 				"tags": [
 					{
 						"tag": "Astragalus"

--- a/Time.com.js
+++ b/Time.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2019-06-10 23:02:32"
+	"lastUpdated": "2019-10-06 18:12:01"
 }
 
 /*
@@ -36,7 +36,7 @@
 */
 
 function detectWeb(doc, url) {
-	if (url.includes('results.html')) {
+	if (url.includes('/search/?q=') && getSearchResults(doc, true)) {
 		return "multiple";
 	}
 	else if (url.search(/\/article\/|\d{4}\/\d{2}\/\d{2}\/./) != -1
@@ -63,10 +63,14 @@ function handleAuthors(authors) {
 		}
 		
 		// x, y and z
-		authors = authors.replace(/^By\s+|\sBy\s+/, "").split(/\s*,\s*|\s+and\s+/i);
+		authors = authors.replace(/^\s*By\s+/, "").split(/\s*,\s*|\s+and\s+/i);
 		var authArr = [];
 		for (var i = 0, n = authors.length; i < n; i++) {
-			authArr.push(ZU.cleanAuthor(ZU.capitalizeTitle(authors[i].replace(/\s+@.+/, "")), 'author'));
+			let author = authors[i].replace(/\s*[@/].+/, "");
+			if (author.toUpperCase() == author) {
+				author = ZU.capitalizeTitle(author);
+			}
+			authArr.push(ZU.cleanAuthor(author, 'author'));
 		}
 		if (authArr.length) return authArr;
 	}
@@ -75,16 +79,18 @@ function handleAuthors(authors) {
 
 function handleKeywords(keywords) {
 	if (keywords && (keywords = keywords.trim())) {
-		return keywords.split(', ');
+		return keywords.split(/,\s*/);
 	}
 	return [];
 }
 
 function scrape(doc, url) {
-	var article = ZU.xpath(doc, '//section/div[@class="wrapper"]/article[contains(@class, "active")]')[0],
-		metaUrl = ZU.xpathText(doc, '/html/head/meta[@property="og:url"]/@content');
-
+	var article = ZU.xpath(doc, '//section/div[@class="wrapper"]/article[contains(@class, "active")]')[0];
+	var metaUrl = ZU.xpathText(doc, '/html/head/meta[@property="og:url"]/@content');
+	
 	if (article && metaUrl && !doc.location.href.includes(metaUrl)) {
+		// time has a feature where you scroll to the next article
+		// in this case we have to use the active article instead
 		var item = new Zotero.Item("magazineArticle");
 		item.title = ZU.trimInternal(article.getElementsByClassName('article-title')[0].textContent);
 		item.publicationTitle = "Time";
@@ -125,18 +131,26 @@ function scrape(doc, url) {
 			var authors = ZU.xpathText(doc, '//meta[@name="byline"]/@content')
 				|| ZU.xpathText(doc, '//span[@class="author vcard"]/a', null, ' and ')
 				|| ZU.xpathText(doc, '//span[@class="entry-byline"]')
-				|| ZU.xpathText(doc, '//header[@class="article-header"]//ul[@class="article-authors"]//span[@class="byline"]/a');
+				|| ZU.xpathText(doc, '//header[@class="article-header"]//ul[@class="article-authors"]//span[@class="byline"]/a')
+				|| ZU.xpathText(doc, '//div[contains(@class, "author-text")]/a');
 			if (authors) item.creators = handleAuthors(authors);
 
 			var title = ZU.xpathText(doc, '//h1[@class="entry-title"]');
-			if (title) item.title = title;
+			if (!item.title && title) item.title = title;
 			
 			var keywords = ZU.xpathText(doc, '/html/head/meta[@name="keywords"]/@content')
 				|| ZU.xpathText(doc, 'header//a[@class="topic-tag" or @class="section-tag"]');
-			if (keywords) item.tags = handleKeywords(keywords);
+			if (item.tags.length == 0 && keywords) item.tags = handleKeywords(keywords);
 			
 			if (!item.abstractNote) item.abstractNote = ZU.xpathText(doc, '//h2[@class="article-excerpt"]');
-			if (!item.date) item.date = ZU.xpathText(doc, '//time[@class="publish-date"]/@datetime');
+			if (!item.date) {
+				item.date = ZU.xpathText(doc, '//time[@class="publish-date"]/@datetime')
+					|| ZU.xpathText(doc, '//div[contains(@class, "published-date")]')
+					|| ZU.xpathText(doc, '//span[contains(@class, "entry-date")]');
+			}
+			if (item.date) {
+				item.date = ZU.strToISO(item.date);
+			}
 			
 			item.complete();
 		});
@@ -152,24 +166,42 @@ function scrape(doc, url) {
 }
 
 
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('article .headline>a');
+	for (var i = 0; i < rows.length; i++) {
+		var href = rows[i].href;
+		var title = ZU.trimInternal(rows[i].textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+
 function doWeb(doc, url) {
-	if (detectWeb(doc, url) == 'multiple') {
-		var items = ZU.getItemArray(doc, doc.getElementsByTagName("h3"));
-		Zotero.selectItems(items, function (selectedItems) {
-			if (!selectedItems) return;
-		
-			var urls = [];
-			for (var i in selectedItems) {
-				urls.push(i);
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return;
 			}
-			Z.debug(urls);
-			ZU.processDocuments(urls, scrape);
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrape);
 		});
 	}
 	else {
 		scrape(doc, url);
 	}
-}/** BEGIN TEST CASES **/
+}
+
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
@@ -338,6 +370,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
+				"date": "2012-03-04",
 				"ISSN": "0040-781X",
 				"abstractNote": "Obama rejected any notion that his administration has not been in Israel's corner. “Over the last three years, as President of the United States, I have kept my commitments to the state of Israel.\" The President then ticked off the number of ways he has supported Israel in the last year.",
 				"language": "en-US",
@@ -350,16 +383,36 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"aipac",
-					"barack obama",
-					"bibi",
-					"iran",
-					"israel",
-					"mahmoud ahamadinejad",
-					"netanyahu",
-					"obama",
-					"speech",
-					"washington"
+					{
+						"tag": "aipac"
+					},
+					{
+						"tag": "barack obama"
+					},
+					{
+						"tag": "bibi"
+					},
+					{
+						"tag": "iran"
+					},
+					{
+						"tag": "israel"
+					},
+					{
+						"tag": "mahmoud ahamadinejad"
+					},
+					{
+						"tag": "netanyahu"
+					},
+					{
+						"tag": "obama"
+					},
+					{
+						"tag": "speech"
+					},
+					{
+						"tag": "washington"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -380,6 +433,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
+				"date": "2012-03-02",
 				"ISSN": "0040-781X",
 				"abstractNote": "Despite signs that some housing markets are improving, the overall trend is for home prices (and values) to keep dropping—and dropping. As values shrink, more and more homeowners find themselves underwater, the unfortunate scenario in which one owes more on the mortgage than the home is worth.",
 				"language": "en-US",
@@ -393,24 +447,60 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"arizona",
-					"baltimore",
-					"california",
-					"california real estate",
-					"dallas",
-					"economics & policy",
-					"florida",
-					"florida real estate",
-					"georgia",
-					"mortgages",
-					"nevada",
-					"personal finance",
-					"real estate & homes",
-					"real estate markets",
-					"sunbelt",
-					"the economy",
-					"underwater",
-					"upside-down"
+					{
+						"tag": "arizona"
+					},
+					{
+						"tag": "baltimore"
+					},
+					{
+						"tag": "california"
+					},
+					{
+						"tag": "california real estate"
+					},
+					{
+						"tag": "dallas"
+					},
+					{
+						"tag": "economics & policy"
+					},
+					{
+						"tag": "florida"
+					},
+					{
+						"tag": "florida real estate"
+					},
+					{
+						"tag": "georgia"
+					},
+					{
+						"tag": "mortgages"
+					},
+					{
+						"tag": "nevada"
+					},
+					{
+						"tag": "personal finance"
+					},
+					{
+						"tag": "real estate & homes"
+					},
+					{
+						"tag": "real estate markets"
+					},
+					{
+						"tag": "sunbelt"
+					},
+					{
+						"tag": "the economy"
+					},
+					{
+						"tag": "underwater"
+					},
+					{
+						"tag": "upside-down"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -419,8 +509,49 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://search.time.com/results.html?Ntt=labor&N=0&Nty=1&p=0&cmd=tags",
+		"url": "https://time.com/search/?q=labor",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://time.com/5691641/trump-conspiracy-fears/",
+		"items": [
+			{
+				"itemType": "magazineArticle",
+				"title": "How Trump's Obsession With a Conspiracy Theory Led to the Impeachment Crisis",
+				"creators": [
+					{
+						"firstName": "Simon",
+						"lastName": "Shuster",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Vera",
+						"lastName": "Bergengruen",
+						"creatorType": "author"
+					}
+				],
+				"date": "2019-10-03",
+				"ISSN": "0040-781X",
+				"abstractNote": "The warning signs were there",
+				"language": "en-US",
+				"libraryCatalog": "time.com",
+				"publicationTitle": "Time",
+				"url": "https://time.com/5691641/trump-conspiracy-fears/",
+				"attachments": [
+					{
+						"title": "Snapshot"
+					}
+				],
+				"tags": [
+					{
+						"tag": "White House"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
1. Update target regex to match CNKI url prefix via proxy
2. Add snapshot attachment by default. PDF and CAJ file links will be added when the url is accessible
3. Use `doGet` to get refoworks from CNKI. `doPost` may have CSRF
    problem via proxy.
4. Add function 'getIDFromRef' to get `dbname` and `filename` from
    reference links. `getIDFromUrl` can not get `dbname` and `filename` when
    the article is pre-released.
5. Change `journal article` field value `callNumber`. `CN` in CNKI
    refwork format is not the `callNumber`, it's a Chinese version of ISSN.
    Move `CN` to extra field.