### PR TITLE
allows "www" in the beginning of eLibrary.ru url

### DIFF
--- a/eLibrary.ru.js
+++ b/eLibrary.ru.js
@@ -2,14 +2,14 @@
 	"translatorID": "587709d3-80c5-467d-9fc8-ed41c31e20cf",
 	"label": "eLibrary.ru",
 	"creator": "Avram Lyon",
-	"target": "^https?://elibrary\\.ru/",
+	"target": "^https?://(www\\.)?elibrary\\.ru/",
 	"minVersion": "2.1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2019-10-19 17:28:01"
+	"lastUpdated": "2020-03-09 18:50:52"
 }
 
 /*


### PR DESCRIPTION
I've noticed that currently elibrary.ru translator does not work because the page url is 
`https://www.elibrary.ru/item.asp?id=30694319`, instead of 
`https://elibrary.ru/item.asp?id=30694319` .
This PR adjusts the `target` accordingly.