### PR TITLE
Protect words with numbers and uppercase characters

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -18,7 +18,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 3,
-	"lastUpdated": "2019-11-30 10:00:00"
+	"lastUpdated": "2019-12-15 20:11:00"
 }
 
 /*
@@ -1307,14 +1307,14 @@ function doExport() {
 		// Case of words with uppercase characters in non-initial positions is
 		// preserved with braces.
 		// Two extra captures because of the other regexp below
-		protectCapsRE = new ZU.XRegExp("()()\\b(\\p{Letter}+\\p{Uppercase_Letter}\\p{Letter}*)", 'g');
+		protectCapsRE = new ZU.XRegExp("()()\\b([\\p{Letter}\\d]+\\p{Uppercase_Letter}[\\p{Letter}\\d]*)", 'g');
 	} else {
 		// Protect all upper case letters, even if the uppercase letter is only in
 		// initial position of the word.
 		// Don't protect first word if only first letter is capitalized
 		protectCapsRE = new ZU.XRegExp(
-			"(.)\\b(\\p{Letter}*\\p{Uppercase_Letter}\\p{Letter}*)" // Non-initial words with capital letter anywhere
-				+ "|^(\\p{Letter}+\\p{Uppercase_Letter}\\p{Letter}*)" // Initial word with capital in non-initial position
+			"(.)\\b([\\p{Letter}\\d]*\\p{Uppercase_Letter}[\\p{Letter}\\d]*)" // Non-initial words with capital letter anywhere
+				+ "|^([\\p{Letter}\\d]+\\p{Uppercase_Letter}[\\p{Letter}\\d]*)" // Initial word with capital in non-initial position
 			, 'g');
 	}
 	


### PR DESCRIPTION
For example 3D will then become {3D} in BibTeX export.
This fixes #1949 for BibTeX.