### PR TITLE
Rewrite ACM translator for new site

### DIFF
--- a/ACM Digital Library.js
+++ b/ACM Digital Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-31 14:12:38"
+	"lastUpdated": "2020-01-09 16:46:31"
 }
 
 /*
@@ -43,7 +43,7 @@ function detectWeb(doc, url) {
 		if (subtype == 'conference') {
 			return 'conferencePaper';
 		}
-		else if (subtype == 'journal' || subtype == 'magazine' || subtype == 'newsletter') {
+		else if (subtype == 'journal' || subtype == 'periodical' || subtype == 'magazine' || subtype == 'newsletter') {
 			return 'journalArticle';
 		}
 		else if (subtype == 'report' || subtype == 'rfc') {
@@ -118,6 +118,7 @@ function scrape(doc) {
 	let extractedContext = doc.querySelector('meta[name=pbContext]').content;
 	let doiRegex = /article:article:doi\\:([^;]+)/;
 	let doi = extractedContext.match(doiRegex)[1].toLowerCase();
+	doi = decodeURIComponent(doi);
 	let lookupEndpoint = 'https://dl.acm.org/action/exportCiteProcCitation?targetFile=custom-bibtex&format=bibTex&dois=';
 	ZU.doGet(lookupEndpoint + doi, function (text) {
 		let json = JSON.parse(text);
@@ -195,39 +196,40 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/doi/abs/10.1145/1596655.1596682",
-		"defer": true,
 		"items": [
 			{
 				"itemType": "conferencePaper",
-				"title": "Tracking Performance Across Software Revisions",
+				"title": "Tracking performance across software revisions",
 				"creators": [
 					{
-						"firstName": "Nagy",
 						"lastName": "Mostafa",
+						"firstName": "Nagy",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Chandra",
 						"lastName": "Krintz",
+						"firstName": "Chandra",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					}
 				],
-				"date": "2009",
+				"date": "August 27, 2009",
 				"DOI": "10.1145/1596655.1596682",
 				"ISBN": "9781605585987",
 				"abstractNote": "Repository-based revision control systems such as CVS, RCS, Subversion, and GIT, are extremely useful tools that enable software developers to concurrently modify source code, manage conflicting changes, and commit updates as new revisions. Such systems facilitate collaboration with and concurrent contribution to shared source code by large developer bases. In this work, we investigate a framework for \"performance-aware\" repository and revision control for Java programs. Our system automatically tracks behavioral differences across revisions to provide developers with feedback as to how their change impacts performance of the application. It does so as part of the repository commit process by profiling the performance of the program or component, and performing automatic analyses that identify differences in the dynamic behavior or performance between two code revisions. In this paper, we present our system that is based upon and extends prior work on calling context tree (CCT) profiling and performance differencing. Our framework couples the use of precise CCT information annotated with performance metrics and call-site information, with a simple tree comparison technique and novel heuristics that together target the cause of performance differences between code revisions without knowledge of program semantics. We evaluate the efficacy of the framework using a number of open source Java applications and present a case study in which we use the framework to distinguish two revisions of the popular FindBugs application.",
-				"extra": "event-place: Calgary, Alberta, Canada",
-				"itemID": "Mostafa:2009:TPA:1596655.1596682",
+				"callNumber": "10.1145/1596655.1596682",
+				"itemID": "10.1145/1596655.1596682",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "162–171",
 				"place": "New York, NY, USA",
 				"proceedingsTitle": "Proceedings of the 7th International Conference on Principles and Practice of Programming in Java",
-				"publisher": "ACM",
+				"publisher": "Association for Computing Machinery",
 				"series": "PPPJ '09",
-				"url": "http://doi.acm.org/10.1145/1596655.1596682",
+				"url": "https://doi.org/10.1145/1596655.1596682",
 				"attachments": [
 					{
-						"title": "ACM Full Text PDF",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
@@ -250,23 +252,24 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/doi/10.5555/1717186",
-		"defer": true,
 		"items": [
 			{
 				"itemType": "book",
 				"title": "Version Control with Git: Powerful Tools and Techniques for Collaborative Software Development",
 				"creators": [
 					{
-						"firstName": "Jon",
 						"lastName": "Loeliger",
+						"firstName": "Jon",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					}
 				],
 				"date": "2009",
 				"ISBN": "9780596520120",
 				"abstractNote": "Version Control with Git takes you step-by-step through ways to track, merge, and manage software projects, using this highly flexible, open source version control system. Git permits virtually an infinite variety of methods for development and collaboration. Created by Linus Torvalds to manage development of the Linux kernel, it's become the principal tool for distributed version control. But Git's flexibility also means that some users don't understand how to use it to their best advantage. Version Control with Git offers tutorials on the most effective ways to use it, as well as friendly yet rigorous advice to help you navigate Git's many functions. With this book, you will: Learn how to use Git in several real-world development environments Gain insight into Git's common-use cases, initial tasks, and basic functions Understand how to use Git for both centralized and distributed version control Use Git to manage patches, diffs, merges, and conflicts Acquire advanced techniques such as rebasing, hooks, and ways to handle submodules (subprojects) Learn how to use Git with Subversion Git has earned the respect of developers around the world. Find out how you can benefit from this amazing tool with Version Control with Git.",
+				"callNumber": "10.5555/1717186",
 				"edition": "1st",
-				"itemID": "Loeliger:2009:VCG:1717186",
+				"itemID": "10.5555/1717186",
 				"libraryCatalog": "ACM Digital Library",
 				"publisher": "O'Reilly Media, Inc.",
 				"shortTitle": "Version Control with Git",
@@ -280,32 +283,34 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/doi/abs/10.1023/A:1008286901817",
-		"defer": true,
 		"items": [
 			{
 				"itemType": "journalArticle",
 				"title": "Simulation Techniques for the Manufacturing Test of MCMs",
 				"creators": [
 					{
-						"firstName": "Mick",
 						"lastName": "Tegethoff",
+						"firstName": "Mick",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Tom",
 						"lastName": "Chen",
+						"firstName": "Tom",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					}
 				],
-				"date": "February 1997",
+				"date": "February 1, 1997",
 				"DOI": "10.1023/A:1008286901817",
 				"ISSN": "0923-8174",
-				"abstractNote": "Simulation techniques used in the Manufacturing Test SIMulator\n(MTSIM) are described. MTSIM is a Concurrent Engineering tool used to\nsimulate the manufacturing test and\nrepair aspects of boards and MCMs from design concept \nthrough manufacturing release. MTSIM helps designers select assembly\nprocess, specify Design For Test (DFT) features, select board test\ncoverage, specify ASIC defect level goals, establish product\nfeasibility, and predict manufacturing quality and cost goals. A new\nyield model for boards and MCMs which accounts for the\nclustering of solder defects is introduced and used to\npredict the yield at each test step. In addition, MTSIM\nestimates the average number of defects per board detected at each\ntest step, and estimates costs incurred in test execution, fault\nisolation and repair. MTSIM models were validated with\nhigh performance assemblies at Hewlett-Packard (HP).",
+				"abstractNote": "Simulation techniques used in the Manufacturing Test SIMulator (MTSIM) are described. MTSIM is a Concurrent Engineering tool used to simulate the manufacturing test and repair aspects of boards and MCMs from design concept through manufacturing release. MTSIM helps designers select assembly process, specify Design For Test (DFT) features, select board test coverage, specify ASIC defect level goals, establish product feasibility, and predict manufacturing quality and cost goals. A new yield model for boards and MCMs which accounts for the clustering of solder defects is introduced and used to predict the yield at each test step. In addition, MTSIM estimates the average number of defects per board detected at each test step, and estimates costs incurred in test execution, fault isolation and repair. MTSIM models were validated with high performance assemblies at Hewlett-Packard (HP).",
+				"callNumber": "10.1023/A:1008286901817",
 				"issue": "1-2",
-				"itemID": "Tegethoff:1997:STM:254650.257486",
+				"itemID": "10.1023/A:1008286901817",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "137–149",
-				"publicationTitle": "J. Electron. Test.",
+				"publicationTitle": "Journal of Electronic Testing: Theory and Applications",
 				"url": "https://doi.org/10.1023/A:1008286901817",
 				"volume": "10",
 				"attachments": [],
@@ -343,39 +348,40 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/doi/abs/10.1145/258948.258973",
-		"defer": true,
 		"items": [
 			{
 				"itemType": "conferencePaper",
-				"title": "Functional Reactive Animation",
+				"title": "Functional reactive animation",
 				"creators": [
 					{
-						"firstName": "Conal",
 						"lastName": "Elliott",
+						"firstName": "Conal",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Paul",
 						"lastName": "Hudak",
+						"firstName": "Paul",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					}
 				],
-				"date": "1997",
+				"date": "August 1, 1997",
 				"DOI": "10.1145/258948.258973",
 				"ISBN": "9780897919180",
 				"abstractNote": "Fran (Functional Reactive Animation) is a collection of data types and functions for composing richly interactive, multimedia animations. The key ideas in Fran are its notions of behaviors and events. Behaviors are time-varying, reactive values, while events are sets of arbitrarily complex conditions, carrying possibly rich information. Most traditional values can be treated as behaviors, and when images are thus treated, they become animations. Although these notions are captured as data types rather than a programming language, we provide them with a denotational semantics, including a proper treatment of real time, to guide reasoning and implementation. A method to effectively and efficiently perform event detection using interval analysis is also described, which relies on the partial information structure on the domain of event times. Fran has been implemented in Hugs, yielding surprisingly good performance for an interpreter-based system. Several examples are given, including the ability to describe physical phenomena involving gravity, springs, velocity, acceleration, etc. using ordinary differential equations.",
-				"extra": "event-place: Amsterdam, The Netherlands",
-				"itemID": "Elliott:1997:FRA:258948.258973",
+				"callNumber": "10.1145/258948.258973",
+				"itemID": "10.1145/258948.258973",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "263–273",
 				"place": "New York, NY, USA",
-				"proceedingsTitle": "Proceedings of the Second ACM SIGPLAN International Conference on Functional Programming",
-				"publisher": "ACM",
+				"proceedingsTitle": "Proceedings of the second ACM SIGPLAN international conference on Functional programming",
+				"publisher": "Association for Computing Machinery",
 				"series": "ICFP '97",
-				"url": "http://doi.acm.org/10.1145/258948.258973",
+				"url": "https://doi.org/10.1145/258948.258973",
 				"attachments": [
 					{
-						"title": "ACM Full Text PDF",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
@@ -388,51 +394,62 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/doi/abs/10.1145/2566617",
-		"defer": true,
 		"items": [
 			{
 				"itemType": "journalArticle",
 				"title": "Check-ins in “Blau Space”: Applying Blau’s Macrosociological Theory to Foursquare Check-ins from New York City",
 				"creators": [
 					{
-						"firstName": "Kenneth",
 						"lastName": "Joseph",
+						"firstName": "Kenneth",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Kathleen M.",
 						"lastName": "Carley",
+						"firstName": "Kathleen M.",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Jason I.",
 						"lastName": "Hong",
+						"firstName": "Jason I.",
+						"creatorTypeID": 1,
 						"creatorType": "author"
 					}
 				],
-				"date": "September 2014",
+				"date": "September 18, 2014",
 				"DOI": "10.1145/2566617",
 				"ISSN": "2157-6904",
 				"abstractNote": "Peter Blau was one of the first to define a latent social space and utilize it to provide concrete hypotheses. Blau defines social structure via social “parameters” (constraints). Actors that are closer together (more homogenous) in this social parameter space are more likely to interact. One of Blau’s most important hypotheses resulting from this work was that the consolidation of parameters could lead to isolated social groups. For example, the consolidation of race and income might lead to segregation. In the present work, we use Foursquare data from New York City to explore evidence of homogeneity along certain social parameters and consolidation that breeds social isolation in communities of locations checked in to by similar users. More specifically, we first test the extent to which communities detected via Latent Dirichlet Allocation are homogenous across a set of four social constraints—racial homophily, income homophily, personal interest homophily and physical space. Using a bootstrapping approach, we find that 14 (of 20) communities are statistically, and all but one qualitatively, homogenous along one of these social constraints, showing the relevance of Blau’s latent space model in venue communities determined via user check-in behavior. We then consider the extent to which communities with consolidated parameters, those homogenous on more than one parameter, represent socially isolated populations. We find communities homogenous on multiple parameters, including a homosexual community and a “hipster” community, that show support for Blau’s hypothesis that consolidation breeds social isolation. We consider these results in the context of mediated communication, in particular in the context of self-representation on social media.",
+				"callNumber": "10.1145/2566617",
 				"issue": "3",
-				"itemID": "Joseph:2014:CLS:2648782.2566617",
+				"itemID": "10.1145/2566617",
 				"libraryCatalog": "ACM Digital Library",
-				"pages": "46:1–46:22",
-				"publicationTitle": "ACM Trans. Intell. Syst. Technol.",
+				"pages": "1–22",
+				"publicationTitle": "ACM Transactions on Intelligent Systems and Technology (TIST)",
 				"shortTitle": "Check-ins in “Blau Space”",
-				"url": "http://doi.acm.org/10.1145/2566617",
+				"url": "https://doi.org/10.1145/2566617",
 				"volume": "5",
 				"attachments": [
 					{
-						"title": "ACM Full Text PDF",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [
-					"Foursquare",
-					"community structure",
-					"latent social space",
-					"urban analytics"
+					{
+						"tag": "Foursquare"
+					},
+					{
+						"tag": "community structure"
+					},
+					{
+						"tag": "latent social space"
+					},
+					{
+						"tag": "urban analytics"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -447,34 +464,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://dl.acm.org/toc/interactions/2016/24/1",
-		"items": [
-			{
-				"itemType": "book",
-				"title": "Interactions, January - February 2017",
-				"creators": [
-					{
-						"firstName": "Ron",
-						"lastName": "Wakkary",
-						"creatorType": "editor"
-					},
-					{
-						"firstName": "Erik",
-						"lastName": "Stolterman",
-						"creatorType": "editor"
-					}
-				],
-				"date": "2016",
-				"itemID": "Wakkary:2016:3029062",
-				"libraryCatalog": "ACM Digital Library",
-				"place": "New York, NY, USA",
-				"publisher": "ACM",
-				"volume": "24",
-				"attachments": [],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
+		"items": "multiple"
 	},
 	{
 		"type": "web",

--- a/ACM Digital Library.js
+++ b/ACM Digital Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-01-09 22:02:54"
+	"lastUpdated": "2020-01-12 22:47:25"
 }
 
 /*
@@ -172,7 +172,18 @@ function scrape(doc) {
 			// Publication name in the CSL is shortened; scrape from page to get full title.
 			let expandedTitle = text(doc, 'span.epub-section__title');
 			if (expandedTitle) {
+				item.journalAbbreviation = item.publicationTitle;
 				item.publicationTitle = expandedTitle;
+			}
+			// Article number 46 --> pages = 46:1–46:22
+			if (cslItem.number) {
+				let number = cslItem.number.replace("Article", "").trim();
+				if (item.pages) {
+					item.pages = item.pages.split("–").map(x => number + ":" + x).join("–");
+				}
+				else {
+					item.pages = number;
+				}
 			}
 		}
 		
@@ -206,6 +217,8 @@ function scrape(doc) {
 			item.extra = item.extra ? item.extra + '\nitemType: data' : 'itemType: data';
 		}
 		
+		delete item.callNumber;
+		
 		item.complete();
 	});
 }
@@ -237,7 +250,6 @@ var testCases = [
 				"DOI": "10.1145/1596655.1596682",
 				"ISBN": "9781605585987",
 				"abstractNote": "Repository-based revision control systems such as CVS, RCS, Subversion, and GIT, are extremely useful tools that enable software developers to concurrently modify source code, manage conflicting changes, and commit updates as new revisions. Such systems facilitate collaboration with and concurrent contribution to shared source code by large developer bases. In this work, we investigate a framework for \"performance-aware\" repository and revision control for Java programs. Our system automatically tracks behavioral differences across revisions to provide developers with feedback as to how their change impacts performance of the application. It does so as part of the repository commit process by profiling the performance of the program or component, and performing automatic analyses that identify differences in the dynamic behavior or performance between two code revisions. In this paper, we present our system that is based upon and extends prior work on calling context tree (CCT) profiling and performance differencing. Our framework couples the use of precise CCT information annotated with performance metrics and call-site information, with a simple tree comparison technique and novel heuristics that together target the cause of performance differences between code revisions without knowledge of program semantics. We evaluate the efficacy of the framework using a number of open source Java applications and present a case study in which we use the framework to distinguish two revisions of the popular FindBugs application.",
-				"callNumber": "10.1145/1596655.1596682",
 				"itemID": "10.1145/1596655.1596682",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "162–171",
@@ -286,7 +298,6 @@ var testCases = [
 				"date": "2009",
 				"ISBN": "9780596520120",
 				"abstractNote": "Version Control with Git takes you step-by-step through ways to track, merge, and manage software projects, using this highly flexible, open source version control system. Git permits virtually an infinite variety of methods for development and collaboration. Created by Linus Torvalds to manage development of the Linux kernel, it's become the principal tool for distributed version control. But Git's flexibility also means that some users don't understand how to use it to their best advantage. Version Control with Git offers tutorials on the most effective ways to use it, as well as friendly yet rigorous advice to help you navigate Git's many functions. With this book, you will: Learn how to use Git in several real-world development environments Gain insight into Git's common-use cases, initial tasks, and basic functions Understand how to use Git for both centralized and distributed version control Use Git to manage patches, diffs, merges, and conflicts Acquire advanced techniques such as rebasing, hooks, and ways to handle submodules (subprojects) Learn how to use Git with Subversion Git has earned the respect of developers around the world. Find out how you can benefit from this amazing tool with Version Control with Git.",
-				"callNumber": "10.5555/1717186",
 				"edition": "1st",
 				"itemID": "10.5555/1717186",
 				"libraryCatalog": "ACM Digital Library",
@@ -324,12 +335,12 @@ var testCases = [
 				"DOI": "10.1023/A:1008286901817",
 				"ISSN": "0923-8174",
 				"abstractNote": "Simulation techniques used in the Manufacturing Test SIMulator (MTSIM) are described. MTSIM is a Concurrent Engineering tool used to simulate the manufacturing test and repair aspects of boards and MCMs from design concept through manufacturing release. MTSIM helps designers select assembly process, specify Design For Test (DFT) features, select board test coverage, specify ASIC defect level goals, establish product feasibility, and predict manufacturing quality and cost goals. A new yield model for boards and MCMs which accounts for the clustering of solder defects is introduced and used to predict the yield at each test step. In addition, MTSIM estimates the average number of defects per board detected at each test step, and estimates costs incurred in test execution, fault isolation and repair. MTSIM models were validated with high performance assemblies at Hewlett-Packard (HP).",
-				"callNumber": "10.1023/A:1008286901817",
 				"issue": "1-2",
 				"itemID": "10.1023/A:1008286901817",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "137–149",
 				"publicationTitle": "Journal of Electronic Testing: Theory and Applications",
+				"journalAbbreviation": "J. Electron. Test.",
 				"url": "https://doi.org/10.1023/A:1008286901817",
 				"volume": "10",
 				"attachments": [],
@@ -389,7 +400,6 @@ var testCases = [
 				"DOI": "10.1145/258948.258973",
 				"ISBN": "9780897919180",
 				"abstractNote": "Fran (Functional Reactive Animation) is a collection of data types and functions for composing richly interactive, multimedia animations. The key ideas in Fran are its notions of behaviors and events. Behaviors are time-varying, reactive values, while events are sets of arbitrarily complex conditions, carrying possibly rich information. Most traditional values can be treated as behaviors, and when images are thus treated, they become animations. Although these notions are captured as data types rather than a programming language, we provide them with a denotational semantics, including a proper treatment of real time, to guide reasoning and implementation. A method to effectively and efficiently perform event detection using interval analysis is also described, which relies on the partial information structure on the domain of event times. Fran has been implemented in Hugs, yielding surprisingly good performance for an interpreter-based system. Several examples are given, including the ability to describe physical phenomena involving gravity, springs, velocity, acceleration, etc. using ordinary differential equations.",
-				"callNumber": "10.1145/258948.258973",
 				"itemID": "10.1145/258948.258973",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "263–273",
@@ -441,12 +451,12 @@ var testCases = [
 				"DOI": "10.1145/2566617",
 				"ISSN": "2157-6904",
 				"abstractNote": "Peter Blau was one of the first to define a latent social space and utilize it to provide concrete hypotheses. Blau defines social structure via social “parameters” (constraints). Actors that are closer together (more homogenous) in this social parameter space are more likely to interact. One of Blau’s most important hypotheses resulting from this work was that the consolidation of parameters could lead to isolated social groups. For example, the consolidation of race and income might lead to segregation. In the present work, we use Foursquare data from New York City to explore evidence of homogeneity along certain social parameters and consolidation that breeds social isolation in communities of locations checked in to by similar users. More specifically, we first test the extent to which communities detected via Latent Dirichlet Allocation are homogenous across a set of four social constraints—racial homophily, income homophily, personal interest homophily and physical space. Using a bootstrapping approach, we find that 14 (of 20) communities are statistically, and all but one qualitatively, homogenous along one of these social constraints, showing the relevance of Blau’s latent space model in venue communities determined via user check-in behavior. We then consider the extent to which communities with consolidated parameters, those homogenous on more than one parameter, represent socially isolated populations. We find communities homogenous on multiple parameters, including a homosexual community and a “hipster” community, that show support for Blau’s hypothesis that consolidation breeds social isolation. We consider these results in the context of mediated communication, in particular in the context of self-representation on social media.",
-				"callNumber": "10.1145/2566617",
 				"issue": "3",
 				"itemID": "10.1145/2566617",
 				"libraryCatalog": "ACM Digital Library",
-				"pages": "1–22",
+				"pages": "46:1–46:22",
 				"publicationTitle": "ACM Transactions on Intelligent Systems and Technology (TIST)",
+				"journalAbbreviation": "ACM Trans. Intell. Syst. Technol.",
 				"shortTitle": "Check-ins in “Blau Space”",
 				"url": "https://doi.org/10.1145/2566617",
 				"volume": "5",
@@ -502,7 +512,6 @@ var testCases = [
 				"ISBN": "9781450372763",
 				"abstractNote": "This organizational history relates the role of the National Science Foundation (NSF) in the development of modern computing. Drawing upon new and existing oral histories, extensive use of NSF documents, and the experience of two of the authors as senior managers, this book describes how NSF's programmatic activities originated and evolved to become the primary source of funding for fundamental research in computing and information technologies. The book traces how NSF's support has provided facilities and education for computing usage by all scientific disciplines, aided in institution and professional community building, supported fundamental research in computer science and allied disciplines, and led the efforts to broaden participation in computing by all segments of society. Today, the research and infrastructure facilitated by NSF computing programs are significant economic drivers of American society and industry. For example, NSF supported work that led to the first widelyused web browser, Netscape; sponsored the creation of algorithms at the core of the Google search engine; facilitated the growth of the public Internet; and funded research on the scientific basis for countless other applications and technologies. NSF has advanced the development of human capital and ideas for future advances in computing and its applications. This account is the first comprehensive coverage of NSF's role in the extraordinary growth and expansion of modern computing and its use. It will appeal to historians of computing, policy makers and leaders in government and academia, and individuals interested in the history and development of computing and the NSF.",
 				"bookTitle": "Computing and the National Science Foundation, 1950--2016: Building a Foundation for Modern Computing",
-				"callNumber": "10.5555/3336323.C5474411",
 				"itemID": "10.5555/3336323.C5474411",
 				"libraryCatalog": "ACM Digital Library",
 				"place": "New York, NY, USA",
@@ -539,12 +548,12 @@ var testCases = [
 				"DOI": "10.1145/3264631.3264634",
 				"ISSN": "1558-2337",
 				"abstractNote": "The current interaction paradigm to access the mobile web forces people who are blind to hold out their phone at all times, thus increasing the risk for the device to fall or be robbed. Moreover, such continuous, two-handed interaction on a small screen hampers the ability of people who are blind to keep their hands free to control aiding devices (e.g., cane) or touch objects nearby, especially on-the-go. To investigate alternative paradigms, we are exploring and reifying strategies for \"screenless access\": a browsing approach that enables users to interact touch-free with aural navigation architectures using one-handed, in-air gestures recognized by an off-the-shelf armband. In this article, we summarize key highlights from an exploratory study with ten participants who are blind or visually impaired who experienced our screenless access prototype. We observed proficient navigation performance after basic training, users conceptual fit with a screen-free paradigm, and low levels of cognitive load, notwithstanding the errors and limits of the design and system proposed. The full paper appeared in W4A2018 [1].",
-				"callNumber": "10.1145/3264631.3264634",
 				"issue": "121",
 				"itemID": "10.1145/3264631.3264634",
 				"libraryCatalog": "ACM Digital Library",
-				"pages": "1",
+				"pages": "3:1",
 				"publicationTitle": "ACM SIGACCESS Accessibility and Computing",
+				"journalAbbreviation": "SIGACCESS Access. Comput.",
 				"shortTitle": "Beyond screen and voice",
 				"url": "https://doi.org/10.1145/3264631.3264634",
 				"attachments": [],
@@ -579,12 +588,12 @@ var testCases = [
 				"DOI": "10.1145/2854146",
 				"ISSN": "0001-0782",
 				"abstractNote": "Google's monolithic repository provides a common source of truth for tens of thousands of developers around the world.",
-				"callNumber": "10.1145/2854146",
 				"issue": "7",
 				"itemID": "10.1145/2854146",
 				"libraryCatalog": "ACM Digital Library",
 				"pages": "78–87",
 				"publicationTitle": "Communications of the ACM",
+				"journalAbbreviation": "Commun. ACM",
 				"url": "https://doi.org/10.1145/2854146",
 				"volume": "59",
 				"attachments": [
@@ -616,7 +625,6 @@ var testCases = [
 				],
 				"date": "2005",
 				"abstractNote": "The geometric surface model generated by common CAD tools is often “dirty” (cracks, small gaps, small holes, surface penetration, inconsistent surface orientation, bad edge-face connectivity, etc.). Also, problems of component overlapping, island components, and patch duplication exist in a component-based system. The process of traditional geometric healing and repairing methods is time-consuming (weeks or months), and often time fails when dealing with a complex “dirty” geometric model. In this dissertation, a new methodology based on “void volume trimming” is presented to resolve problems stated above. The meshing process starts from generating a Cartesian volume mesh using the 2 N tree (instead of the traditional Octree) data structure. With this structure, several mesh adaptation methods based on geometric features coupled with a smoothing algorithm between neighbor cells are developed to generate the preferred mesh sizes at desired regions while ensuring the gradual transition between dense and coarse meshes. In the process of constructing surface mesh for “dirty” geometric components, an effective “surface orientation free” algorithm is proposed. For resolving of “mesh leak” at cracks and small gap regions, the continuous “intersecting cell” set is used instead of geometric surfaces as the domain bound. The major contribution of this dissertation is the development of “void volume trimming” algorithm. With this methodology, the watertight feature can be promised, and the axis-aligned surface mesh is gradually adjusted to be geometric aligned while maintaining high mesh quality. Meanwhile, the surface mesh is pushed towards the geometry for satisfaction of mapping criteria. The constrained smoothing algorithm presented in this dissertation further improves the mesh quality while shrinking the surface mesh closer to geometry components. At the same time, the use of the SPP (Shortest Path Projection) algorithm coupled with the ADT (Alternating Digital Tree) data structure has been shown that it is efficient when generating body-fitted surface meshes for complex “dirty” geometries while maintaining high performance. The present critical feature preservation method has shown its capability of capturing the detailed features, while the introduced patch mapping method can topologically maintain the geometric model property. Case studies and application results have demonstrated that the current methodology is efficient for handling the component-based complex “dirty” geometric model.",
-				"callNumber": "10.5555/1087674",
 				"extra": "AAI3164056\nISBN-10: 0496987127",
 				"itemID": "10.5555/1087674",
 				"libraryCatalog": "ACM Digital Library",


### PR DESCRIPTION
Supports the new ACM site (#1811), which has changed over already. The tests don't run (see below), but I've manually tested that it all works. 

A couple of notes: I return that magazines and newsletters are `journalArticle` as this is the type exported by their CSL. I also wasn't sure what the best way of dealing with ISBN was in cases where it is provided but the appropriate item type doesn't have a field for it, so put it in the extras. 

With regard to the conversation in #2097, a conference proceedings page will bring up a dialog for users to select papers in that proceedings rather than download the proceedings information. This is easily changed depending on what we decide to be most reasonable. 

There is a slight problem with the new site in that it does not work without the cookie `cookiePolicy=accept` set: it just redirects to https://dl.acm.org/action/cookieAbsent. As a result I've not been able to run the translator in Scaffold, either manually or with the tests. Manually setting the headers in `doGet` to include the cookie doesn't work either, as it looks like XMLHttpRequest doesn't allow that. In any case I don't think that would address the problem with the tests.