### PR TITLE
Fix Google AI translator

### DIFF
--- a/Google AI.js
+++ b/Google AI.js
@@ -2,14 +2,14 @@
 	"translatorID": "5f1c4a3b-b7cf-4170-a896-e4d82c0621c9",
 	"label": "Google AI",
 	"creator": "Guy Aglionby",
-	"target": "^https://research\\.google/(pubs|people|research-areas)",
+	"target": "^https://research\\.google/(pubs|people|research-areas|teams)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-31 16:28:48"
+	"lastUpdated": "2019-12-31 16:36:03"
 }
 
 /*
@@ -209,6 +209,11 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://research.google/research-areas/algorithms-and-theory/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://research.google/teams/applied-science/gas/",
 		"items": "multiple"
 	}
 ]

--- a/Google AI.js
+++ b/Google AI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-31 16:22:04"
+	"lastUpdated": "2019-12-31 16:28:48"
 }
 
 /*
@@ -116,7 +116,7 @@ function scrape(doc) {
 	translator.translate();
 }
 
-function extractBibtex(doc) { 
+function extractBibtex(doc) {
 	let bibtex = ZU.xpathText(doc, '//a[contains(text(), "Bibtex")]/@copy-to-clipboard');
 	return decodeURIComponent(bibtex);
 }

--- a/Google AI.js
+++ b/Google AI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-09-28 12:10:45"
+	"lastUpdated": "2019-12-31 16:12:50"
 }
 
 /*
@@ -36,36 +36,36 @@
 
 // See BibTeX.js
 var bibtex2zoteroTypeMap = {
-	"book":"book", // or booklet, proceedings
-	"inbook":"bookSection",
-	"incollection":"bookSection",
-	"article":"journalArticle", // or magazineArticle or newspaperArticle
-	"patent" :"patent",
-	"phdthesis":"thesis",
-	"unpublished":"manuscript",
-	"inproceedings":"conferencePaper", // check for conference also
-	"conference":"conferencePaper",
-	"techreport":"report",
-	"booklet":"book",
-	"manual":"book",
-	"mastersthesis":"thesis",
-	"misc":"book",
-	"proceedings":"book",
-	"online":"webpage",
+	book: "book", // or booklet, proceedings
+	inbook: "bookSection",
+	incollection: "bookSection",
+	article: "journalArticle", // or magazineArticle or newspaperArticle
+	patent: "patent",
+	phdthesis: "thesis",
+	unpublished: "manuscript",
+	inproceedings: "conferencePaper", // check for conference also
+	conference: "conferencePaper",
+	techreport: "report",
+	booklet: "book",
+	manual: "book",
+	mastersthesis: "thesis",
+	misc: "book",
+	proceedings: "book",
+	online: "webpage",
 	// from BibLaTeX translator:
-	"thesis":"thesis",
-	"letter":"letter",
-	"movie":"film",
-	"artwork":"artwork",
-	"report":"report",
-	"legislation":"bill",
-	"jurisdiction":"case",
-	"audio":"audioRecording",
-	"video":"videoRecording",
-	"software":"computerProgram",
-	"inreference":"encyclopediaArticle",
-	"collection":"book",
-	"mvbook":"book"
+	thesis: "thesis",
+	letter: "letter",
+	movie: "film",
+	artwork: "artwork",
+	report: "report",
+	legislation: "bill",
+	jurisdiction: "case",
+	audio: "audioRecording",
+	video: "videoRecording",
+	software: "computerProgram",
+	inreference: "encyclopediaArticle",
+	collection: "book",
+	mvbook: "book"
 };
 
 function detectWeb(doc, url) {
@@ -73,9 +73,11 @@ function detectWeb(doc, url) {
 		let bibtex = extractBibtex(doc);
 		let doctype = bibtex.split('{')[0].replace('@', '');
 		return bibtex2zoteroTypeMap[doctype] || 'journalArticle';
-	} else if (getSearchResults(doc, true)) {
+	}
+	else if (getSearchResults(doc, true)) {
 		return 'multiple';
 	}
+	return false;
 }
 
 function doWeb(doc, url) {
@@ -85,16 +87,17 @@ function doWeb(doc, url) {
 		// https://ai.google/research/pubs/
 		Zotero.selectItems(getSearchResults(doc), function (selected) {
 			if (!selected) {
-				return true;
+				return;
 			}
 			ZU.processDocuments(Object.keys(selected), scrape);
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
 
-function scrape(doc, url) { 
+function scrape(doc) {
 	let bibtex = extractBibtex(doc);
 	let translator = Zotero.loadTranslator("import");
 	translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
@@ -111,13 +114,13 @@ function scrape(doc, url) {
 		delete item.itemID;
 		item.complete();
 	});
-	translator.translate();	
+	translator.translate();
 }
 
-function extractBibtex(doc) { 
+function extractBibtex(doc) {
 	let escapedBibtex = ZU.xpathText(doc, '//a[span[contains(@class, "icon--copy")]]/@ng-click')
-							.replace("CopyCtrl.onClick($event, '", '')
-							.replace("', true)", '');
+		.replace("CopyCtrl.onClick($event, '", '')
+		.replace("', true)", '');
 	return decodeURIComponent(escapedBibtex);
 }
 
@@ -125,7 +128,7 @@ function getSearchResults(doc, checkOnly) {
 	let items = {};
 	let found = false;
 	let rows = ZU.xpath(doc, '//a[contains(@class, "card__title")]');
-	for (let i=0; i<rows.length; i++) {
+	for (let i = 0; i < rows.length; i++) {
 		let href = rows[i].href;
 		let title = ZU.trimInternal(rows[i].textContent);
 		if (!href || !title) continue;
@@ -135,6 +138,7 @@ function getSearchResults(doc, checkOnly) {
 	}
 	return found ? items : false;
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{

--- a/Google AI.js
+++ b/Google AI.js
@@ -2,14 +2,14 @@
 	"translatorID": "5f1c4a3b-b7cf-4170-a896-e4d82c0621c9",
 	"label": "Google AI",
 	"creator": "Guy Aglionby",
-	"target": "^https://ai\\.google/research/(pubs|people)",
+	"target": "^https://research\\.google/(pubs|people|research-areas)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-31 16:12:50"
+	"lastUpdated": "2019-12-31 16:22:04"
 }
 
 /*
@@ -86,10 +86,9 @@ function doWeb(doc, url) {
 		// https://ai.google/research/people/105197
 		// https://ai.google/research/pubs/
 		Zotero.selectItems(getSearchResults(doc), function (selected) {
-			if (!selected) {
-				return;
+			if (selected) {
+				ZU.processDocuments(Object.keys(selected), scrape);
 			}
-			ZU.processDocuments(Object.keys(selected), scrape);
 		});
 	}
 	else {
@@ -104,7 +103,7 @@ function scrape(doc) {
 	translator.setString(bibtex);
 	translator.setHandler("itemDone", function (obj, item) {
 		let downloadUrl = ZU.xpathText(doc, '//a[span[contains(@class, "icon--download")]]/@href');
-		if (downloadUrl.endsWith('.pdf')) {
+		if (downloadUrl && downloadUrl.endsWith('.pdf')) {
 			item.attachments.push({
 				url: downloadUrl,
 				title: 'Full Text PDF',
@@ -117,11 +116,9 @@ function scrape(doc) {
 	translator.translate();
 }
 
-function extractBibtex(doc) {
-	let escapedBibtex = ZU.xpathText(doc, '//a[span[contains(@class, "icon--copy")]]/@ng-click')
-		.replace("CopyCtrl.onClick($event, '", '')
-		.replace("', true)", '');
-	return decodeURIComponent(escapedBibtex);
+function extractBibtex(doc) { 
+	let bibtex = ZU.xpathText(doc, '//a[contains(text(), "Bibtex")]/@copy-to-clipboard');
+	return decodeURIComponent(bibtex);
 }
 
 function getSearchResults(doc, checkOnly) {
@@ -143,7 +140,7 @@ function getSearchResults(doc, checkOnly) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "https://ai.google/research/pubs/pub47251",
+		"url": "https://research.google/pubs/pub47251/",
 		"items": [
 			{
 				"itemType": "conferencePaper",
@@ -187,7 +184,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://ai.google/research/pubs/pub46616",
+		"url": "https://research.google/pubs/pub46616/",
 		"items": [
 			{
 				"itemType": "report",
@@ -208,6 +205,11 @@ var testCases = [
 				"seeAlso": []
 			}
 		]
+	},
+	{
+		"type": "web",
+		"url": "https://research.google/research-areas/algorithms-and-theory/",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/

--- a/Google Research.js
+++ b/Google Research.js
@@ -1,6 +1,6 @@
 {
 	"translatorID": "5f1c4a3b-b7cf-4170-a896-e4d82c0621c9",
-	"label": "Google AI",
+	"label": "Google Research",
 	"creator": "Guy Aglionby",
 	"target": "^https://research\\.google/(pubs|people|research-areas|teams)",
 	"minVersion": "3.0",
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-31 16:36:03"
+	"lastUpdated": "2020-01-01 19:36:16"
 }
 
 /*
@@ -82,7 +82,8 @@ function detectWeb(doc, url) {
 
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) === 'multiple') {
-		// Test cases: (defer: true is broken so cannot currently use automated tests)
+		// The below two pages with multiples are populated after page load has finished,
+		// so can't be used as automatic test cases. For others this is not the case.
 		// https://ai.google/research/people/105197
 		// https://ai.google/research/pubs/
 		Zotero.selectItems(getSearchResults(doc), function (selected) {
@@ -168,7 +169,7 @@ var testCases = [
 					}
 				],
 				"date": "2018",
-				"libraryCatalog": "Google AI",
+				"libraryCatalog": "Google Research",
 				"proceedingsTitle": "Proceedings of the Symposium on Usable Privacy and Security 2018",
 				"attachments": [
 					{
@@ -197,7 +198,7 @@ var testCases = [
 					}
 				],
 				"date": "2018",
-				"libraryCatalog": "Google AI",
+				"libraryCatalog": "Google Research",
 				"url": "http://www.unofficialgoogledatascience.com/2018/01/designing-ab-tests-in-collaboration.html",
 				"attachments": [],
 				"tags": [],


### PR DESCRIPTION
URL changed and so did the Bibtex copy link. 

I also don't know if this translator may now be more accurately called 'Google Research'?