### PR TITLE
Newspapers.com: Save PDF instead of image

### DIFF
--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-04-08 23:40:05"
+	"lastUpdated": "2020-10-08 17:39:43"
 }
 
 /*
@@ -85,12 +85,12 @@ function doWeb(doc, _url) {
 
 	newItem.abstractNote = details.media.note;
 	
-	var uniqueID = newItem.url.match(/\d+/)
-	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID
+	var uniqueID = newItem.url.match(/\d+/);
+	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID;
 	newItem.attachments.push({
-		title:"Full Text PDF",
-		mimeType:"application/pdf",
-		url:pdfurl
+		title: "Full Text PDF",
+		mimeType: "application/pdf",
+		url: pdfurl
 	});
 
 	newItem.publicationTitle = details.source.publisherName;

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-04-08 23:07:42"
+	"lastUpdated": "2020-04-08 23:40:05"
 }
 
 /*
@@ -85,8 +85,6 @@ function doWeb(doc, _url) {
 
 	newItem.abstractNote = details.media.note;
 	
-	// downloads pdfs instead of images - not pretty but functional
-	// works for ids of length 7 or 8
 	var uniqueID = newItem.url.match(/\d+/)
 	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID
 	newItem.attachments.push({
@@ -111,8 +109,6 @@ function doWeb(doc, _url) {
 		newItem.title = "Clipped From " + newItem.publicationTitle;
 	}
 	newItem.complete();
-Zotero.debug(pdfurl)
-
 }
 
 

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-05-09 03:46:53"
+	"lastUpdated": "2020-04-02 01:44:09"
 }
 
 /*
@@ -39,6 +39,7 @@ function detectWeb(_doc, _url) {
 	return "newspaperArticle";
 }
 
+
 function doWeb(doc, _url) {
 	var newItem = new Zotero.Item("newspaperArticle");
 	var scripts = doc.getElementsByTagName("script");
@@ -51,7 +52,7 @@ function doWeb(doc, _url) {
 			break;
 		}
 	}
-
+	
 	// one JSON.parse to unstringify the json string, and one to parse it into an object
 	// the replace fixes escaped apostrophes in the source, which JSON.parse considers invalid
 	var details = JSON.parse(JSON.parse(json.replace(/\\'/g, "'")));
@@ -84,14 +85,16 @@ function doWeb(doc, _url) {
 
 	newItem.abstractNote = details.media.note;
 	
-	/*
-	<meta property="og:image" content="https://img0.newspapers.com/img/img?id=97710064&width=557&height=4616&crop=1150_215_589_4971&rotation=0&brightness=0&contrast=0&invert=0&ts=1467779959&h=e478152fd53dd7afc4e72a18c1dad4ea">
-	*/
-	newItem.attachments = [{
-		url: metaArr["og:image"],
-		title: "Image",
-		mimeType: "image/jpeg"
-	}];
+	// downloads pdfs instead of images - not pretty but functional
+	// works for ids of length 7 or 8
+	var clipID = newItem.url.replace("https://www.newspapers.com/clip/","")
+	var uniqueID = clipID.substring(0,8)
+	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID
+	newItem.attachments.push({
+		title:"Full Text PDF",
+		mimeType:"application/pdf",
+		url:pdfurl
+	});
 
 	newItem.publicationTitle = details.source.publisherName;
 	// details["source"]["title"] gives a string like
@@ -109,13 +112,15 @@ function doWeb(doc, _url) {
 		newItem.title = "Clipped From " + newItem.publicationTitle;
 	}
 	newItem.complete();
+Zotero.debug(pdfurl)
 }
+
 
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/",
+		"url": "https://www.newspapers.com/clip/7960447/my-day-eleanor-roosevelt/",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
@@ -132,11 +137,11 @@ var testCases = [
 				"pages": "15",
 				"place": "Akron, Ohio",
 				"publicationTitle": "The Akron Beacon Journal",
-				"url": "https://www.newspapers.com/clip/7960447/my_day_eleanor_roosevelt/",
+				"url": "https://www.newspapers.com/clip/7960447/my-day-eleanor-roosevelt/",
 				"attachments": [
 					{
-						"title": "Image",
-						"mimeType": "image/jpeg"
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [],
@@ -147,7 +152,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.newspapers.com/clip/18535448/the_sunday_leader/",
+		"url": "https://www.newspapers.com/clip/18535448/the-sunday-leader/",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
@@ -158,11 +163,11 @@ var testCases = [
 				"pages": "5",
 				"place": "Wilkes-Barre, Pennsylvania",
 				"publicationTitle": "The Sunday Leader",
-				"url": "https://www.newspapers.com/clip/18535448/the_sunday_leader/",
+				"url": "https://www.newspapers.com/clip/18535448/the-sunday-leader/",
 				"attachments": [
 					{
-						"title": "Image",
-						"mimeType": "image/jpeg"
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [],
@@ -173,7 +178,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.newspapers.com/clip/31333699/driven_from_governors_office_ohio/",
+		"url": "https://www.newspapers.com/clip/31333699/driven-from-governors-office-ohio/",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
@@ -184,11 +189,11 @@ var testCases = [
 				"pages": "1",
 				"place": "Rushville, Indiana",
 				"publicationTitle": "Rushville Republican",
-				"url": "https://www.newspapers.com/clip/31333699/driven_from_governors_office_ohio/",
+				"url": "https://www.newspapers.com/clip/31333699/driven-from-governors-office-ohio/",
 				"attachments": [
 					{
-						"title": "Image",
-						"mimeType": "image/jpeg"
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [],

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-04-02 01:44:09"
+	"lastUpdated": "2020-04-08 23:07:42"
 }
 
 /*
@@ -87,8 +87,7 @@ function doWeb(doc, _url) {
 	
 	// downloads pdfs instead of images - not pretty but functional
 	// works for ids of length 7 or 8
-	var clipID = newItem.url.replace("https://www.newspapers.com/clip/","")
-	var uniqueID = clipID.substring(0,8)
+	var uniqueID = newItem.url.match(/\d+/)
 	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID
 	newItem.attachments.push({
 		title:"Full Text PDF",
@@ -113,6 +112,7 @@ function doWeb(doc, _url) {
 	}
 	newItem.complete();
 Zotero.debug(pdfurl)
+
 }
 
 

--- a/newspapers.com.js
+++ b/newspapers.com.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-10-08 17:39:43"
+	"lastUpdated": "2020-10-29 03:32:09"
 }
 
 /*
@@ -85,7 +85,7 @@ function doWeb(doc, _url) {
 
 	newItem.abstractNote = details.media.note;
 	
-	var uniqueID = newItem.url.match(/\d+/);
+	var uniqueID = newItem.url.match(/\/clip\/(\d+)/)[1];
 	var pdfurl = "https://www.newspapers.com/clippings/download/?id=" + uniqueID;
 	newItem.attachments.push({
 		title: "Full Text PDF",


### PR DESCRIPTION
changes attachment type from image to pdf, also corrects test case urls