### PR TITLE
Douban: deal with url item and update unit tests

### DIFF
--- a/Douban.js
+++ b/Douban.js
@@ -9,23 +9,23 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-01-01 16:52:39"
+	"lastUpdated": "2019-10-28 20:20:19"
 }
 
 /*
    Douban Translator
    Copyright (C) 2009-2010 TAO Cheng, acestrong@gmail.com
-   
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -62,9 +62,10 @@ function trimMultispace(text) {
 
 // #############################
 // ##### Scraper functions #####
-// ############################# 
+// #############################
 
 function scrapeAndParse(doc, url) {
+	// Z.debug({ url })
 Zotero.Utilities.HTTP.doGet(url, function(page){
 	//Z.debug(page)
 	var pattern;
@@ -82,7 +83,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.title = Zotero.Utilities.trim(trimTags(title));
 //		Zotero.debug("title: "+title);
 	}
-	
+
 	// 又名
 	pattern = /<span [^>]*?>又名:(.*?)<\/span>/;
 	if (pattern.test(page)) {
@@ -92,7 +93,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 	}
 
 	// 作者
-	
+
 	page = page.replace(/\n/g, "")
 	//Z.debug(page)
 	pattern = /<span>\s*<span[^>]*?>\s*作者<\/span>:(.*?)<\/span>/;
@@ -116,7 +117,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 				"author", useComma));
 		}
 	}
-	
+
 	// 译者
 	pattern = /<span>\s*<span [^>]*?>\s*译者<\/span>:(.*?)<\/span>/;
 	if (pattern.test(page)) {
@@ -144,7 +145,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.ISBN = Zotero.Utilities.trim(isbn);
 //		Zotero.debug("isbn: "+isbn);
 	}
-	
+
 	// 页数
 	pattern = /<span [^>]*?>页数:<\/span>(.*?)<br\/>/;
 	if (pattern.test(page)) {
@@ -152,7 +153,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.numPages = Zotero.Utilities.trim(numPages);
 //		Zotero.debug("numPages: "+numPages);
 	}
-	
+
 	// 出版社
 	pattern = /<span [^>]*?>出版社:<\/span>(.*?)<br\/>/;
 	if (pattern.test(page)) {
@@ -160,7 +161,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.publisher = Zotero.Utilities.trim(publisher);
 //		Zotero.debug("publisher: "+publisher);
 	}
-	
+
 	// 丛书
 	pattern = /<span [^>]*?>丛书:<\/span>(.*?)<br\/>/;
 	if (pattern.test(page)) {
@@ -168,7 +169,7 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.series = Zotero.Utilities.trim(series);
 //		Zotero.debug("series: "+series);
 	}
-	
+
 	// 出版年
 	pattern = /<span [^>]*?>出版年:<\/span>(.*?)<br\/>/;
 	if (pattern.test(page)) {
@@ -176,14 +177,14 @@ Zotero.Utilities.HTTP.doGet(url, function(page){
 		newItem.date = Zotero.Utilities.trim(date);
 //		Zotero.debug("date: "+date);
 	}
-	
+
 	// 简介
 	var tags = ZU.xpath(doc, '//div[@id="db-tags-section"]/div//a');
 	for (i in tags){
 		newItem.tags.push(tags[i].textContent)
 	}
 	newItem.abstractNote = ZU.xpathText(doc, '//span[@class="short"]/div[@class="intro"]/p')
-	
+
 	newItem.complete();
 });
 }
@@ -205,14 +206,19 @@ function detectWeb(doc, url) {
 
 function doWeb(doc, url) {
 	var articles = new Array();
-	if (detectWeb(doc, url) == "multiple") { 
+	let r = /douban.com\/url\//
+	if (detectWeb(doc, url) == "multiple") {
+		// also searches but they don't work as test cases in Scaffold
+		// e.g. https://book.douban.com/subject_search?search_text=Murakami&cat=1001
 		var items = {};
 		var titles = ZU.xpath(doc, '//div[@class="title"]/a');
 		var title;
 		for (let i = 0; i < titles.length; i++){
 			title = titles[i];
-			Zotero.debug(title.href);
-			Zotero.debug(title.textContent);
+			//Zotero.debug({ href: title.href, title: title.textContent });
+			if (r.test(title.href)) { // Ignore links
+				continue
+			}
 			items[title.href] = title.textContent;
 		}
 		Zotero.selectItems(items, function (items) {
@@ -229,13 +235,9 @@ function doWeb(doc, url) {
 		scrapeAndParse(doc, url);
 	}
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
-	{
-		"type": "web",
-		"url": "http://book.douban.com/subject_search?search_text=Murakami&cat=1001",
-		"items": "multiple"
-	},
 	{
 		"type": "web",
 		"url": "https://book.douban.com/subject/1355643/",
@@ -255,11 +257,11 @@ var testCases = [
 						"creatorType": "translator"
 					}
 				],
-				"date": "2003-06-30",
+				"date": "2003",
 				"ISBN": "9780099448822",
 				"abstractNote": "When he hears her favourite Beatles song, Toru Watanabe recalls his first love Naoko, the girlfriend of his best friend Kizuki. Immediately he is transported back almost twenty years to his student days in Tokyo, adrift in a world of uneasy friendships, casual sex, passion, loss and desire - to a time when an impetuous young woman called Midori marches into his life and he has ..., (展开全部)",
 				"libraryCatalog": "Douban",
-				"numPages": "400",
+				"numPages": "389",
 				"publisher": "Vintage",
 				"url": "https://book.douban.com/subject/1355643/",
 				"attachments": [],
@@ -268,8 +270,8 @@ var testCases = [
 					"小说",
 					"挪威森林英文版",
 					"日本",
+					"日本文学",
 					"村上春树",
-					"英文",
 					"英文原版",
 					"英文版"
 				],
@@ -277,6 +279,11 @@ var testCases = [
 				"seeAlso": []
 			}
 		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.douban.com/doulist/120664512/",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
Safari can't open this [link](https://www.douban.com/url/9552666/) where Chrome can.
This is why some [Dou List](https://www.douban.com/doulist/120664512/) which contains URL item can't be scraped (I guess)
I fixed this issue by add the URL item as a webpage without snapshot.