### PR TITLE
Fix Trove tag detection

### DIFF
--- a/Trove.js
+++ b/Trove.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-15 01:00:33"
+	"lastUpdated": "2020-09-15 01:07:09"
 }
 
 /*
@@ -126,7 +126,6 @@ function scrapeNewspaper(doc, url) {
 					item.tags.push(tag);
 				}
 			}
-			Zotero.debug(item.tags);
 
 			// I've created a proxy server to generate the PDF and return the URL without locking up the browser.
 			var proxyURL = "http://trove-proxy.herokuapp.com/pdf/" + articleID;

--- a/Trove.js
+++ b/Trove.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-15 00:35:51"
+	"lastUpdated": "2020-09-15 01:00:33"
 }
 
 /*
@@ -32,15 +32,21 @@
 
 
 function detectWeb(doc, url) {
+	// Note that the url for search results has changed, 
+	// so the first pattern will never match.
+	// However, results scraping needs to be rewritten due to the redesign,
+	// so leave this as is for now.
 	if (url.includes('/result?') || url.includes('/newspaper/page')) {
 		return getSearchResults(doc, url, true) ? 'multiple' : false;
 	}
 	else if (url.includes('/newspaper/article')) {
 		return "newspaperArticle";
 	}
-	else if (url.includes('/work/')) {
-		return "book";
-	}
+//  Scraping from works is very brokened due to site redesign
+//  Prevent detection until a fix is available
+//	else if (url.includes('/work/')) {
+//		return "book";
+//	}
 	return false;
 }
 

--- a/Trove.js
+++ b/Trove.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-15 01:13:55"
+	"lastUpdated": "2020-09-15 01:24:23"
 }
 
 /*
@@ -32,7 +32,7 @@
 
 
 function detectWeb(doc, url) {
-	// Note that the url for search results has changed, 
+	// Note that the url for search results has changed,
 	// so the first pattern will never match.
 	// However, results scraping needs to be rewritten due to the redesign,
 	// so leave this as is for now.
@@ -42,11 +42,11 @@ function detectWeb(doc, url) {
 	else if (url.includes('/newspaper/article')) {
 		return "newspaperArticle";
 	}
-//  Scraping from works is very brokened due to site redesign
-//  Prevent detection until a fix is available
-//	else if (url.includes('/work/')) {
-//		return "book";
-//	}
+	//  Scraping from works is very brokened due to site redesign
+	//  Prevent detection until a fix is available
+	//	else if (url.includes('/work/')) {
+	//		return "book";
+	//	}
 	return false;
 }
 

--- a/Trove.js
+++ b/Trove.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-01-05 17:34:52"
+	"lastUpdated": "2020-09-15 00:35:51"
 }
 
 /*
@@ -116,10 +116,11 @@ function scrapeNewspaper(doc, url) {
 				// Add tags
 				var tags = ZU.xpath(doc, "//ul[contains(@class,'nlaTagContainer')]/li");
 				for (let tag of tags) {
-					tag = ZU.xpathText(tag, "a[not(contains(@class,'anno-remove'))]");
+					tag = ZU.xpathText(tag, "div/a[not(contains(@class,'anno-remove'))]");
 					item.tags.push(tag);
 				}
 			}
+			Zotero.debug(item.tags);
 
 			// I've created a proxy server to generate the PDF and return the URL without locking up the browser.
 			var proxyURL = "http://trove-proxy.herokuapp.com/pdf/" + articleID;
@@ -336,7 +337,12 @@ var testCases = [
 				"place": "Vic.",
 				"publicationTitle": "Sunbury News (Vic. : 1900 - 1927)",
 				"url": "http://nla.gov.au/nla.news-article70068753",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Trove newspaper PDF",
+						"mimeType": "application/pdf"
+					}
+				],
 				"tags": [
 					{
 						"tag": "Meteorology Journal - Clement Wragge"

--- a/Trove.js
+++ b/Trove.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-15 01:07:09"
+	"lastUpdated": "2020-09-15 01:13:55"
 }
 
 /*
@@ -128,7 +128,7 @@ function scrapeNewspaper(doc, url) {
 			}
 
 			// I've created a proxy server to generate the PDF and return the URL without locking up the browser.
-			var proxyURL = "http://trove-proxy.herokuapp.com/pdf/" + articleID;
+			var proxyURL = "https://trove-proxy.herokuapp.com/pdf/" + articleID;
 			ZU.doGet(proxyURL, function (pdfURL) {
 				// With the last argument 'false' passed to doGet
 				// we allow all status codes to continue and reach


### PR DESCRIPTION
This fixes #2244 - a `<div>` had been wrapped around the `<a>` tag so I just updated the xpath. 

I also updated the PDF proxy to use https. This was discussed in #2106 .

I also commented out the detection of 'works' in Trove. Trove recently underwent a major redesign and has been rebuilt in React. This means that the scraping code for works and search results are very broken. I'm not sure if there's a fix at this stage, so I thought it best just to prevent detection until there was a chance for further investigation.