### PR TITLE
Do not remove words from first word of title when the word is hyphenated

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -383,6 +383,10 @@ var citeKeyConversions = {
 	},
 	t: function (flags, item) {
 		if (item.title) {
+      var first_word = item.title.toLowerCase().split(/\s+/g)[0];
+      if (first_word.includes("-")) {
+        return first_word;
+      }
 			return item.title.toLowerCase().replace(citeKeyTitleBannedRe, "").split(/\s+/g)[0];
 		}
 		return "notitle";


### PR DESCRIPTION
The current BibLaTex export of Zotero creates the following bibtex key for this paper:
```
@book{smith_proof--stake_2020,
  title = {Proof-of-Stake Protocols},
  url = {https://eprint.iacr.org/...,
  author = {Smith, John},
  date = {2020},
}
```

but it iin my opinion it should not replace words like:
```
var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l'|el|las|los|al|uno|una|unos|unas|de|des|del|d')(\s+|\b)|(<\/?(i|b|sup|sub|sc|span style="small-caps"|span)>)/g;
```
when the first word of the title is hyphenated like in the example.
So the result should be this:
```
@book{smith_proof-of-stake_2020,
  title = {Proof-of-Stake Protocols},
  url = {https://eprint.iacr.org/...,
  author = {Smith, John},
  date = {2020},
}
``` 

