### PR TITLE
ASCE Rewrite with EM

### DIFF
--- a/ASCE.js
+++ b/ASCE.js
@@ -2,23 +2,20 @@
 	"translatorID": "303bdfc5-11b8-4107-bca1-63ca97701a0f",
 	"label": "ASCE",
 	"creator": "Sebastian Karcher",
-	"target": "^https?://(www\\.)?ascelibrary\\.org/",
+	"target": "^https?://(www\\.)?ascelibrary\\.org/(toc|doi|action)/",
 	"minVersion": "2.1.9",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-04-01 14:22:53"
+	"lastUpdated": "2020-06-28 02:29:25"
 }
-
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	ASCE Translator
-	(Based on Taylor and Francis Translator)
-	Copyright © 2012 Sebastian Karcher
+	Copyright © 2020 Sebastian Karcher
 
 	This file is part of Zotero.
 
@@ -39,116 +36,70 @@
 */
 
 
-function getTitles(doc) {
-	return ZU.xpath(doc, '//table[@class="articleEntry"]//td[@valign="top"]/a[1]');
-}
+// attr()/text() v2
+// eslint-disable-next-line
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null}
 
 function detectWeb(doc, url) {
-/*	if (url.match(/\/doi\/abs\/10\.|\/doi\/full\/10\./)) {
+	if (/\/doi\/((abs|full)\/)?10\./.test(url)) {
 		return "journalArticle";
-	} else if (url.match(/\/action\/doSearch\?|\/toc\//))
-		{
+	}
+	else if (getSearchResults(doc, true)) {
 		return "multiple";
-		} */
-    //currently this triggers a massive download that shuts down Zotero for a significant time; turning it off until I have a fix (which should be shortly)
-    return false;
+	}
+	return false;
 }
 
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('div[class*="art_title"]>a');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
 
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
-		var items = new Object();
-		var titles = getTitles(doc);
-		var doi;
-		for (var i=0, n=titles.length; i<n; i++) {
-			doi = titles[i].href.match(/\/doi\/(?:abs|full)\/(10\.[^?#]+)/);
-			if (doi) {
-				items[doi[1]] = titles[i].textContent;
-			}
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (items) ZU.processDocuments(Object.keys(items), scrape);
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, url) {
+	// EM only gets a social media preview for the abastract
+	let abstract = text(doc, 'article.article div[class*="Abstract"]>p');
+
+	// Z.debug(abstract);
+	var translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', function (obj, item) {
+		item.libraryCatalog = "ASCE";
+		if (abstract) {
+			item.abstractNote = abstract;
 		}
+		// Remove mapping from DC:coverage to archiveLocation
+		item.archiveLocation = "";
+		item.complete();
+	});
 
-		Zotero.selectItems(items, function(selectedItems){
-			if (!selectedItems) return true;
-			
-			var dois = new Array();
-			for (var i in selectedItems) {
-				dois.push(i);
-			}
-			scrape(null, url,dois);
-		});
-	} else {
-		var doi = url.match(/\/doi\/(?:abs|full)\/(10\.[^?#]+)/);
-		scrape(doc, url,[doi[1]]);
-	}
+	translator.getTranslatorObject(function (trans) {
+		trans.doWeb(doc, url);
+	});
 }
-
-function finalizeItem(item, doc, doi, baseUrl) {
-	var pdfurl = baseUrl + '/doi/pdf/';
-	var absurl = baseUrl + '/doi/abs/';
-
-	//add attachments
-	item.attachments = [{
-		title: 'Full Text PDF',
-		url: pdfurl + doi,
-		mimeType: 'application/pdf'
-	}];
-	if (doc) {
-		item.attachments.push({
-			title: 'Snapshot',
-			document: doc
-		});
-	} else {
-		item.attachments.push({
-			title: 'Snapshot',
-			url: item.url || absurl + doi,
-			mimeType: 'text/html'
-		});
-	}
-
-	item.complete();
-}
-
-function scrape(doc, url, dois) {
-	var baseUrl = url.match(/https?:\/\/[^\/]+/)[0]
-	var postUrl = baseUrl + '/action/downloadCitation';
-	var postBody = 	'downloadFileName=citation&' +
-					'direct=true&' +
-					'include=abs&' +
-					'doi=';
-	var risFormat = '&format=ris';
-	var bibtexFormat = '&format=bibtex';
-
-	for (var i=0, n=dois.length; i<n; i++) {
-		(function(doi) {
-			ZU.doPost(postUrl, postBody + doi + bibtexFormat, function(text) {
-				var translator = Zotero.loadTranslator("import");
-				// Use BibTeX translator
-				translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
-				translator.setString(text);
-				translator.setHandler("itemDone", function(obj, item) {
-					item.bookTitle = item.publicationTitle;
-
-					//unfortunately, bibtex is missing some data
-					//publisher, ISSN/ISBN
-					ZU.doPost(postUrl, postBody + doi + risFormat, function(text) {
-						risTrans = Zotero.loadTranslator("import");
-						risTrans.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
-						risTrans.setString(text);
-						risTrans.setHandler("itemDone", function(obj, risItem) {
-							item.publisher = risItem.publisher;
-							item.ISSN = risItem.ISSN;
-							item.ISBN = risItem.ISBN;
-							finalizeItem(item, doc, doi, baseUrl);
-						});
-						risTrans.translate();
-					});
-				});
-				translator.translate();
-			});
-		})(dois[i]);
-	}
-}
-
 
 /** BEGIN TEST CASES **/
 var testCases = [
@@ -159,7 +110,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://ascelibrary.org/doi/abs/10.1061/%28ASCE%290887-381X%282003%2917%3A1%2837%29",
+		"url": "https://ascelibrary.org/doi/abs/10.1061/%28ASCE%290887-381X%282003%2917%3A1%2837%29",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -181,16 +132,17 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2003",
+				"date": "2003/03/01",
 				"DOI": "10.1061/(ASCE)0887-381X(2003)17:1(37)",
 				"ISSN": "0887-381X",
 				"abstractNote": "In seeking to promote cycling in wintertime, it is desirable to understand how important the winter maintenance service level is in people’s decision to cycle or not, and methods to compare different road conditions on cycleways are therefore needed. By measuring friction, an assessment of the service level can be achieved, but methods available often involve the use of large vehicles, which can lead to overloading damage on cycleways, and constitute a safety risk for cyclists and pedestrians. A portable friction tester (PFT), originally designed to measure friction on road markings, was thought to be an appropriate instrument for cycleways and was, therefore, tested on different winter road conditions, and on different cycleway pavement materials. In this study, it was found that the PFT is a valuable tool for measuring friction on cycleways. Different winter road conditions, as well as different pavement materials, can be distinguished from each other through PFT measurements. The PFT provides a good complement to visual inspections of cycleways in winter maintenance evaluation and can, for example, be used to determine if desired service levels have been achieved.",
 				"issue": "1",
-				"itemID": "doi:10.1061/(ASCE)0887-381X(2003)17:1(37)",
+				"language": "EN",
 				"libraryCatalog": "ASCE",
 				"pages": "37-57",
 				"publicationTitle": "Journal of Cold Regions Engineering",
-				"url": "http://dx.doi.org/10.1061/(ASCE)0887-381X(2003)17:1(37)",
+				"rights": "Copyright © 2003 American Society of Civil Engineers",
+				"url": "https://ascelibrary.org/doi/abs/10.1061/%28ASCE%290887-381X%282003%2917%3A1%2837%29",
 				"volume": "17",
 				"attachments": [
 					{
@@ -201,7 +153,38 @@ var testCases = [
 						"title": "Snapshot"
 					}
 				],
-				"tags": [],
+				"tags": [
+					{
+						"tag": "Bicycles"
+					},
+					{
+						"tag": "Friction"
+					},
+					{
+						"tag": "Maintenance"
+					},
+					{
+						"tag": "Measurement"
+					},
+					{
+						"tag": "Roads"
+					},
+					{
+						"tag": "friction"
+					},
+					{
+						"tag": "inspection"
+					},
+					{
+						"tag": "maintenance engineering"
+					},
+					{
+						"tag": "road traffic"
+					},
+					{
+						"tag": "safety"
+					}
+				],
 				"notes": [],
 				"seeAlso": []
 			}

--- a/RDF.js
+++ b/RDF.js
@@ -12,37 +12,37 @@
 	},
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2019-11-30 20:49:31"
+	"lastUpdated": "2020-06-26 20:49:31"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
-	
+
 	Copyright © 2011 Center for History and New Media
 					 George Mason University, Fairfax, Virginia, USA
 					 http://zotero.org
-	
+
 	This file is part of Zotero.
-	
+
 	Zotero is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Zotero is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
-	
+
 	***** END LICENSE BLOCK *****
 */
 
 function detectImport() {
 	// Make sure there are actually nodes
-	
+
 	var nodes = Zotero.RDF.getAllResources();
 	if (nodes) {
 		return true;
@@ -111,7 +111,7 @@ function handleCreators(newItem, creators, creatorType) {
 	if (!creators) {
 		return;
 	}
-	
+
 	if (typeof (creators[0]) != "string") {	// see if creators are in a container
 		let c;
 		try {
@@ -127,7 +127,7 @@ function handleCreators(newItem, creators, creatorType) {
 		let info = extractCreatorInfo(c);
 		if (info) newItem.creators.push(info);
 	}
-	
+
 	function extractCreatorInfo(obj) {
 		if (typeof obj == "string") {
 			// Use comma to split if present
@@ -164,7 +164,7 @@ function processCollection(node, collection) {
 	collection.type = "collection";
 	collection.name = getFirstResults(node, [n.dc + "title", n.dc1_0 + "title", n.dcterms + "title"], true);
 	collection.children = [];
-	
+
 	// check for children
 	var children = getFirstResults(node, [n.dcterms + "hasPart"]);
 	if (children) {
@@ -174,7 +174,7 @@ function processCollection(node, collection) {
 			if (type) {
 				type = Zotero.RDF.getResourceURI(type[0]);
 			}
-			
+
 			if (type == n.bib + "Collection" || type == n.z + "Collection") {
 				// for collections, process recursively
 				collection.children.push(processCollection(child));
@@ -184,7 +184,7 @@ function processCollection(node, collection) {
 					Zotero.debug("Not adding child item <" + Zotero.RDF.getResourceURI(child) + "> to collection", 2);
 					continue;
 				}
-				
+
 				// all other items are added by ID
 				collection.children.push({ id: Zotero.RDF.getResourceURI(child), type: "item" });
 			}
@@ -232,11 +232,11 @@ function getNodeByType(nodes, type) {
 	if (!nodes) {
 		return false;
 	}
-	
+
 	if (typeof (type) == "string") {
 		type = [type];
 	}
-	
+
 	for (let i = 0; i < nodes.length; i++) {
 		var node = nodes[i];
 		var nodeType = Zotero.RDF.getTargets(node, rdf + "type");
@@ -271,11 +271,11 @@ function isPart(node) {
 
 function detectType(newItem, node, ret) {
 	if (!node) return false;
-	
+
 	// also deal with type detection based on parts, so we can differentiate
 	// magazine and journal articles, and find container elements
 	var isPartOf = getFirstResults(node, [n.dcterms + "isPartOf", n.so + "isPartOf"]);
-	
+
 	// get parts of parts, because parts are sections of wholes.
 	if (isPartOf) {
 		// keep track of processed parts, so we don't end up in an infinite loop
@@ -288,7 +288,7 @@ function detectType(newItem, node, ret) {
 			}
 			processedParts.push(isPartOf[i]);
 		}
-		
+
 		// remove self from parts
 		for (let i = 0; i < isPartOf.length; i++) {
 			if (Zotero.RDF.getResourceURI(isPartOf[i]) == Zotero.RDF.getResourceURI(node)) {
@@ -297,7 +297,7 @@ function detectType(newItem, node, ret) {
 			}
 		}
 	}
-	
+
 	var container;
 	// for schema.org we need several containers
 	var containerPeriodical;
@@ -336,7 +336,7 @@ function detectType(newItem, node, ret) {
 				if (pref == n.z) t.z = type;
 				if (pref == n.so) t.so = type;
 				break;
-			
+
 			// bib, bibo types
 			case "booksection":
 				t.bib = 'bookSection';
@@ -370,7 +370,7 @@ function detectType(newItem, node, ret) {
 					t.bib = "webpage";
 				}
 				break;
-			
+
 			// schema.org types
 			// subtypes of http://schema.org/CreativeWork and https://bib.schema.org/
 			case 'newsarticle':
@@ -443,7 +443,7 @@ function detectType(newItem, node, ret) {
 			case 'datacatalog':
 			case 'dataset':
 				t.so = 'journalArticle'; break; // until dataset gets implemented
-			
+
 			// specials cases
 			case "article":
 			// choose between journal, newspaper, and magazine articles
@@ -479,7 +479,7 @@ function detectType(newItem, node, ret) {
 
 				// process as file
 				t.zotero = "attachment";
-	
+
 				var path = getFirstResults(node, [rdf + "resource"]);
 				if (path) {
 					newItem.path = Zotero.RDF.getResourceURI(path[0]);
@@ -488,7 +488,7 @@ function detectType(newItem, node, ret) {
 				newItem.mimeType = getFirstResults(node, [n.link + "type"], true);
 		}
 	}
-	
+
 	// zotero:itemType, zotero:type
 	type = getFirstResults(node, [n.z + "itemType", n.z + "type"], true);
 	if (type && isNaN(parseInt(type)) // itemTypeExists also takes item type IDs. We don't want to consider those
@@ -547,7 +547,7 @@ function detectType(newItem, node, ret) {
 				case 'workingpaper':
 					t.dc = 'report';
 					break;
-				
+
 				// via examples from oro.open.ac.uk, http://eprints.soton.ac.uk/
 				case 'musicitem':
 					t.dcGuess = 'audioRecording';
@@ -629,7 +629,7 @@ function detectType(newItem, node, ret) {
 				t.eprints = 'bookSection';
 				break;
 				// case 'bookreview':
-				
+
 			case 'conferenceitem':
 			case 'conferencepaper':
 			case 'conferenceposter':
@@ -702,7 +702,7 @@ function detectType(newItem, node, ret) {
 			t.og = "webpage";
 			break;
 	}
-	
+
 	// PRISM:aggregationtype
 	/** is this actually inside container?*/
 	type = getFirstResults(node, [n.prism + "aggregationtype",
@@ -833,7 +833,7 @@ function detectType(newItem, node, ret) {
 				break;
 		}
 	}
-	
+
 	// fill return object which is passed as an argument
 	ret.container = container;
 	ret.containerPeriodical = containerPeriodical;
@@ -881,7 +881,7 @@ function importItem(newItem, node) {
 		// name is a generic property and not only for titles
 		newItem.title = getFirstResults(node, [n.so + "name"], true);
 	}
-	
+
 	// regular author-type creators
 	var possibleCreatorTypes = Zotero.Utilities.getCreatorsForType(newItem.itemType);
 	var creators;
@@ -919,16 +919,16 @@ function importItem(newItem, node) {
 			creators = getFirstResults(node, [n.so + "producer"]);
 		}
 		else if (creatorType == "programmer") {
-			creators = getFirstResults(node, [n.z+"programmers", n.so + "author", n.codemeta + "maintainer"]);
+			creators = getFirstResults(node, [n.z + "programmers", n.so + "author", n.codemeta + "maintainer"]);
 		}
 		else {
 			creators = getFirstResults(node, [n.z + creatorType + "s"]);
 		}
-		
+
 		if (creators) handleCreators(newItem, creators, creatorType);
 	}
-	
-	
+
+
 	// publicationTitle -- first try PRISM, then DC
 	newItem.publicationTitle = getFirstResults(node, [n.prism + "publicationName",
 		n.prism2_0 + "publicationName",
@@ -953,7 +953,7 @@ function importItem(newItem, node) {
 	}
 	// rights
 	newItem.rights = getFirstResults(node, [n.prism + "copyright", n.prism2_0 + "copyright", n.prism2_1 + "copyright", n.dc + "rights", n.dc1_0 + "rights", n.dcterms + "rights", n.so + "license"], true);
-	
+
 	// section
 	var section = getNodeByType(isPartOf, n.bib + "Part");
 	if (section) {
@@ -962,7 +962,7 @@ function importItem(newItem, node) {
 	if (!section) {
 		newItem.section = getFirstResults(node, [n.article + "section", n.so + "genre"], true);
 	}
-	
+
 	// series
 	var series = getNodeByType(isPartOf, n.bib + "Series");
 	if (series) {
@@ -971,7 +971,7 @@ function importItem(newItem, node) {
 		newItem.seriesText = getFirstResults(series, [n.dc + "description", n.dc1_0 + "description", n.dcterms + "description"], true);
 		newItem.seriesNumber = getFirstResults(series, [n.dc + "identifier", n.dc1_0 + "identifier", n.dcterms + "description"], true);
 	}
-	
+
 	// volume
 	newItem.volume = getFirstResults([container, node, containerPublicationVolume, containerPeriodical], [n.prism + "volume",
 		n.prism2_0 + "volume",
@@ -981,7 +981,7 @@ function importItem(newItem, node) {
 		n.dc + "source.Volume",
 		n.dcterms + "citation.volume",
 		n.so + "volumeNumber"], true);
-	
+
 	// issue
 	var issueNodes = [node];
 	if (container) {
@@ -995,7 +995,7 @@ function importItem(newItem, node) {
 		n.dc + "source.Issue",
 		n.dcterms + "citation.issue",
 		n.so + "issueNumber"], true);
-	
+
 
 	// number means the same thing as issue
 	// and will automatically then also map
@@ -1006,7 +1006,7 @@ function importItem(newItem, node) {
 	newItem.edition = getFirstResults(node, [n.prism + "edition", n.prism2_0 + "edition", n.prism2_1 + "edition", n.bibo + "edition", n.so + "bookEdition", n.so + "version"], true);
 	// these fields mean the same thing
 	newItem.versionNumber = newItem.edition;
-	
+
 	// pages
 	newItem.pages = getFirstResults(node, [n.bib + "pages", n.eprints + "pagerange", n.prism2_0 + "pageRange", n.prism2_1 + "pageRange", n.bibo + "pages", n.dc + "identifier.pageNumber", n.so + "pagination"], true);
 	if (!newItem.pages) {
@@ -1017,7 +1017,7 @@ function importItem(newItem, node) {
 		if (epage) pages.push(epage);
 		if (pages.length) newItem.pages = pages.join("-");
 	}
-	
+
 	// numPages
 	newItem.numPages = getFirstResults(node, [n.bibo + "numPages", n.eprints + "pages", n.so + "numberOfPages"], true);
 
@@ -1026,16 +1026,16 @@ function importItem(newItem, node) {
 
 	// short title
 	newItem.shortTitle = getFirstResults(node, [n.bibo + "shortTitle"], true);
-	
+
 	// mediums
 	newItem.artworkMedium = newItem.interviewMedium = getFirstResults(node, [n.dcterms + "medium"], true);
-	
+
 	// programmingLanguage
 	newItem.programmingLanguage = getFirstResults(node, [n.so + "programmingLanguage"], true);
-	
+
 	// system
 	newItem.system = getFirstResults(node, [n.so + "operatingSystem"], true);
-	
+
 	// publisher
 	var publisher = getFirstResults([node, containerPeriodical, containerPublicationVolume], [n.dc + "publisher",
 		n.dc1_0 + "publisher",
@@ -1078,10 +1078,10 @@ function importItem(newItem, node) {
 		// Prefer place of publication to conference location
 		newItem.place = getFirstResults(node, [n.eprints + "place_of_pub", n.eprints + "event_location"], true);
 	}
-	
+
 	// these fields mean the same thing
 	newItem.distributor = newItem.label = newItem.company = newItem.institution = newItem.publisher;
-	
+
 	// date
 	newItem.date = getFirstResults(node, [n.eprints + "date",
 		n.prism + "publicationDate",
@@ -1106,7 +1106,7 @@ function importItem(newItem, node) {
 	// lastModified
 	newItem.lastModified = getFirstResults(node, [n.dcterms + "modified",
 		n.so + "dateModified"], true);
-	
+
 	// identifier
 	var identifiers = getFirstResults(node, [n.dc + "identifier", n.dc1_0 + "identifier", n.dcterms + "identifier"]);
 	if (container) {
@@ -1121,13 +1121,13 @@ function importItem(newItem, node) {
 			}
 		}
 	}
-	
+
 	if (identifiers) {
 		for (var i in identifiers) {
 			if (typeof (identifiers[i]) == "string") {
 				// grab other things
 				var beforeSpace = identifiers[i].substr(0, identifiers[i].indexOf(" ")).toUpperCase();
-			
+
 				// Attempt to determine type of identifier by prefix label
 				if (beforeSpace == "ISBN") {
 					newItem.ISBN = identifiers[i].substr(5).toUpperCase();
@@ -1140,13 +1140,13 @@ function importItem(newItem, node) {
 				}
 				// Or just try parsing values
 				else if (ZU.cleanISBN(identifiers[i])) {
-					newItem.ISBN = identifiers[i];
+					newItem.ISBN = ZU.cleanISBN(identifiers[i]);
 				}
 				else if (ZU.cleanISSN(identifiers[i])) {
-					newItem.ISSN = identifiers[i];
+					newItem.ISSN = ZU.cleanISSN(identifiers[i]);
 				}
 				else if (ZU.cleanDOI(identifiers[i])) {
-					newItem.DOI = identifiers[i];
+					newItem.DOI = ZU.cleanDOI(identifiers[i]);
 				}
 			}
 			else {
@@ -1158,7 +1158,7 @@ function importItem(newItem, node) {
 			}
 		}
 	}
-	
+
 	// ISSN, if encoded per PRISM
 	newItem.ISSN = getFirstResults([container, node, containerPeriodical, containerPublicationVolume], [n.prism + "issn",
 		n.prism2_0 + "issn",
@@ -1177,7 +1177,7 @@ function importItem(newItem, node) {
 	newItem.ISBN = getFirstResults(node, [n.eprints + "isbn"], true) || newItem.ISBN;
 	// DOI from nonstandard DC, PRISM, or BIBO
 	newItem.DOI = getFirstResults(node, [n.dc + "identifier.DOI", n.prism2_0 + "doi", n.prism2_1 + "doi", n.bibo + "doi"], true) || newItem.DOI;
-	
+
 	if (!newItem.url) {
 		var url = getFirstResults(node, [n.eprints + "official_url",
 			n.vcard2 + "url",
@@ -1191,10 +1191,10 @@ function importItem(newItem, node) {
 			newItem.url = Zotero.RDF.getResourceURI(url[0]);
 		}
 	}
-	
+
 	// archiveLocation
 	newItem.archiveLocation = getFirstResults(node, [n.dc + "coverage", n.dc1_0 + "coverage", n.dcterms + "coverage"], true);
-	
+
 	// abstract
 	newItem.abstractNote = getFirstResults(node, [n.eprints + "abstract",
 		n.prism + "teaser",
@@ -1207,10 +1207,10 @@ function importItem(newItem, node) {
 		n.dcterms + "description.abstract",
 		n.dc1_0 + "description",
 		n.so + "description"], true);
-	
+
 	// type
 	let type = getFirstResults(node, [n.dc + "type", n.dc1_0 + "type", n.dcterms + "type"], true);
-	
+
 	/** CUSTOM ITEM TYPE  -- Currently only Dataset **/
 	if (type && (type.toLowerCase() == "dataset" || type.toLowerCase() == "datacatalog")) {
 		if (newItem.extra) {
@@ -1233,7 +1233,7 @@ function importItem(newItem, node) {
 	for (let i = 0; i < typeProperties.length; i++) {
 		newItem[typeProperties[i]] = type;
 	}
-	
+
 
 	// thesis type from eprints
 	if (newItem.itemType == "thesis") {
@@ -1273,22 +1273,22 @@ function importItem(newItem, node) {
 	if (adr) {
 		newItem.address = getFirstResults(adr[0], [n.vcard2 + "label"], true);
 	}
-	
+
 	// telephone
 	newItem.telephone = getFirstResults(node, [n.vcard2 + "tel"], true);
-	
+
 	// email
 	newItem.email = getFirstResults(node, [n.vcard2 + "email"], true);
-	
+
 	// accepted
 	newItem.accepted = getFirstResults(node, [n.dcterms + "dateAccepted"], true);
 
 	// language
 	newItem.language = getFirstResults(node, [n.dc + "language", n.dc1_0 + "language", n.dcterms + "language", n.so + "inLanguage"], true);
-	
+
 	// see also
 	processSeeAlso(node, newItem);
-	
+
 	// description/attachment note
 	if (newItem.itemType == "attachment") {
 		newItem.note = getFirstResults(node, [n.dc + "description", n.dc1_0 + "description", n.dcterms + "description"], true);
@@ -1300,9 +1300,9 @@ function importItem(newItem, node) {
 	else if (!newItem.abstractNote) {
 		newItem.abstractNote = getFirstResults(node, [n.dc + "description", n.dcterms + "description"], true);
 	}
-	
+
 	/** NOTES **/
-	
+
 	var referencedBy = Zotero.RDF.getTargets(node, n.dcterms + "isReferencedBy");
 	for (let i = 0; i < referencedBy.length; i++) {
 		var referentNode = referencedBy[i];
@@ -1315,14 +1315,14 @@ function importItem(newItem, node) {
 				// handle see also
 				processSeeAlso(referentNode, note);
 				processTags(referentNode, note);
-				
+
 				// add note
 				newItem.notes.push(note);
 			}
 		}
 	}
 
-	
+
 	if (newItem.itemType == "note") {
 		// add note for standalone
 		let note = getFirstResults(node, [rdf + "value", n.dc + "description", n.dc1_0 + "description", n.dcterms + "description"], true);
@@ -1330,9 +1330,9 @@ function importItem(newItem, node) {
 		// empty to avoid an error
 		newItem.note = note ? note : " ";
 	}
-	
+
 	/** TAGS **/
-	
+
 	var subjects = getFirstResults(node, [n.dc + "subject",
 		n.dc1_0 + "subject",
 		n.dcterms + "subject",
@@ -1367,7 +1367,7 @@ function importItem(newItem, node) {
 			}
 		}
 	}
-	
+
 	/** ATTACHMENTS **/
 	var relations = getFirstResults(node, [n.link + "link"]);
 	if (relations) {
@@ -1381,7 +1381,7 @@ function importItem(newItem, node) {
 			}
 		}
 	}
-	
+
 	var pdfURL = getFirstResults(node, [n.eprints + "document_url"]);
 	if (pdfURL) {
 		newItem.attachments.push({
@@ -1390,7 +1390,7 @@ function importItem(newItem, node) {
 			path: pdfURL[0]
 		});
 	}
-	
+
 	/** OTHER FIELDS **/
 	var arcs = Zotero.RDF.getArcsOut(node);
 	for (let i = 0; i < arcs.length; i++) {
@@ -1400,7 +1400,7 @@ function importItem(newItem, node) {
 			newItem[property] = Zotero.RDF.getTargets(node, n.z + property)[0];
 		}
 	}
-	
+
 	return true;
 }
 
@@ -1418,7 +1418,7 @@ function getNodes(skipCollections) {
 				|| Zotero.RDF.getSources(node, n.dcterms + "creator")) {
 			continue;
 		}
-		
+
 		// type
 		let type = Zotero.RDF.getTargets(node, rdf + "type");
 		if (type) {
@@ -1461,7 +1461,7 @@ function startImport(resolve, reject) {
 			resolve();
 			return;
 		}
-		
+
 		// keep track of collections while we're looping through
 		var collections = [];
 		importNext(nodes, 0, collections, resolve, reject);
@@ -1475,27 +1475,27 @@ function importNext(nodes, index, collections, resolve, reject) {
 	try {
 		for (let i = index; i < nodes.length; i++) {
 			var node = nodes[i];
-			
+
 			// type
 			let type = Zotero.RDF.getTargets(node, rdf + "type");
 			if (type) {
 				type = Zotero.RDF.getResourceURI(type[0]);
-				
+
 				// skip if this is not an independent attachment,
 				if ((type == n.z + "Attachment" || type == n.bib + "Memo") && isPart(node)) {
 					continue;
 				}
-				
+
 				// skip collections until all the items are done
 				if (type == n.bib + "Collection" || type == n.z + "Collection") {
 					collections.push(node);
 					continue;
 				}
 			}
-			
+
 			var newItem = new Zotero.Item();
 			newItem.itemID = Zotero.RDF.getResourceURI(node);
-			
+
 			if (importItem(newItem, node)) {
 				var maybePromise = newItem.complete();
 				if (maybePromise) {
@@ -1505,10 +1505,10 @@ function importNext(nodes, index, collections, resolve, reject) {
 					return;
 				}
 			}
-			
+
 			Zotero.setProgress((i + 1) / nodes.length * 100);
 		}
-		
+
 		// Collections
 		for (let i = 0; i < collections.length; i++) {
 			var collection = collections[i];
@@ -1522,7 +1522,7 @@ function importNext(nodes, index, collections, resolve, reject) {
 	catch (e) {
 		reject(e);
 	}
-	
+
 	resolve();
 }
 


### PR DESCRIPTION
Use ZU.clean functions in RDF not just to identify but also to actually import identifiers.

Tests for multiples fail in Scaffold due to missing cookie, but work in the browser.