### PR TITLE
update of DEPATISnet.js

### DIFF
--- a/DEPATISnet.js
+++ b/DEPATISnet.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-12-07 20:44:27"
+	"lastUpdated": "2020-07-10 11:53:20"
 }
 
 /*
@@ -81,7 +81,7 @@ function cleanTitle(value) {
 
 function cleanName(name, inventors) {
 	name = ZU.trimInternal(name);
-	if (name == "") return "";
+	if (name === "") return "";
 	
 	var parts = name.split(",");
 
@@ -117,8 +117,8 @@ function scrape(doc, url) {
 
 	var ipcs = [];
 
-	var rows = ZU.xpath(doc, '//table[@class="tab_detail"]/tbody/tr');
-	
+	var rows = ZU.xpath(doc, '//table/tbody/tr');			//old line: //var rows = ZU.xpath(doc, '//table[@class="tab_detail"]/tbody/tr');
+
 	for (var i = 0, n = rows.length; i < n; i++) {
 		var columns = ZU.xpath(rows[i], './td');
 
@@ -146,13 +146,13 @@ function scrape(doc, url) {
 				var creators = value.textContent.split(";");
 				for (let creator of creators) {
 					creator = cleanName(creator, true);
-					if (creator != "") {
+					if (creator !== "") {
 						newItem.creators.push(ZU.cleanAuthor(creator, "inventor", true));
 					}
 				}
 				break;
 			case "PA":
-				var assigneeNames = value.textContent.split(";").map(name => cleanName(name, false)).filter(name => name != "");
+				var assigneeNames = value.textContent.split(";").map(name => cleanName(name, false)).filter(name => name !== "");
 				newItem.assignee = assigneeNames.join("; ");
 				break;
 			case "ICM":
@@ -197,13 +197,14 @@ function scrape(doc, url) {
 		snapshot: false
 	});
 	
-	var pages = ZU.xpathText(doc, '//div[@id="inhalt"]/h2');
+	var pages = ZU.xpathText(doc, '/html/body/div[4]/p/span');			//old line: //var pages = ZU.xpathText(doc, '//div[@id="inhalt"]/h2');
+	alert(pages);
 	// e.g. "Dokument   DE000004446098C2   (Seiten: 8)"
 	// but there is no PDF available when we have "Seiten: 0"
 	if (pages && /(Seiten|Pages):\s*[1-9][0-9]*/.test(pages)) {
 		var pdfurl = "https://depatisnet.dpma.de/DepatisNet/depatisnet/" + pn + "_all_pages.pdf?window=1&space=menu&content=download_doc_verify&action=download_doc&docid=" + pn;
 		newItem.attachments.push({
-			title: "Fulltext",
+			title: pn,		//old line:  title: "Fulltext",
 			url: pdfurl,
 			mimeType: "application/pdf"
 		});


### PR DESCRIPTION
With regard to the post https://github.com/zotero/translators/issues/2197 the xpath parameters have been updated:

Line 120:
var rows = ZU.xpath(doc, '//table[@class="tab_detail"]/tbody/tr');
to:
var rows = ZU.xpath(doc, '//table/tbody/tr');

Line 200:
var pages = ZU.xpathText(doc, '//div[@id="inhalt"]/h2');
to:
var pages = ZU.xpathText(doc, '//p/span');

Also the name for the downloaded pdf has been changed. Instead of 'fulltext' the file is now named after the patent number:

Line 207:
title: "Fulltext",
to:
title: pn,