### PR TITLE
Fix Semantic Scholar Plugin

### DIFF
--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -35,9 +35,17 @@
 	***** END LICENSE BLOCK *****
 */
 
+// See also https://github.com/zotero/translators/blob/master/BibTeX.js
+var bibtex2zoteroTypeMap = {
+	inproceedings: "conferencePaper",
+	conference: "conferencePaper",
+	article: "journalArticle"
+};
+
 function detectWeb(doc, url) {
-	// the regex in target will ensure we're on a paper
-	return 'journalArticle';
+	let citation = ZU.xpathText(doc, '//pre[@class="bibtex-citation"]');
+	let type = citation.split('{')[0].replace('@', '');
+	return bibtex2zoteroTypeMap[type];
 }
 
 function doWeb(doc, url) {
@@ -53,18 +61,23 @@ function doWeb(doc, url) {
 }
 
 function parseDocument(doc, url) {
+	let citation = ZU.xpathText(doc, '//pre[@class="bibtex-citation"]');
+	let type = citation.split('{')[0].replace('@', '');
+	const itemType = bibtex2zoteroTypeMap[type];
+
+	var item = new Zotero.Item(itemType);
+
 	// load structured schema data 
 	const schemaTag = doc.querySelector("script.schema-data");
 	const schemaObject = JSON.parse(schemaTag.innerHTML);
 	const article = schemaObject["@graph"][1][0];
 
-	var item = new Zotero.Item("journalArticle");
 	item.title = article["name"];
 	item.abstractNote = article["description"];
 
 	if (article["author"]) {
 		article["author"].forEach(author => {
-			item.creators.push(ZU.cleanAuthor(author["name"]));
+			item.creators.push(ZU.cleanAuthor(author["name"], 'author'));
 		});
 	}
 	item.publicationTitle = article["publication"];
@@ -119,9 +132,7 @@ var testCases = [
 					}
 				],
 				"date": "2010",
-				"DOI": "10.1007/978-3-642-14770-8_33",
-				"abstractNote": "In the present paper we describe TectoMT, a multi-purpose open-source NLP framework. It allows for fast and efficient development of NLP applications by exploiting a wide range of software modules already integrated in TectoMT, such as tools for sentence segmentation, tokenization, morphological analysis, POS tagging, shallow and deep syntax parsing, named entity recognition, anaphora resolution, tree-to-tree translation, natural language generation, word-level alignment of parallel corpora, and other tasks. One of the most complex applications of TectoMT is the English-Czech machine translation system with transfer on deep syntactic (tectogrammatical) layer. Several modules are available also for other languages (German, Russian, Arabic). Where possible, modules are implemented in a language-independent way, so they can be reused in many applications.",
-				"itemID": "Popel2010TectoMTMN",
+				"abstractNote": "In the present paper we describe TectoMT, a multi-purpose open-source NLP framework. It allows for fast and efficient development of NLP applications by exploiting a wide range of software modules already integrated in TectoMT, such as tools for sentence segmentation, tokenization, morphological analysis, POS tagging, shallow and deep syntax parsing, named entity recognition, anaphora resolution, tree-to-tree translation, natural language generation, word-level alignment of parallel corpora, and other tasks. One of the most complex applications of TectoMT is the English-Czech machine translation system with transfer on deep syntactic (tectogrammatical) layer. Several modules are available also for other languages (German, Russian, Arabic).Where possible, modules are implemented in a language-independent way, so they can be reused in many applications.",
 				"libraryCatalog": "Semantic Scholar",
 				"proceedingsTitle": "IceTAL",
 				"shortTitle": "TectoMT",
@@ -130,497 +141,16 @@ var testCases = [
 						"title": "Semantic Scholar Link",
 						"mimeType": "text/html",
 						"snapshot": false
-					}
-				],
-				"tags": [
-					{
-						"tag": "Anaphora (linguistics)"
 					},
 					{
-						"tag": "Language-independent specification"
-					},
-					{
-						"tag": "Machine translation"
-					},
-					{
-						"tag": "Multi-Purpose Viewer"
-					},
-					{
-						"tag": "Named-entity recognition"
-					},
-					{
-						"tag": "Natural language generation"
-					},
-					{
-						"tag": "Natural language processing"
-					},
-					{
-						"tag": "Open-source software"
-					},
-					{
-						"tag": "Parallel text"
-					},
-					{
-						"tag": "Parsing"
-					},
-					{
-						"tag": "Part-of-speech tagging"
-					},
-					{
-						"tag": "Sentence boundary disambiguation"
-					},
-					{
-						"tag": "Text corpus"
-					},
-					{
-						"tag": "Tokenization (data security)"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/The-spring-in-the-arch-of-the-human-foot-Ker-Bennett/8555e05e52e5c04017ca7a9c9da9ed9c39e4f9a0",
-		"defer": true,
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "The spring in the arch of the human foot",
-				"creators": [
-					{
-						"firstName": "Robert F.",
-						"lastName": "Ker",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Michael Brian",
-						"lastName": "Bennett",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "S. R.",
-						"lastName": "Bibby",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Ralph Charles",
-						"lastName": "Kester",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "R. McN",
-						"lastName": "Alexander",
-						"creatorType": "author"
-					}
-				],
-				"date": "1987",
-				"DOI": "10.1038/325147a0",
-				"abstractNote": "Large mammals, including humans, save much of the energy needed for running by means of elastic structures in their legs and feet1,2. Kinetic and potential energy removed from the body in the first half of the stance phase is stored briefly as elastic strain energy and then returned in the second half by elastic recoil. Thus the animal runs in an analogous fashion to a rubber ball bouncing along. Among the elastic structures involved, the tendons of distal leg muscles have been shown to be important2,3. Here we show that the elastic properties of the arch of the human foot are also important.",
-				"itemID": "Ker1987TheSI",
-				"libraryCatalog": "Semantic Scholar",
-				"pages": "147-149",
-				"publicationTitle": "Nature",
-				"volume": "325",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
+						"title": "Publisher Link",
 						"mimeType": "text/html",
 						"snapshot": false
-					}
-				],
-				"tags": [
-					{
-						"tag": "Tendon structure"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Foundations-of-Statistical-Natural-Language-Manning-Sch%C3%BCtze/06fd7d924d499fbc62ccbcc2e458fb6c187bcf6f",
-		"items": [
-			{
-				"itemType": "conferencePaper",
-				"title": "Foundations of statistical natural language processing",
-				"creators": [
-					{
-						"firstName": "Christopher D.",
-						"lastName": "Manning",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Hinrich",
-						"lastName": "Schütze",
-						"creatorType": "author"
-					}
-				],
-				"date": "1999",
-				"DOI": "10.1023/A:1011424425034",
-				"abstractNote": "Statistical approaches to processing natural language text have become dominant in recent years. This foundational text is the first comprehensive introduction to statistical natural language processing (NLP) to appear. The book contains all the theory and algorithms needed for building NLP tools. It provides broad but rigorous coverage of mathematical and linguistic foundations, as well as detailed discussion of statistical methods, allowing students and researchers to construct their own implementations. The book covers collocation finding, word sense disambiguation, probabilistic parsing, information retrieval, and other applications.",
-				"itemID": "Manning1999FoundationsOS",
-				"libraryCatalog": "Semantic Scholar",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [
-					{
-						"tag": "Algorithm"
-					},
-					{
-						"tag": "Data compression"
-					},
-					{
-						"tag": "Grams"
-					},
-					{
-						"tag": "Language model"
-					},
-					{
-						"tag": "Linear interpolation"
-					},
-					{
-						"tag": "N-gram"
-					},
-					{
-						"tag": "Natural language processing"
-					},
-					{
-						"tag": "Protologism"
-					},
-					{
-						"tag": "Smoothing"
-					},
-					{
-						"tag": "Stochastic grammar"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Interleukin-7-mediates-the-homeostasis-of-na%C3%AFve-and-Schluns-Kieper/aee7b854bed51120fe356a5792dfb22fec7cf2ae",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "Interleukin-7 mediates the homeostasis of naïve and memory CD8 T cells in vivo",
-				"creators": [
-					{
-						"firstName": "Kimberly S.",
-						"lastName": "Schluns",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "William C.",
-						"lastName": "Kieper",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Stephen C.",
-						"lastName": "Jameson",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Leo",
-						"lastName": "Lefrançois",
-						"creatorType": "author"
-					}
-				],
-				"date": "2000",
-				"DOI": "10.1038/80868",
-				"abstractNote": "The naïve and memory T lymphocyte pools are maintained through poorly understood homeostatic mechanisms that may include signaling via cytokine receptors. We show that interleukin-7 (IL-7) plays multiple roles in regulating homeostasis of CD8+ T cells. We found that IL-7 was required for homeostatic expansion of naïve CD8+ and CD4+ T cells in lymphopenic hosts and for CD8+ T cell survival in normal hosts. In contrast, IL- 7 was not necessary for growth of CD8+ T cells in response to a virus infection but was critical for generating T cell memory. Up-regulation of Bcl-2 in the absence of IL-7 signaling was impaired after activation in vivo. Homeostatic proliferation of memory cells was also partially dependent on IL-7. These results point to IL-7 as a pivotal cytokine in T cell homeostasis.",
-				"itemID": "Schluns2000Interleukin7MT",
-				"libraryCatalog": "Semantic Scholar",
-				"pages": "426-432",
-				"publicationTitle": "Nature Immunology",
-				"volume": "1",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					}
-				],
-				"tags": [
-					{
-						"tag": "Chronic Lymphocytic Leukemia"
-					},
-					{
-						"tag": "Homeostasis"
-					},
-					{
-						"tag": "Interleukin-7"
-					},
-					{
-						"tag": "Leukemia, B-Cell"
-					},
-					{
-						"tag": "Memory Disorders"
-					},
-					{
-						"tag": "T-Lymphocyte"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Prim%C3%A4re-Ziliendyskinesie-in-%C3%96sterreich-Lesic-Maurer/13c67d45a9919f44bbd07fde9bdf5f4a0e9ecc8d",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "Primäre Ziliendyskinesie in Österreich",
-				"creators": [
-					{
-						"firstName": "Irena",
-						"lastName": "Lesic",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Elisabeth",
-						"lastName": "Maurer",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Marie-Pierre F.",
-						"lastName": "Strippoli",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Claudia E.",
-						"lastName": "Kuehni",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Angelo",
-						"lastName": "Barbato",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Thomas",
-						"lastName": "Frischer",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "ERS Taskforce on Primary Ciliary Dyskinesia in",
-						"lastName": "children",
-						"creatorType": "author"
-					}
-				],
-				"date": "2009",
-				"DOI": "10.1007/s00508-009-1197-4",
-				"abstractNote": "SummaryINTRODUCTION: Primary ciliary dyskinesia (PCD) is a rare hereditary recessive disease with symptoms of recurrent pneumonia, chronic bronchitis, bronchiectasis, and chronic sinusitis. Chronic rhinitis is often the presenting symptom in newborns and infants. Approximately half of the patients show visceral mirror image arrangements (situs inversus). In this study, we aimed 1) to determine the number of paediatric PCD patients in Austria, 2) to show the diagnostic and therapeutic modalities used in the clinical centres and 3) to describe symptoms of children with PCD. PATIENTS, MATERIAL AND METHODS: For the first two aims, we analysed data from a questionnaire survey of the European Respiratory Society (ERS) task force on Primary Ciliary Dyskinesia in children. All paediatric respiratory units in Austria received a questionnaire. Symptoms of PCD patients from Vienna Children's University Hospital (aim 3) were extracted from case histories. RESULTS: In 13 Austrian clinics 48 patients with PCD (36 aged from 0–19 years) were identified. The prevalence of reported cases (aged 0–19 yrs) in Austria was 1:48000. Median age at diagnosis was 4.8 years (IQR 0.3–8.2), lower in children with situs inversus compared to those without (3.1 vs. 8.1 yrs, p = 0.067). In 2005–2006, the saccharine test was still the most commonly used screening test for PCD in Austria (45%). Confirmation of the diagnosis was usually by electron microscopy (73%). All clinics treated exacerbations immediately with antibiotics, 73% prescribed airway clearance therapy routinely to all patients. Other therapies and diagnostic tests were applied very inconsistently across Austrian hospitals. All PCD patients from Vienna (n = 13) had increased upper and lower respiratory secretions, most had recurring airway infections (n = 12), bronchiectasis (n = 7) and bronchitis (n = 7). CONCLUSION: Diagnosis and therapy of PCD in Austria are inhomogeneous. Prospective studies are needed to learn more about the course of the disease and to evaluate benefits and harms of different treatment strategies.ZusammenfassungEINLEITUNG: Die primäre Ziliendyskinesie (Primary Ciliary Dykinesia, PCD) ist eine seltene, meist autosomal-rezessiv vererbte Erkrankung, mit den typischen Manifestationen rezidivierende Pneumonien, chronische Bronchitis, Bronchiektasien, chronische Sinusitis und, insbesondere bei Neugeborenen und Säuglingen, chronischer Rhinitis. Die Hälfte der Patienten haben einen Situs inversus. Die Ziele dieser Studie waren, 1) die Anzahl pädiatrischer PCD-Patienten in Österreich zu erfassen, 2) die diagnostischen und therapeutischen Modalitäten der behandelnden Zentren darzustellen und 3) die Symptomatik der Patienten zu beschreiben. PATIENTEN, MATERIAL UND METHODEN: Zur Beantwortung der ersten zwei Fragen analysierten wir die österreichischen Resultate einer Fragebogenuntersuchung der pädiatrischen PCD Taskforce der European Respiratory Society (ERS). Die klinischen Charakteristika der PCD-Patienten an der Universitätsklinik für Kinder- und Jugendheilkunde in Wien stellten wir anhand der Krankengeschichten zusammen. ERGEBNISSE: In 13 österreichischen Krankenhäusern wurden 48 Patienten identifiziert (36 im Alter von 0–19 Jahre). Dies ergibt für Österreich eine Prävalenz diagnostizierter PCD-Patienten (0–19 Jahre) von 1:48000. Das mediane Alter bei Diagnose war 4,8 Jahre (IQR 0,3–8,2 Jahre). Patienten mit Situs inversus wurden früher diagsnotiziert (3,1 Jahre versus 8,1 Jahre; p = 0,067). Das gebräuchlichste screening-Verfahren (2005–2006) war der Saccharintest (45%), zur Diagnosesicherung wurde meist die Elektronenmikroskopie eingesetzt (73%). Alle Kliniken behandelten Exazerbationen sofort antibiotisch, Atemphysiotherapie wurde in 73% der Zentren eingesetzt. Insgesamt waren Diagnostik und Therapie der PCD in Österreich uneinheitlich. Alle Patienten der Universitätsklinik Wien (n = 13) hatten eine verstärkte Sekretproduktion, die meisten rezidivierende Atemwegsinfekte (n = 12), Bronchiektasen (n = 7) und Bronchitis (n = 7). KONKLUSION: Diagnostik und Therapie der PCD in Österreich sind uneinheitlich. Prospektive Studien sind notwendig, den Verlauf der Erkrankung zu erforschen sowie Nutzen und Schaden unterschiedlicher Therapie-konzepte darzustellen.",
-				"itemID": "Lesic2009PrimreZI",
-				"libraryCatalog": "Semantic Scholar",
-				"pages": "616-622",
-				"publicationTitle": "Wiener klinische Wochenschrift",
-				"volume": "121",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					}
-				],
-				"tags": [
-					{
-						"tag": "Addison Disease"
-					},
-					{
-						"tag": "Apoptosis"
-					},
-					{
-						"tag": "Bronchiectasis"
-					},
-					{
-						"tag": "Bronchitis, Chronic"
-					},
-					{
-						"tag": "Chronic sinusitis"
-					},
-					{
-						"tag": "Ciliary Motility Disorders"
-					},
-					{
-						"tag": "Dyskinesia, Drug-Induced"
-					},
-					{
-						"tag": "Epilepsy"
-					},
-					{
-						"tag": "Extraction"
-					},
-					{
-						"tag": "Infant, Newborn"
-					},
-					{
-						"tag": "Kartagener Syndrome"
-					},
-					{
-						"tag": "Neoplasms, Unknown Primary"
-					},
-					{
-						"tag": "Osteoarthritis, Spine"
-					},
-					{
-						"tag": "Physical medicine/manipulation"
-					},
-					{
-						"tag": "Recurrent pneumonia"
-					},
-					{
-						"tag": "Situs Inversus"
-					},
-					{
-						"tag": "Surgical Wound Infection"
-					},
-					{
-						"tag": "Urinary Calculi"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/author/Jane-Holmes/3023517",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Superpower-Your-Browser-with-LibX-and-Zotero-Puckett/ac7caef334a4296503cc062529290d4c3ef6be32",
-		"items": [
-			{
-				"itemType": "conferencePaper",
-				"title": "Superpower Your Browser with LibX and Zotero",
-				"creators": [
-					{
-						"firstName": "J.",
-						"lastName": "Puckett",
-						"creatorType": "author"
-					}
-				],
-				"date": "2010",
-				"abstractNote": "© 2010 Jason Puckett the providers of either program discontinued supporting them, another institution could simply download the source code and take over development. As Firefox plugins, both LibX and Zotero are self-updating. Firefox periodically checks for new versions of all its add-ons and prompts the user to update with a few clicks. This process is unlikely to confuse even users who have never installed software. (The Internet Explorer version of LibX must be updated manually by downloading a new version from the library’s Web site and running an executable fi le.) This allows the library to push out new search options, and Zotero’s developers to push updates ranging from new features to updated bibliographic styles. It also allows for far more frequent improvements to the software than most commercial programs provide.",
-				"itemID": "Puckett2010SuperpowerYB",
-				"libraryCatalog": "Semantic Scholar",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [
-					{
-						"tag": "LibX"
-					},
-					{
-						"tag": "Zotero"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.semanticscholar.org/paper/Tracking-State-Changes-in-Procedural-Text%3A-A-and-Dalvi-Huang/5e9c9d0164ae041786f8fdc5726da12403e91a6c",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "Tracking State Changes in Procedural Text: A Challenge Dataset and Models for Process Paragraph Comprehension",
-				"creators": [
-					{
-						"firstName": "Bhavana",
-						"lastName": "Dalvi",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Lifu",
-						"lastName": "Huang",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Niket",
-						"lastName": "Tandon",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Wen-tau",
-						"lastName": "Yih",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Peter",
-						"lastName": "Clark",
-						"creatorType": "author"
-					}
-				],
-				"date": "2018",
-				"abstractNote": "We present a new dataset and models for comprehending paragraphs about processes (e.g., photosynthesis), an important genre of text describing a dynamic world. The new dataset, ProPara, is the first to contain natural (rather than machine-generated) text about a changing world along with a full annotation of entity states (location and existence) during those changes (81k datapoints). The end-task, tracking the location and existence of entities through the text, is challenging because the causal effects of actions are often implicit and need to be inferred. We find that previous models that have worked well on synthetic data achieve only mediocre performance on ProPara, and introduce two new neural models that exploit alternative mechanisms for state prediction, in particular using LSTM input encoding and span prediction. The new models improve accuracy by up to 19%. The dataset and models are available to the community at http://data.allenai.org/propara.",
-				"itemID": "Dalvi2018TrackingSC",
-				"libraryCatalog": "Semantic Scholar",
-				"proceedingsTitle": "NAACL-HLT",
-				"shortTitle": "Tracking State Changes in Procedural Text",
-				"attachments": [
-					{
-						"title": "Semantic Scholar Link",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [
-					{
-						"tag": "Causal filter"
-					},
-					{
-						"tag": "Entity"
-					},
-					{
-						"tag": "List comprehension"
-					},
-					{
-						"tag": "Long short-term memory"
-					},
-					{
-						"tag": "Synthetic data"
 					}
 				],
 				"notes": [],
 				"seeAlso": [],
-				"publicationTitle": "ArXiv",
-				"volume": "abs/1805.06975"
+				"tags": []
 			}
 		]
 	}

--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-01-17 15:47:05"
+	"lastUpdated": "2020-02-05 15:02:05"
 }
 
 /*
@@ -104,7 +104,7 @@ function parseDocument(doc, url) {
 	// use the public api to retrieve more structured data
 	const paperIdRegex = /\/(.{40})(\?|$)/;
 	const paperId = paperIdRegex.exec(url)[1];
-	const apiUrl = `http://api.semanticscholar.org/v1/paper/${paperId}?client=zotero_connect`;
+	const apiUrl = `https://api.semanticscholar.org/v1/paper/${paperId}?client=zotero_connect`;
 	ZU.doGet(apiUrl, (data) => {
 		let json = JSON.parse(data);
 		item.DOI = json.doi;

--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -98,7 +98,7 @@ function parseDocument(doc, url) {
 			title: "Full Text PDF",
 			mimeType: 'application/pdf'
 		});
-	} 
+	}
 	else {
 		item.attachments.push({
 			url: paperLink,

--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-07-07 21:59:05"
+	"lastUpdated": "2020-01-17 15:47:05"
 }
 
 /*
@@ -42,7 +42,7 @@ var bibtex2zoteroTypeMap = {
 	article: "journalArticle"
 };
 
-function detectWeb(doc, url) {
+function detectWeb(doc) {
 	let citation = ZU.xpathText(doc, '//pre[@class="bibtex-citation"]');
 	let type = citation.split('{')[0].replace('@', '');
 	return bibtex2zoteroTypeMap[type];
@@ -67,21 +67,21 @@ function parseDocument(doc, url) {
 
 	var item = new Zotero.Item(itemType);
 
-	// load structured schema data 
+	// load structured schema data
 	const schemaTag = doc.querySelector("script.schema-data");
 	const schemaObject = JSON.parse(schemaTag.innerHTML);
 	const article = schemaObject["@graph"][1][0];
 
-	item.title = article["name"];
-	item.abstractNote = article["description"];
+	item.title = article.name;
+	item.abstractNote = article.description;
 
-	if (article["author"]) {
-		article["author"].forEach(author => {
-			item.creators.push(ZU.cleanAuthor(author["name"], 'author'));
+	if (article.author) {
+		article.author.forEach((author) => {
+			item.creators.push(ZU.cleanAuthor(author.name, 'author'));
 		});
 	}
-	item.publicationTitle = article["publication"];
-	item.date = article["datePublished"];
+	item.publicationTitle = article.publication;
+	item.date = article.datePublished;
 
 	// attachments
 	item.attachments.push({
@@ -91,14 +91,15 @@ function parseDocument(doc, url) {
 		snapshot: false
 	});
 
-	const paperLink = article["about"]["url"];
+	const paperLink = article.about.url;
 	if (paperLink.includes("pdfs.semanticscholar.org") || paperLink.includes("arxiv.org")) {
 		item.attachments.push({
 			url: paperLink,
 			title: "Full Text PDF",
 			mimeType: 'application/pdf'
 		});
-	} else {
+	} 
+	else {
 		item.attachments.push({
 			url: paperLink,
 			title: "Publisher Link",

--- a/Semantic Scholar.js
+++ b/Semantic Scholar.js
@@ -91,6 +91,7 @@ function parseDocument(doc, url) {
 		snapshot: false
 	});
 
+	// if semantic scholar has a pdf as it's primary paper link it will appear in the about field
 	const paperLink = article.about.url;
 	if (paperLink.includes("pdfs.semanticscholar.org") || paperLink.includes("arxiv.org")) {
 		item.attachments.push({
@@ -99,16 +100,16 @@ function parseDocument(doc, url) {
 			mimeType: 'application/pdf'
 		});
 	}
-	else {
-		item.attachments.push({
-			url: paperLink,
-			title: "Publisher Link",
-			mimeType: "text/html",
-			snapshot: false
-		});
-	}
 
-	item.complete();
+	// use the public api to retrieve more structured data
+	const paperIdRegex = /\/(.{40})(\?|$)/;
+	const paperId = paperIdRegex.exec(url)[1];
+	const apiUrl = `http://api.semanticscholar.org/v1/paper/${paperId}?client=zotero_connect`;
+	ZU.doGet(apiUrl, (data) => {
+		let json = JSON.parse(data);
+		item.DOI = json.doi;
+		item.complete();
+	});
 }
 
 /** BEGIN TEST CASES **/
@@ -142,16 +143,12 @@ var testCases = [
 						"title": "Semantic Scholar Link",
 						"mimeType": "text/html",
 						"snapshot": false
-					},
-					{
-						"title": "Publisher Link",
-						"mimeType": "text/html",
-						"snapshot": false
 					}
 				],
 				"notes": [],
 				"seeAlso": [],
-				"tags": []
+				"tags": [],
+				"DOI": "10.1007/978-3-642-14770-8_33"
 			}
 		]
 	}


### PR DESCRIPTION
The way the Semantic Scholar plugin was written wasn't going to work and it's consistently throwing errors when attempted to be used today:

![image](https://user-images.githubusercontent.com/399279/72656799-5edf1080-3952-11ea-8a61-192843b57c34.png)

```
TypeError: rawData is undefined at moz-extension://8698ca6d-2f0d-3740-aef0-c4fcf97e2d0b/inject/translate_inject.js line 63 > eval:125
```

More background: It was trying to read data from a `DATA` variable that only appears in the html when first loading a paper page (used for sharing server side renderered data with the client). However once you load the page navigating within the Single-Page-App takes you to new papers that will not have that variable ever. Since the tests were grabbing fresh html from the server it worked fine there but in an actual browser it would fail 100% of the time that you changed pages. For example if you load a paper, click a citation and then from that new paper try to use the old plugin you'll get a mix of new/old fields mixed together.

----------------------------

In the short-run I'm proposing this simpler implementation that uses the schema-metadata section the site is providing for search engines. This will be stable and reliable. I also removed the Search functionality as it was pretty janky and didn't actually produce useful artifacts (just paper titles but no links/metadata to go along with them).

Longer term we could do something fancier to help expose more data (like the topics/tags) reliably.