### PR TITLE
Update base url of direct links into RecordSearch

### DIFF
--- a/National Archives of Australia.js
+++ b/National Archives of Australia.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-18 07:13:48"
+	"lastUpdated": "2020-09-18 08:17:27"
 }
 
 /*
@@ -201,7 +201,7 @@ function parseItemTable(table) {
 		else if (label == 'related searches') {
 			var childrens = td[1].getElementsByTagName('a');
 			data = [];
-			for (let i = 0; i < childrens.length; i++) {
+			for (let j = 0; j < childrens.length; j++) {
 				data.push(childrens[i].textContent.trim());
 			}
 		}
@@ -220,13 +220,15 @@ function parseItemTable(table) {
 
 function scrapeItem(doc) {
 	var meta = parseItemTable(ZU.xpath(doc, '//div[@class="detailsTable"]//tbody')[0]);
-
+	Zotero.debug('META');
+	Zotero.debug(meta);
 	var item = new Zotero.Item('manuscript');
 	item.title = meta.title;
 	item.date = meta['contents date range'];
 	item.place = meta.location;
-	item.medium = meta['physical format'];
 	item.archiveLocation = meta.citation.replace(/^NAA\s*:\s*/i, '');
+	item['access status'] = meta['access status'];
+	item['access decision'] = meta['date of decision'];
 
 	var barcode = encodeURIComponent(meta['item barcode']);
 	item.url = 'https://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=I&Number=' + barcode;
@@ -234,9 +236,9 @@ function scrapeItem(doc) {
 	if (meta['item notes']) {
 		item.notes.push(meta['item notes']);
 	}
-
 	// Add link to digital copy if available
-	if (ZU.xpath(doc, '//div[contains(@id, "_pnlDigitalCopy")]/a[normalize-space(text())="View digital copy"]').length) {
+	Zotero.debug('https://recordsearch.naa.gov.au/SearchNRetrieve/Interface/ViewImage.aspx?B=' + barcode)
+	if (ZU.xpath(doc, '//div[contains(@id, "_pnlDigitalCopy")]/a[contains(normalize-space(text()), "View digital copy")]').length) {
 		item.attachments.push({
 			title: "Digital copy at National Archives of Australia",
 			url: 'https://recordsearch.naa.gov.au/SearchNRetrieve/Interface/ViewImage.aspx?B=' + barcode,

--- a/National Archives of Australia.js
+++ b/National Archives of Australia.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-01-29 10:18:58"
+	"lastUpdated": "2020-09-17 05:30:31"
 }
 
 /*
@@ -125,7 +125,7 @@ function scrape(doc, url) {
 		default:
 			throw new Error("Unknown page type: " + m[1]);
 	}
-	
+	Zotero.debug(item);
 	if (item) {
 		item.archive = item.libraryCatalog = "National Archives of Australia";
 		item.complete();
@@ -186,7 +186,7 @@ function scrapeItem(doc, url) {
 	item.archiveLocation = meta.citation.replace(/^NAA\s*:\s*/i, '');
 	
 	var barcode = encodeURIComponent(meta['item barcode']);
-	item.url = 'http://www.naa.gov.au/cgi-bin/Search?O=I&Number=' + barcode;
+	item.url = 'http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=I&Number=' + barcode;
 	
 	if (meta['item notes']) {
 		item.notes.push(meta['item notes']);
@@ -196,7 +196,7 @@ function scrapeItem(doc, url) {
 	if (ZU.xpath(doc, '//div[contains(@id, "_pnlDigitalCopy")]/a[normalize-space(text())="View digital copy"]').length) {
 		item.attachments.push({
 			title: "Digital copy at National Archives of Australia",
-			url: '/SearchNRetrieve/Interface/ViewImage.aspx?B=' + barcode,
+			url: 'http://recordsearch.naa.gov.au/SearchNRetrieve/Interface/ViewImage.aspx?B=' + barcode,
 			mimeType: 'text/html',
 			snapshot: false
 		});
@@ -216,7 +216,7 @@ function scrapeSeries(doc, url) {
 	item.archiveLocation = meta['series number'];
 	
 	var seriesNumber = encodeURIComponent(meta['series number']);
-	item.url = 'http://www.naa.gov.au/cgi-bin/Search?O=S&Number=' + seriesNumber;
+	item.url = 'http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=S&Number=' + seriesNumber;
 	
 	// Agencies recording into this series
 	var agencies = ZU.xpath(doc, '//div[@id="provenanceRecording"]//div[@class="linkagesInfo"]');
@@ -357,7 +357,7 @@ function scrapePhoto(doc, url) {
 	item.date = meta.date || meta['date range'];
 	item.place = meta.location || meta['item location'];
 	
-	item.url = 'http://www.naa.gov.au/cgi-bin/Search?O=PSI&Number=' // Magic. Not sure where this is pulled from, but it's stable
+	item.url = 'http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=PSI&Number=' // Magic. Not sure where this is pulled from, but it's stable
 		+ encodeURIComponent(meta.barcode);
 	
 	item.archiveLocation = meta['image no.'];
@@ -438,7 +438,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.naa.gov.au/cgi-bin/Search?O=I&Number=8606210",
+		"url": "http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=I&Number=8606210",
 		"defer": true,
 		"items": [
 			{
@@ -467,7 +467,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.naa.gov.au/cgi-bin/Search?O=I&Number=1339624",
+		"url": "http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=I&Number=1339624",
 		"defer": true,
 		"items": [
 			{
@@ -489,7 +489,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.naa.gov.au/cgi-bin/Search?O=S&Number=A10950",
+		"url": "http://recordsearch.naa.gov.au/scripts/AutoSearch.asp?O=S&Number=A10950",
 		"defer": true,
 		"items": [
 			{

--- a/National Archives of Australia.js
+++ b/National Archives of Australia.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-19 02:41:36"
+	"lastUpdated": "2020-09-19 02:58:21"
 }
 
 /*
@@ -125,7 +125,7 @@ function getSearchResults(doc, url, checkOnly) {
 				else {
 					title = results[i].getAttribute('title');
 					if (!title) continue;
-					link = results[i].getElementsByTagName('b')[0];
+					link = results[i].getElementsByTagName('a')[0];
 					if (!link) continue;
 					link = link.href;
 				}
@@ -282,7 +282,9 @@ function scrapeSeries(doc) {
 	item.type = 'series';
 	item.date = meta['contents dates'];
 	// Split multiple holdings with semi-colon
-	item.place = meta['quantity and location'].replace(/([A-Z]{1})([0-9]{1})/g, '$1; $2');
+	if (meta['quantity and location']) {
+		item.place = meta['quantity and location'].replace(/([A-Z]{1})([0-9]{1})/g, '$1; $2');
+	}
 	item.format = meta['predominant physical format'];
 	item.abstractNote = meta['series note'];
 	item.archiveLocation = meta['series number'];


### PR DESCRIPTION
The National Archives changed the location of the script that lets you build direct links into RecordSearch. This pull requests updates the urls to use the new redirect script.