### PR TITLE
Another attempt to fix wrong chromedriver version CI issues

### DIFF
--- a/.ci/pull-request-check/check-pull-request.sh
+++ b/.ci/pull-request-check/check-pull-request.sh
@@ -57,7 +57,7 @@ export ZOTERO_REPOSITORY_URL="http://localhost:8085/"
 ./build.sh -p b -d
 cd ..
 
-npm install chromedriver --detect_chromedriver_version
+npm explore chromedriver -- npm run install --detect_chromedriver_version
 
 get_translators_to_check
 ./selenium-test.js "$TRANSLATORS_TO_CHECK"


### PR DESCRIPTION
Closes #2283

Sorry @adam3smith, I missed the original issue you've created in the email stream, would have got around to this sooner.

For the record there's been some changes to the way dependency install scripts work with npm 7/node 15, to which Travis must have switched recently. They claim they've only disabled logging, which may be true and after this PR the test checker will still fail, but at least we will have better logging about why the correct chromedriver version is not being installed.