### PR TITLE
Add LingBuzz

### DIFF
--- a/LingBuzz.js
+++ b/LingBuzz.js
@@ -67,16 +67,16 @@ function doWeb(doc, url) {
 		});
 	}
 	else {
-		if(url.match(/semanticsArchive/)) {
-			scrapeSA(doc, url);
-		}
-		else {
-			scrape(doc, url);
-		}
+		scrape(doc, url);
 	}
 }
 
-function scrape(doc, _url) {
+function scrape(doc, url) {
+	if (url.match(/semanticsArchive/)) {
+		scrapeSA(doc, url);
+		return;
+	}
+	
 	var newItem = new Zotero.Item("report");
 	newItem.extra = "type: article\n"; // will map to preprint
 

--- a/LingBuzz.js
+++ b/LingBuzz.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "e048e70e-8fea-43e9-ac8e-940bc3d71b0b",
 	"label": "LingBuzz",
-	"creator": "Göktuğ Kayaalp",
-	"target": "^https://ling.auf.net/lingbuzz/\\d+",
+	"creator": "Göktuğ Kayaalp and Abe Jellinek",
+	"target": "^https://ling\\.auf\\.net/lingbuzz/(\\d+|_search)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-10-07 15:14:37"
+	"lastUpdated": "2021-06-03 21:54:52"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2020 Göktuğ Kayaalp <self at gkayaalp dot com>
+	Copyright © 2021 Göktuğ Kayaalp <self at gkayaalp dot com> and Abe Jellinek
 
 	This file is part of Zotero.
 
@@ -35,47 +35,151 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(_doc, _url) {
-	return "journalArticle";
+function detectWeb(doc, url) {
+	if (url.includes("/_search") && getSearchResults(doc, true)) {
+		return "multiple";
+	}
+	return "report";
 }
 
-function doWeb(doc, _url) {
-	var newItem = new Zotero.Item("journalArticle");
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	// exclude author links
+	var rows = doc.querySelectorAll('td a:not([href*="?_s="])');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (items) ZU.processDocuments(Object.keys(items), scrape);
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, _url) {
+	var newItem = new Zotero.Item("report");
+	newItem.extra = "type: article\n"; // will map to preprint
 
 	// Collect information.
-	var idBlock = doc.querySelector("center").innerText.split("\n");
-	var title = idBlock[0];
-	var author = idBlock[1];
-	var date = idBlock[2];
-	var abstract = doc.querySelector(
-		"center"
-	).nextElementSibling.nextSibling.textContent;
-	var table = doc.querySelector("tbody").innerText.split(/\n|\t/);
-	var reference = table[3];
-	var keywords = table[8].split(/[;,] /);
-	var pdfURL = doc.querySelector(
-		"body > table:nth-child(4) > tbody:nth-child(1) > tr:nth-child(1) "
-		+ "> td:nth-child(2) > a:nth-child(1)"
-	).href;
-	// Phew.  That was... disgusting, if I'm polite.
+	var idBlock = doc.querySelector("center");
+	var title = text(idBlock, "a[href*='.pdf']");
+	var authors = idBlock.querySelectorAll("a[href*='_k=']");
+	// These are unpleasant but they're the best we have.
+	var date = idBlock.lastChild.textContent;
+	var abstract = idBlock.nextElementSibling.nextSibling.textContent;
+
+	var tableRows = doc.querySelectorAll("tbody tr");
+	for (let row of tableRows) {
+		let [left, right] = row.querySelectorAll("td");
+		if (!left || !right) continue;
+		let fieldName = left.innerText.toLowerCase();
+		if (fieldName.includes("format")) {
+			let pdfUrl = right.querySelector("a[href*='.pdf']").href;
+			newItem.attachments.push({ url: pdfUrl, title: "LingBuzz Full Text PDF", mimeType: "application/pdf" });
+		}
+		else if (fieldName.includes("keywords")) {
+			newItem.tags.push(...right.innerText.split(/[;,] /));
+		}
+	}
 
 	newItem.title = title;
-	newItem.creators.push(
-		Zotero.Utilities.cleanAuthor(author, "author"));
+	for (let authorLink of authors) {
+		newItem.creators.push(
+			Zotero.Utilities.cleanAuthor(authorLink.innerText, "author"));
+	}
 	newItem.abstractNote = abstract;
-	newItem.date = date;
-	newItem.language = "English"; // haven't seen an article in other language.
-
-	newItem.attachments = [
-		{ document: doc, title: "Snapshot", mimeType: "text/html" },
-		{ url: pdfURL, title: "LingBuzz Full Text PDF", mimeType: "application/pdf" }
-	];
-
-	newItem.tags = keywords;
-	newItem.callNumber = reference; // XXX: IDK if this is the apt field.
-
-	newItem.publicationTitle = "LingBuzz";
+	newItem.date = ZU.strToISO(date);
+	newItem.attachments.push({ document: doc, title: "Snapshot" });
+	newItem.publisher = "LingBuzz";
 
 	newItem.complete();
 }
 
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://ling.auf.net/lingbuzz/005988",
+		"items": [
+			{
+				"itemType": "report",
+				"title": "Verb height indeed determines prosodic phrasing: evidence from Iron Ossetic",
+				"creators": [
+					{
+						"firstName": "Lena",
+						"lastName": "Borise",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "David",
+						"lastName": "Erschler",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-05",
+				"abstractNote": "We provide novel evidence in favor of the proposal by Hamlaoui and Szendrői (2015, 2017), who argue for a flexible mapping between an Intonational Phrase (ɩ) and syntactic constituents. According to them, ɩ corresponds to the highest projection that hosts verbal material, together with its specifier. The prediction is that the size of ɩ co-varies with the height of the verb, if the latter is variable. Our evidence comes from Iron Ossetic (East Iranian), a language with multiple projections available for verb raising, depending on context. The flexible ɩ-mapping approach – but not more rigid approaches to ɩ-formation – can account for the properties of ɩ-formation in Iron Ossetic. This applies to the prosody of utterances that contain negative indefinites, narrow foci, and single wh-phrases. More complex wh-questions (those with multiple wh-phrases and/or negative indefinites) provide evidence that syntax-based flexible ɩ-mapping approach interacts with language-specific eurhythmic constraints. The Iron Ossetic facts, therefore, provide support for the flexible ɩ-mapping approach, which has not been tested until now on languages of this type.",
+				"extra": "type: article",
+				"institution": "LingBuzz",
+				"libraryCatalog": "LingBuzz",
+				"shortTitle": "Verb height indeed determines prosodic phrasing",
+				"attachments": [
+					{
+						"title": "LingBuzz Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "focus"
+					},
+					{
+						"tag": "iranian"
+					},
+					{
+						"tag": "iron ossetic"
+					},
+					{
+						"tag": "phonology"
+					},
+					{
+						"tag": "prosodic phrasing"
+					},
+					{
+						"tag": "syntax"
+					},
+					{
+						"tag": "syntax-prosody interface"
+					},
+					{
+						"tag": "wh-questions"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://ling.auf.net/lingbuzz/_search?q=svan",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/

--- a/LingBuzz.js
+++ b/LingBuzz.js
@@ -1,0 +1,81 @@
+{
+	"translatorID": "e048e70e-8fea-43e9-ac8e-940bc3d71b0b",
+	"label": "LingBuzz",
+	"creator": "Göktuğ Kayaalp",
+	"target": "^https://ling.auf.net/lingbuzz/\\d+",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2020-10-07 15:14:37"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2020 Göktuğ Kayaalp <self at gkayaalp dot com>
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(_doc, _url) {
+	return "journalArticle";
+}
+
+function doWeb(doc, _url) {
+	var newItem = new Zotero.Item("journalArticle");
+
+	// Collect information.
+	var idBlock = doc.querySelector("center").innerText.split("\n");
+	var title = idBlock[0];
+	var author = idBlock[1];
+	var date = idBlock[2];
+	var abstract = doc.querySelector(
+		"center"
+	).nextElementSibling.nextSibling.textContent;
+	var table = doc.querySelector("tbody").innerText.split(/\n|\t/);
+	var reference = table[3];
+	var keywords = table[8].split(/[;,] /);
+	var pdfURL = doc.querySelector(
+		"body > table:nth-child(4) > tbody:nth-child(1) > tr:nth-child(1) "
+		+ "> td:nth-child(2) > a:nth-child(1)"
+	).href;
+	// Phew.  That was... disgusting, if I'm polite.
+
+	newItem.title = title;
+	newItem.creators.push(
+		Zotero.Utilities.cleanAuthor(author, "author"));
+	newItem.abstractNote = abstract;
+	newItem.date = date;
+	newItem.language = "English"; // haven't seen an article in other language.
+
+	newItem.attachments = [
+		{ document: doc, title: "Snapshot", mimeType: "text/html" },
+		{ url: pdfURL, title: "LingBuzz Full Text PDF", mimeType: "application/pdf" }
+	];
+
+	newItem.tags = keywords;
+	newItem.callNumber = reference; // XXX: IDK if this is the apt field.
+
+	newItem.publicationTitle = "LingBuzz";
+
+	newItem.complete();
+}
+


### PR DESCRIPTION
This patch adds a translator for LingBuzz. It's pretty simple given the spartan nature of the website. Works on the article details page. The website doesn't have search or a meaningful listing feature (apart from the homepage), so I only implemented saving a single article.

I'm not sure if I'm using the correct field on line 74, but LingBuzz requests that the article number in the form `lingbuzz/\d+` be used when citing LingBuzz articles, and that's the field that looked the most sensible for me. They don't seem to use DOIs.