### PR TITLE
Idref fix & improvement

### DIFF
--- a/Idref.js
+++ b/Idref.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-02-12 13:03:06"
+	"lastUpdated": "2019-11-03 13:03:06"
 }
 
 /*
@@ -35,23 +35,24 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(doc, url) { 
-	if (ZU.xpathText(doc, '//div[@class="detail_bloc_biblio"]') && getSearchResults(doc, true)) {
-		return "multiple";	
+function detectWeb(doc, url) {
+	if (getSearchResults(doc, true)) {
+		return "multiple";
 	}
+	Z.monitorDOMChanges(doc.getElementById("ref-liees-p"));
 }
 
 function getSearchResults(doc, checkOnly) {
 	var resultsTitle = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_value")]');
 	var resultsHref = ZU.xpath(doc, '//div[@id="perenne-references-docs"]/span[contains(@class, "detail_label")]/a/@href');
 	var found = false;
-	items = {};
-	for (let i=0; i<resultsTitle.length; i++) {
-		href = resultsHref[i].textContent;
+	var items = {};
+	for (let i = 0; i < resultsTitle.length; i++) {
+		var href = resultsHref[i].textContent;
 		// We need to replace the http://www.sudoc.fr/XXXXXX links are they are redirects and aren't handled correctly from subtranslator
 		href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
 
-		if ( (href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) ) {
+		if ((href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) || (href.includes("catalogue.bnf.fr")) || (href.includes("www.theses.fr")) || (href.includes("pub.orcid.org"))) {
 			if (checkOnly) return true;
 			found = true;
 			items[href] = resultsTitle[i].textContent;
@@ -60,8 +61,7 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-function doWeb(doc, url)
-{
+function doWeb(doc, url) {
 	Zotero.selectItems(getSearchResults(doc, false), function (selectedItems) {
 		if (!selectedItems) {
 			return true;
@@ -75,27 +75,50 @@ function doWeb(doc, url)
 }
 
 function scrape(doc, url) {
-	var translator = Zotero.loadTranslator('web');	
+	var translator = Zotero.loadTranslator('web');
 	
-	if (url.includes("archives-ouvertes")){
-		// HAL Archives ouvertes
+	if (url.includes("archives-ouvertes")) {
 		translator.setTranslator('58ab2618-4a25-4b9b-83a7-80cd0259f896');
-	} else if (url.includes("sudoc.abes.fr")) {
-		// Sudoc
+	}
+	else if (url.includes("sudoc.abes.fr")) {
 		translator.setTranslator('1b9ed730-69c7-40b0-8a06-517a89a3a278');
-	} else {
+	}
+	else if (url.includes("catalogue.bnf.fr")) {
+		translator.setTranslator('47533cd7-ccaa-47a7-81bb-71c45e68a74d');
+	}
+	else if (url.includes("www.theses.fr")) {
+		translator.setTranslator('3f73f0aa-f91c-4192-b0d5-907312876cb9');
+	}
+	else {
+		// Orcid is the only case where we need to use an import translator, different behvior from previous ones
+		if (url.includes("pub.orcid.org")) {
+			// Idrefs contains orcid links with /works/ for which the content negotiation
+			// does not allow to get CSL results. Each link describes only one reference
+			// so we can safely replace /works/ by /work/. The last one allows content negotiation
+			url = url.replace("/works/", "/work/");
+
+			ZU.doGet(url, function (text) {
+				var translator = Zotero.loadTranslator("import");
+				translator.setTranslator("bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7");// CSL JSON
+				translator.setString(text);
+				translator.translate();
+			}, undefined, undefined, { Accept: "application/vnd.citationstyles.csl+json" });
+	
+			return;
+		}
 		Z.debug("Undefined website");
-		return false;
+		return;
 	}
 
 	translator.setHandler('itemDone', function (obj, item) {
 		item.complete();
 	});
 	
-	translator.getTranslatorObject(function(trans) {
+	translator.getTranslatorObject(function (trans) {
 		trans.doWeb(doc, url);
 	});
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{

--- a/Idref.js
+++ b/Idref.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-11-03 13:03:06"
+	"lastUpdated": "2019-11-09 11:21:06"
 }
 
 /*
@@ -35,11 +35,12 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(doc, url) {
+function detectWeb(doc, _url) {
 	if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
 	Z.monitorDOMChanges(doc.getElementById("ref-liees-p"));
+	return false;
 }
 
 function getSearchResults(doc, checkOnly) {
@@ -61,10 +62,10 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-function doWeb(doc, url) {
+function doWeb(doc, _url) {
 	Zotero.selectItems(getSearchResults(doc, false), function (selectedItems) {
 		if (!selectedItems) {
-			return true;
+			return;
 		}
 		var articles = [];
 		for (var i in selectedItems) {


### PR DESCRIPTION
Based on discussion on #1610 this PR is : 

- using the ```monitorDOMChanges``` function to delay the detectWeb function result until the result list is fully loaded;
- adding calls to three translators that were not supported previously : catalogue.bnf.fr, theses.fr & orcid.org. Records from these three sites can appear on idref authors pages.