### PR TITLE
improve "title" field for the "Library Catalog (PICA)" translator

### DIFF
--- a/Library Catalog (PICA).js
+++ b/Library Catalog (PICA).js
@@ -381,7 +381,10 @@ function scrape(doc, url) {
 				if (!newItem.title) {
 					newItem.title = title[0];
 				}
-				newItem.title = newItem.title.replace(/\s+:/, ":").replace(/\s*\[[^\]]+\]/g, "");
+				// replace(/\s+:/, " :") => cleanup extra spaces before a colon
+				//                          and respects the english (no space) or french typo (with a space)
+				// replace(/\s*\[[^\]]+\]/g, "") => cleanup "[ xxx ]" patterns in the title
+				newItem.title = newItem.title.replace(/\s+:/, " :").replace(/\s*\[[^\]]+\]/g, "");
 				break;
 
 			case 'periodical':


### PR DESCRIPTION
The current behavior is problematic for French records because a space is needed before a colon.
The current code removes ALL spaces before a colon and breaks the French typo rule.

This patch remove all extra spaces before a colon in the title field and leave one space if the cleanup occurs.
It also add few comments to explain what theses regexp are doing on the title field.