### PR TITLE
IMDb - Fixed creators, date, genre, running time, tags

### DIFF
--- a/IMDb.js
+++ b/IMDb.js
@@ -35,21 +35,25 @@
 	***** END LICENSE BLOCK *****
 */
 
+// attr()/text() v2
+// eslint-disable-next-line
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
 
 function detectWeb(doc, url) {
-	if (url.indexOf('/title/tt')>-1) {
+	if (url.includes('/title/tt')) {
 		return "film";
-	} else if (url.indexOf('/find?')>-1 && getSearchResults(doc, true)) {
+	}
+	else if (url.includes('/find?') && getSearchResults(doc, true)) {
 		return "multiple";
 	}
+	return false;
 }
-
 
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
 	var rows = ZU.xpath(doc, '//td[contains(@class, "result_text")]');
-	for (var i=0; i<rows.length; i++) {
+	for (let i = 0; i < rows.length; i++) {
 		var href = ZU.xpathText(rows[i], './a/@href');
 		var title = ZU.trimInternal(rows[i].textContent);
 		if (!href || !title) continue;
@@ -60,12 +64,11 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
 			if (!items) {
-				return true;
+				return;
 			}
 			var articles = [];
 			for (var i in items) {
@@ -73,7 +76,8 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
@@ -120,11 +124,11 @@ function scrape(doc, _url) {
 	item.complete();
 }
 
-
 function addExtra(item, value) {
 	if (!item.extra) {
 		item.extra = '';
-	} else {
+	}
+	else {
 		item.extra += "\n";
 	}
 	item.extra += value;
@@ -134,11 +138,11 @@ function addExtra(item, value) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://www.imdb.com/title/tt0089276/",
+		"url": "https://www.imdb.com/title/tt0089276/",
 		"items": [
 			{
 				"itemType": "film",
-				"title": "The Official Story",
+				"title": "La historia oficial",
 				"creators": [
 					{
 						"firstName": "Luis",
@@ -169,26 +173,37 @@ var testCases = [
 						"firstName": "Chunchuna",
 						"lastName": "Villafañe",
 						"creatorType": "contributor"
-					}
-				],
-				"date": "1985-11-08",
-				"abstractNote": "Directed by Luis Puenzo.  With Norma Aleandro, Héctor Alterio, Chunchuna Villafañe, Hugo Arana. After the end of the Dirty War, a high school teacher sets out to find out who the mother of her adopted daughter is.",
-				"extra": "original-title: La historia oficial\nIMDb ID: tt0089276",
-				"genre": "Drama, History, War",
-				"libraryCatalog": "www.imdb.com",
-				"runningTime": "1h 52min",
-				"url": "http://www.imdb.com/title/tt0089276/",
-				"attachments": [
+					},
 					{
-						"title": "Snapshot"
+						"firstName": "Hugo",
+						"lastName": "Arana",
+						"creatorType": "contributor"
 					}
 				],
+				"date": "1985-04-03",
+				"abstractNote": "La historia oficial is a movie starring Norma Aleandro, Héctor Alterio, and Chunchuna Villafañe. During the final months of Argentinian Military Dictatorship in 1983, a high school teacher sets out to find out who the mother of her...",
+				"distributor": "Historias Cinematograficas Cinemania,  Progress Communications",
+				"extra": "Translated title: The Official Story\nIMDb ID: tt0089276\nevent-location: Argentina",
+				"genre": "Drama, History, War",
+				"libraryCatalog": "IMDb",
+				"runningTime": "1h52m",
+				"attachments": [],
 				"tags": [
-					" adopted daughter",
-					" high school teacher",
-					" lawyer",
-					" professor",
-					" school"
+					{
+						"tag": "adopted daughter"
+					},
+					{
+						"tag": "high school teacher"
+					},
+					{
+						"tag": "lawyer"
+					},
+					{
+						"tag": "school"
+					},
+					{
+						"tag": "thumb sucking"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -197,16 +212,16 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.imdb.com/find?q=shakespeare&s=tt",
+		"url": "https://www.imdb.com/find?q=shakespeare&s=tt",
 		"items": "multiple"
 	},
 	{
 		"type": "web",
-		"url": "http://www.imdb.com/title/tt0060613/",
+		"url": "https://www.imdb.com/title/tt0060613/",
 		"items": [
 			{
 				"itemType": "film",
-				"title": "Skin, Skin",
+				"title": "Käpy selän alla",
 				"creators": [
 					{
 						"firstName": "Mikko",
@@ -237,26 +252,37 @@ var testCases = [
 						"firstName": "Pekka",
 						"lastName": "Autiovuori",
 						"creatorType": "contributor"
-					}
-				],
-				"date": "1967-08-18",
-				"abstractNote": "Directed by Mikko Niskanen.  With Eero Melasniemi, Kristiina Halkola, Pekka Autiovuori, Kirsti Wallasvaara. Depiction of four urban youths and their excursion to the countryside.",
-				"extra": "original-title: Käpy selän alla\nIMDb ID: tt0060613",
-				"genre": "Drama",
-				"libraryCatalog": "www.imdb.com",
-				"runningTime": "1h 29min",
-				"url": "http://www.imdb.com/title/tt0060613/",
-				"attachments": [
+					},
 					{
-						"title": "Snapshot"
+						"firstName": "Kirsti",
+						"lastName": "Wallasvaara",
+						"creatorType": "contributor"
 					}
 				],
+				"date": "1966-10-21",
+				"abstractNote": "Käpy selän alla is a movie starring Eero Melasniemi, Kristiina Halkola, and Pekka Autiovuori. Depiction of four urban youths and their excursion to the countryside.",
+				"distributor": "FJ-Filmi",
+				"extra": "Translated title: Amour libre\nIMDb ID: tt0060613\nevent-location: Finland",
+				"genre": "Drama",
+				"libraryCatalog": "IMDb",
+				"runningTime": "1h29m",
+				"attachments": [],
 				"tags": [
-					" countryside",
-					" dance",
-					" drunk",
-					" topless",
-					" youth"
+					{
+						"tag": "countryside"
+					},
+					{
+						"tag": "drunk"
+					},
+					{
+						"tag": "male female relationship"
+					},
+					{
+						"tag": "topless"
+					},
+					{
+						"tag": "youth"
+					}
 				],
 				"notes": [],
 				"seeAlso": []


### PR DESCRIPTION
This fixes #1780. Edited scraper works well in Scaffold, then I put it in my zotero/translator folder and he refuses to use it on Chrome/Mozilla (console says : "Error: Could not establish connection. Receiving end does not exist."). Reverted back in my zotero/translator folder to the original script, and the problem persists on both browsers... Since it does not seem to come from my edits, I open the pull request if you know where it comes from please let me know