### PR TITLE
Adding two types of sources to Idref.js (oatao + persee)

### DIFF
--- a/Idref.js
+++ b/Idref.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-11-16 21:34:33"
+	"lastUpdated": "2019-11-21 11:52:29"
 }
 
 /*
@@ -35,6 +35,17 @@
 	***** END LICENSE BLOCK *****
 */
 
+var domain2translator = {
+	'www.sudoc.abes.fr': '1b9ed730-69c7-40b0-8a06-517a89a3a278',
+	'hal.archives-ouvertes.fr': '58ab2618-4a25-4b9b-83a7-80cd0259f896',
+	'memsic.ccsd.cnrs.fr': '58ab2618-4a25-4b9b-83a7-80cd0259f896',
+	'catalogue.bnf.fr': '47533cd7-ccaa-47a7-81bb-71c45e68a74d',
+	'www.theses.fr': '3f73f0aa-f91c-4192-b0d5-907312876cb9',
+	'www.persee.fr': '951c027d-74ac-47d4-a107-9c3069ab7b48',
+	'oatao.univ-toulouse.fr': '951c027d-74ac-47d4-a107-9c3069ab7b48',
+	'pub.orcid.org': 'bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7',
+};
+
 function detectWeb(doc, _url) {
 	if (getSearchResults(doc, true)) {
 		return "multiple";
@@ -52,11 +63,15 @@ function getSearchResults(doc, checkOnly) {
 		var href = resultsHref[i].textContent;
 		// We need to replace the http://www.sudoc.fr/XXXXXX links are they are redirects and aren't handled correctly from subtranslator
 		href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
+		var domain = urlToDomain(href);
 
-		if ((href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) || (href.includes("catalogue.bnf.fr")) || (href.includes("www.theses.fr")) || (href.includes("pub.orcid.org")) || (href.includes("www.persee.fr")) || (href.includes("oatao.univ-toulouse.fr"))) {
+		if (domain2translator[domain]) {
 			if (checkOnly) return true;
 			found = true;
 			items[href] = resultsTitle[i].textContent;
+		}
+		else {
+			Z.debug("Not found : " + domain);
 		}
 	}
 	return found ? items : false;
@@ -78,38 +93,29 @@ function doWeb(doc, _url) {
 function scrape(doc, url) {
 	var translator = Zotero.loadTranslator('web');
 	
-	if (url.includes("archives-ouvertes")) {
-		translator.setTranslator('58ab2618-4a25-4b9b-83a7-80cd0259f896');
+	// Orcid is the only case where we need to use an import translator, different behvior from previous ones
+	if (url.includes("pub.orcid.org")) {
+		// Idrefs contains orcid links with /works/ for which the content negotiation
+		// does not allow to get CSL results. Each link describes only one reference
+		// so we can safely replace /works/ by /work/. The last one allows content negotiation
+		url = url.replace("/works/", "/work/");
+
+		ZU.doGet(url, function (text) {
+			var translator = Zotero.loadTranslator("import");
+			translator.setTranslator("bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7");// CSL JSON
+			translator.setString(text);
+			translator.translate();
+		}, undefined, undefined, { Accept: "application/vnd.citationstyles.csl+json" });
+
+		return;
 	}
-	else if (url.includes("sudoc.abes.fr")) {
-		translator.setTranslator('1b9ed730-69c7-40b0-8a06-517a89a3a278');
-	}
-	else if (url.includes("catalogue.bnf.fr")) {
-		translator.setTranslator('47533cd7-ccaa-47a7-81bb-71c45e68a74d');
-	}
-	else if (url.includes("www.theses.fr")) {
-		translator.setTranslator('3f73f0aa-f91c-4192-b0d5-907312876cb9');
-	}
-	else if (url.includes("www.persee.fr") || url.includes("oatao.univ-toulouse.fr")) {
-		translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48'); // Embedded metadata
+	
+	var domain = urlToDomain(url);
+	
+	if (domain2translator[domain]) {
+		translator.setTranslator(domain2translator[domain]);
 	}
 	else {
-		// Orcid is the only case where we need to use an import translator, different behvior from previous ones
-		if (url.includes("pub.orcid.org")) {
-			// Idrefs contains orcid links with /works/ for which the content negotiation
-			// does not allow to get CSL results. Each link describes only one reference
-			// so we can safely replace /works/ by /work/. The last one allows content negotiation
-			url = url.replace("/works/", "/work/");
-
-			ZU.doGet(url, function (text) {
-				var translator = Zotero.loadTranslator("import");
-				translator.setTranslator("bc03b4fe-436d-4a1f-ba59-de4d2d7a63f7");// CSL JSON
-				translator.setString(text);
-				translator.translate();
-			}, undefined, undefined, { Accept: "application/vnd.citationstyles.csl+json" });
-	
-			return;
-		}
 		Z.debug("Undefined website");
 		return;
 	}
@@ -121,6 +127,10 @@ function scrape(doc, url) {
 	translator.getTranslatorObject(function (trans) {
 		trans.doWeb(doc, url);
 	});
+}
+
+function urlToDomain(url) {
+	return url.replace(/https?:\/\/([^/]*).*/, "$1");
 }
 
 /** BEGIN TEST CASES **/

--- a/Idref.js
+++ b/Idref.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-11-09 11:21:06"
+	"lastUpdated": "2019-11-16 21:34:33"
 }
 
 /*
@@ -53,7 +53,7 @@ function getSearchResults(doc, checkOnly) {
 		// We need to replace the http://www.sudoc.fr/XXXXXX links are they are redirects and aren't handled correctly from subtranslator
 		href = href.replace(/http:\/\/www\.sudoc\.fr\/(.*)$/, "http://www.sudoc.abes.fr/xslt/DB=2.1//SRCH?IKT=12&TRM=$1");
 
-		if ((href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) || (href.includes("catalogue.bnf.fr")) || (href.includes("www.theses.fr")) || (href.includes("pub.orcid.org"))) {
+		if ((href.includes("www.sudoc.abes.fr")) || (href.includes("archives-ouvertes")) || (href.includes("catalogue.bnf.fr")) || (href.includes("www.theses.fr")) || (href.includes("pub.orcid.org")) || (href.includes("www.persee.fr")) || (href.includes("oatao.univ-toulouse.fr"))) {
 			if (checkOnly) return true;
 			found = true;
 			items[href] = resultsTitle[i].textContent;
@@ -89,6 +89,9 @@ function scrape(doc, url) {
 	}
 	else if (url.includes("www.theses.fr")) {
 		translator.setTranslator('3f73f0aa-f91c-4192-b0d5-907312876cb9');
+	}
+	else if (url.includes("www.persee.fr") || url.includes("oatao.univ-toulouse.fr")) {
+		translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48'); // Embedded metadata
 	}
 	else {
 		// Orcid is the only case where we need to use an import translator, different behvior from previous ones

--- a/Idref.js
+++ b/Idref.js
@@ -130,7 +130,7 @@ function scrape(doc, url) {
 }
 
 function urlToDomain(url) {
-	return url.replace(/https?:\/\/([^/]*).*/, "$1");
+	return url.replace(/^https?:\/\/([^/]*).*/, "$1");
 }
 
 /** BEGIN TEST CASES **/


### PR DESCRIPTION
IDref is a website describing authorities and getting bib records from multiple sources where the authority exists. This PR makes the translators compatible with more sources : 

- [OATAO](https://oatao.univ-toulouse.fr/) for example with some titles from this author : https://www.idref.fr/224733621 (the ones that appear with [the red icon](https://www.idref.fr/img/bibliographie-oatao.png))
- [Persée](https://www.persee.fr/) for example with some titles from this author : https://www.idref.fr/026905035 (the ones that appear with [the green icon](https://www.idref.fr/img/bibliographie-persee.png))