### PR TITLE
Added unsupported CrossRef content types

### DIFF
--- a/Crossref-REST.js
+++ b/Crossref-REST.js
@@ -194,8 +194,8 @@ function processCrossref(json) {
 		}
 		
 		// edited-book, standard-series - ignore, because Crossref has zero results for this type
-		// component, journal, journal-issue, journal-volume, other, proceedings - ignore,
-		// because Zotero doesn't have equivalent item types.
+		// component, journal, journal-issue, journal-volume, other, proceedings,
+		// proceedings-series, peer-review - ignore, because Zotero doesn't have equivalent item types.
 		
 		item.abstractNote = result.abstract;
 		


### PR DESCRIPTION
`proceedings-series` and `peer-review` are listed as CrossRef content types in https://api.crossref.org/v1/types. I understand these 
types do not have equivalent item types in Zotero. Therefore, here I added them to the comment about unsupported CrossRef types.