### PR TITLE
FAO Publications: Update DOI method

### DIFF
--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-05-17 12:27:13"
+	"lastUpdated": "2020-10-31 13:41:42"
 }
 
 /*
@@ -59,12 +59,12 @@ function scrape(doc, url) {
 	if (url.includes('card')) {
 		// attach document card URL and snapshot
 		// TEMP: Disable at least until we have post-JS snapshots
-		/*newItem.attachments.push({
+		/* newItem.attachments.push({
 			url: url,
 			title: 'FAO Document Record Snapshot',
 			mimeType: 'text/html',
 			snapshot: true
-		});*/
+		}); */
 
 		//* ********* Begin fixed-location variables **********
 
@@ -98,10 +98,13 @@ function scrape(doc, url) {
 					newItem.abstractNote = child.textContent;
 				}
 			}
-			// DOI: Some docs contain DOI as the last paragraph in abs field
+			// DOI: Some docs contain DOI as a separate paragraph in abs field
+			// use DOI URL as url when DOI exists
 			var DOILead = 'https://doi.org/';
-			if (abs.textContent.includes(DOILead)) {
-				newItem.DOI = abs.textContent.slice(abs.textContent.indexOf(DOILead) + DOILead.length);
+			if (abs.innerText.includes(DOILead)) {
+				var DOIMatch = abs.innerText.match(/https:\/\/doi\.org\/(.+)/i);
+				newItem.DOI = DOIMatch[1];
+				newItem.url = DOIMatch[0];
 			}
 		}
 		// attach PDF
@@ -111,8 +114,10 @@ function scrape(doc, url) {
 			title: 'Full Text PDF',
 			mimeType: 'application/pdf'
 		});
-		// url
-		newItem.url = url;
+		// url when DOI doesn't exist
+		if (!abs.innerText.includes(DOILead)) {
+			newItem.url = url;
+		}
 		// language: 2 or 3 letters following ISO 639
 		// indicated by the last 1-3 letters in PDF file name (langCode)
 		// One good example is the various language versions of http://www.fao.org/publications/card/en/c/I2801E
@@ -153,7 +158,7 @@ function scrape(doc, url) {
 		if (!subTitle) {
 			newItem.title = mainTitle;
 		}
-		else if ((newItem.language == 'zh') || (newItem.language == 'ja') || (newItem.language == 'ko')) {
+		else if ((newItem.language == 'zh') || (newItem.language == 'ja')) {
 			newItem.title = mainTitle + '：' + subTitle;
 		}
 		else {
@@ -331,6 +336,58 @@ function doWeb(doc, url) {
 var testCases = [
 	{
 		"type": "web",
+		"url": "http://www.fao.org/documents/card/en/c/ca8466en",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Responding to the impact of the COVID-19 outbreak on food value chains through efficient logistics",
+				"creators": [
+					{
+						"lastName": "FAO",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2020",
+				"ISBN": "9789251323717",
+				"abstractNote": "Measures implemented around the world to contain the COVID-19 pandemic have entailed a severe reduction not only in the transportation of goods and services that rely on transport, but also in the migration of labour domestically and internationally. Workers are less available reflecting both disruptions in transportation systems and restrictions to stop the transmission of the disease, within and across borders. \n\nThe Food and Agriculture Organization of the United Nations (FAO) urges countries to maintain functioning food value chains to avoid food shortages, following practices that are being proven to work. This note summarizes some practices that could be useful for governments and the private sector to maintain critical logistical elements in food value chain.\n\nRevised 26 April 2020.\n\nSee the full list of policy briefs related to COVID-19\n\n.",
+				"language": "en",
+				"libraryCatalog": "FAO Publications",
+				"numPages": "4",
+				"place": "Rome, Italy",
+				"publisher": "FAO",
+				"url": "https://doi.org/10.4060/ca8466en",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Coronavirus"
+					},
+					{
+						"tag": "agrifood sector"
+					},
+					{
+						"tag": "infectious diseases"
+					},
+					{
+						"tag": "logistics"
+					},
+					{
+						"tag": "value chains"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
 		"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
 		"defer": true,
 		"items": [
@@ -359,7 +416,7 @@ var testCases = [
 				"publisher": "FAO",
 				"series": "FAO Fisheries and Aquaculture Circular",
 				"seriesNumber": "No. 1207",
-				"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
+				"url": "https://doi.org/10.4060/ca8751en",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -481,7 +538,7 @@ var testCases = [
 				"place": "Rome, Italy",
 				"publisher": "FAO",
 				"shortTitle": "FAO publications catalogue 2020",
-				"url": "http://www.fao.org/documents/card/en/c/ca7988en/",
+				"url": "https://doi.org/10.4060/ca7988en",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -765,12 +822,12 @@ var testCases = [
 				"notes": [],
 				"seeAlso": []
 			}
-		],
-		"defer": true
+		]
 	},
 	{
 		"type": "web",
 		"url": "http://www.fao.org/publications/card/ar/c/c6c2c8d7-3683-53a7-ab58-ce480c65f36c/",
+		"defer": true,
 		"items": [
 			{
 				"itemType": "book",
@@ -822,8 +879,7 @@ var testCases = [
 				"notes": [],
 				"seeAlso": []
 			}
-		],
-		"defer": true
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -113,7 +113,7 @@ function scrape(doc, url) {
 			mimeType: 'application/pdf'
 		});
 		// url
-			newItem.url = url;
+		newItem.url = url;
 		// language: 2 or 3 letters following ISO 639
 		// indicated by the last 1-3 letters in PDF file name (langCode)
 		// One good example is the various language versions of http://www.fao.org/publications/card/en/c/I2801E

--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-10-31 13:41:42"
+	"lastUpdated": "2021-06-07 20:18:39"
 }
 
 /*
@@ -99,12 +99,10 @@ function scrape(doc, url) {
 				}
 			}
 			// DOI: Some docs contain DOI as a separate paragraph in abs field
-			// use DOI URL as url when DOI exists
 			var DOILead = 'https://doi.org/';
 			if (abs.innerText.includes(DOILead)) {
 				var DOIMatch = abs.innerText.match(/https:\/\/doi\.org\/(.+)/i);
 				newItem.DOI = DOIMatch[1];
-				newItem.url = DOIMatch[0];
 			}
 		}
 		// attach PDF
@@ -114,10 +112,8 @@ function scrape(doc, url) {
 			title: 'Full Text PDF',
 			mimeType: 'application/pdf'
 		});
-		// url when DOI doesn't exist
-		if (!abs.innerText.includes(DOILead)) {
+		// url
 			newItem.url = url;
-		}
 		// language: 2 or 3 letters following ISO 639
 		// indicated by the last 1-3 letters in PDF file name (langCode)
 		// One good example is the various language versions of http://www.fao.org/publications/card/en/c/I2801E
@@ -174,10 +170,10 @@ function scrape(doc, url) {
 		var metaText = ZU.xpath(doc, '//*[@id="mainN0"]')[0].innerText.split('\n'); // scrape text of meta area and split into an array based on line breaks.
 		// get what variables are listed in the page, save to object existingMeta
 		var textVariable = { // declarations for metadata names as appeared in document pages in different languages
-			date: ['سنة النشر', '出版年代', 'Year of publication', 'Année de publication', 'Год издания', 'Fecha de publicación'],
+			date: ['سنة النشر', '出版年份', 'Year of publication', 'Année de publication', 'Год издания', 'Fecha de publicación'],
 			publisher: ['الناشر', '出版方', 'Publisher', 'Éditeur', 'Издатель', 'Editor'],
-			place: ['مكان النشر', '出版地點', 'Place of publication', 'Lieu de publication', 'Место публикации', 'Lugar de publicacion'],
-			pages: ['الصفحات', '页次', 'Pages', 'Страницы', 'Páginas'],
+			place: ['مكان النشر', '出版地点', 'Place of publication', 'Lieu de publication', 'Место публикации', 'Lugar de publicacion'],
+			pages: ['الصفحات', '页数', 'Pages', 'Страницы', 'Páginas'],
 			ISBN: ['الرقم الدولي الموحد للكتاب', 'ISBN'],
 			author: ['الكاتب', '作者', 'Author', 'Auteur', 'Автор', 'Autor'],
 			seriesTitle: ['العنوان التسلسي', '系列标题', 'Serial Title', 'Titre de la série', 'Название серии', 'Título de la serie'],
@@ -357,7 +353,7 @@ var testCases = [
 				"numPages": "4",
 				"place": "Rome, Italy",
 				"publisher": "FAO",
-				"url": "https://doi.org/10.4060/ca8466en",
+				"url": "http://www.fao.org/documents/card/en/c/ca8466en",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -416,7 +412,7 @@ var testCases = [
 				"publisher": "FAO",
 				"series": "FAO Fisheries and Aquaculture Circular",
 				"seriesNumber": "No. 1207",
-				"url": "https://doi.org/10.4060/ca8751en",
+				"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -538,7 +534,7 @@ var testCases = [
 				"place": "Rome, Italy",
 				"publisher": "FAO",
 				"shortTitle": "FAO publications catalogue 2020",
-				"url": "https://doi.org/10.4060/ca7988en",
+				"url": "http://www.fao.org/documents/card/en/c/ca7988en/",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -574,14 +570,14 @@ var testCases = [
 				"title": "Vivre et se nourir de la forêt en Afrique centrale",
 				"creators": [
 					{
-						"lastName": "Ousseynou Ndoye",
-						"creatorType": "author",
-						"fieldMode": 1
+						"firstName": "O.",
+						"lastName": "Ndoye",
+						"creatorType": "author"
 					},
 					{
-						"lastName": " Paul Vantomme",
-						"creatorType": "author",
-						"fieldMode": 1
+						"firstName": "P.",
+						"lastName": "Vantomme",
+						"creatorType": "author"
 					}
 				],
 				"date": "2016",
@@ -592,8 +588,8 @@ var testCases = [
 				"numPages": "251",
 				"place": "Rome, Italy",
 				"publisher": "FAO",
-				"series": "Non-wood forest products working paper",
-				"seriesNumber": "21",
+				"series": "Produits Forestiers Non-Ligneux",
+				"seriesNumber": "No. 21",
 				"url": "http://www.fao.org/publications/card/fr/c/77dbd058-8dd4-4295-af77-23f6b28cc683/",
 				"attachments": [
 					{
@@ -606,64 +602,34 @@ var testCases = [
 						"tag": "Afrique centrale"
 					},
 					{
-						"tag": "Aménagement forestier"
+						"tag": "Commerce international"
 					},
 					{
-						"tag": "Burundi"
-					},
-					{
-						"tag": "Cameroun"
-					},
-					{
-						"tag": "Congo"
+						"tag": "Communauté rurale"
 					},
 					{
 						"tag": "Connaissance indigène"
 					},
 					{
-						"tag": "Conservation de la diversité biologique"
+						"tag": "Nouvelle technologie"
 					},
 					{
-						"tag": "Forêt humide"
+						"tag": "Petite entreprise"
 					},
 					{
-						"tag": "Gabon"
-					},
-					{
-						"tag": "Gnetum"
-					},
-					{
-						"tag": "Guinée Équatoriale"
+						"tag": "Politique forestière"
 					},
 					{
 						"tag": "Produit forestier non ligneux"
 					},
 					{
-						"tag": "Ricinodendron heudelotii"
+						"tag": "Ressource forestière"
 					},
 					{
-						"tag": "Rwanda"
+						"tag": "Sécurité alimentaire"
 					},
 					{
-						"tag": "République centrafricaine"
-					},
-					{
-						"tag": "République démocratique du Congo"
-					},
-					{
-						"tag": "Sao Tomé-et-Principe"
-					},
-					{
-						"tag": "Tchad"
-					},
-					{
-						"tag": "Technologie traditionnelle"
-					},
-					{
-						"tag": "forest products derivation"
-					},
-					{
-						"tag": "méthode traditionnelle"
+						"tag": "Valeur économique"
 					},
 					{
 						"tag": "sustainable forest management"
@@ -855,25 +821,25 @@ var testCases = [
 				],
 				"tags": [
 					{
-						"tag": "fishery economics"
+						"tag": "null"
 					},
 					{
-						"tag": "forestry economics"
+						"tag": "null"
 					},
 					{
-						"tag": "gender"
+						"tag": "null"
 					},
 					{
-						"tag": "governance"
-					},
-					{
-						"tag": "guidelines"
-					},
-					{
-						"tag": "land tenure"
+						"tag": "null"
 					},
 					{
 						"tag": "أمن غذائي"
+					},
+					{
+						"tag": "الحكم"
+					},
+					{
+						"tag": "حيازة الأراضي"
 					}
 				],
 				"notes": [],

--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-06-07 20:18:39"
+	"lastUpdated": "2021-06-08 14:01:41"
 }
 
 /*
@@ -29,9 +29,28 @@
 	***** END LICENSE BLOCK *****
 */
 function detectWeb(doc, url) {
-	// Just differentiate single and multiple. Correct itemType (either book or conferencePaper) will be determined in scrape().
+	// Just differentiate single and multiple. 
+	// Identify item type (book or conferencePaper) based on "fdr_label" class.
 	if (url.includes('card')) {
-		return 'book';
+		let isConferencePaper = false;
+		let confMetaName = ['اسم الاجتماع', '会议名称', 'Meeting Name', 'Nom de la réunion', 'Название мероприятия', 'Nombre de la reunión'];
+		let labelArray = doc.querySelectorAll('.fdr_label');
+		for (let i = 0; i < labelArray.length; i++) {
+			for (let j = 0; j < confMetaName.length; j++) {
+				isConferencePaper = labelArray[i].innerText.includes(confMetaName[j]);
+				if (isConferencePaper) {
+					break;
+				}
+			}
+			if (isConferencePaper) {
+			break;
+			}
+		}
+	  	if (isConferencePaper) {
+			return 'conferencePaper';
+		} else {
+			return 'book';
+		}
 	}
 
 	/* Multiples currently don't load properly

--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -29,7 +29,7 @@
 	***** END LICENSE BLOCK *****
 */
 function detectWeb(doc, url) {
-	// Just differentiate single and multiple. 
+	// Just differentiate single and multiple.
 	// Identify item type (book or conferencePaper) based on "fdr_label" class.
 	if (url.includes('card')) {
 		let isConferencePaper = false;
@@ -43,10 +43,10 @@ function detectWeb(doc, url) {
 				}
 			}
 			if (isConferencePaper) {
-			break;
+				break;
 			}
 		}
-	  	if (isConferencePaper) {
+		if (isConferencePaper) {
 			return 'conferencePaper';
 		} else {
 			return 'book';

--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-06-08 14:01:41"
+	"lastUpdated": "2021-06-08 21:19:23"
 }
 
 /*
@@ -48,7 +48,8 @@ function detectWeb(doc, url) {
 		}
 		if (isConferencePaper) {
 			return 'conferencePaper';
-		} else {
+		}
+		else {
 			return 'book';
 		}
 	}
@@ -271,9 +272,9 @@ function scrape(doc, url) {
 			if (key.includes('seriesTitle')) {
 				newItem.series = metaResult;
 			}
-			// seriesNumber: convert first letter to upper case
+			// seriesNumber: extract the number.
 			if (key.includes('seriesNumber')) {
-				newItem.seriesNumber = metaResult[0].toUpperCase() + metaResult.slice(1);
+				newItem.seriesNumber = (metaResult.match(/\d+/) || [])[0];
 			}
 			// conferenceName: save for later conditions.
 			if (key.includes('conference')) {
@@ -430,7 +431,7 @@ var testCases = [
 				"place": "Rome, Italy",
 				"publisher": "FAO",
 				"series": "FAO Fisheries and Aquaculture Circular",
-				"seriesNumber": "No. 1207",
+				"seriesNumber": "1207",
 				"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
 				"attachments": [
 					{
@@ -608,7 +609,7 @@ var testCases = [
 				"place": "Rome, Italy",
 				"publisher": "FAO",
 				"series": "Produits Forestiers Non-Ligneux",
-				"seriesNumber": "No. 21",
+				"seriesNumber": "21",
 				"url": "http://www.fao.org/publications/card/fr/c/77dbd058-8dd4-4295-af77-23f6b28cc683/",
 				"attachments": [
 					{


### PR DESCRIPTION
Reupload for https://github.com/zotero/translators/pull/2191 

DOI has become standard for new FAO publications.
Method for obtaining the DOI is optimized. Also assign DOI URL as newItem.url when DOI exists.

Thanks!