### PR TITLE
Bib(La)TeX: Add comma at the end of entry

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -866,6 +866,6 @@ function doExport() {
 			}
 		}
 
-		Zotero.write("\n}");
+		Zotero.write(",\n}");
 	}
 }

--- a/BibTeX.js
+++ b/BibTeX.js
@@ -1533,7 +1533,7 @@ function doExport() {
 			}
 		}
 		
-		Zotero.write("\n}");
+		Zotero.write(",\n}");
 	}
 }
 


### PR DESCRIPTION
See https://forums.zotero.org/discussion/81594/empty-field-in-a-bibtex-file-causing-biber-failing

Biber (one of the tools for creating bibliographfies in LaTeX) is failing when an item is empty (with no entries) and there's no comma after the citekey. As the comma can be at the end of any item (even one with entries), this simply adds the comma to fix the bug.