### PR TITLE
Add Rechtspraak.nl translator

### DIFF
--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "bf053edc-a8c3-458c-93db-6d04ead2e636",
 	"label": "EUR-Lex",
-	"creator": "Philipp Zumstein, Pieter van der Wees",
-	"target": "^https?://(www\\.)?eur-lex\\.europa\\.eu/(legal-content/[A-Z][A-Z]/(TXT|ALL)/|search.html\\?)",
+	"creator": "Philipp Zumstein",
+	"target": "^https?://(www\\.)?eur-lex\\.europa\\.eu/(legal-content/[A-Z][A-Z]/TXT/|search.html\\?)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-01-13 13:04:33"
+	"lastUpdated": "2017-12-21 20:27:07"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017-2020 Philipp Zumstein, Pieter van der Wees
+	Copyright © 2017 Philipp Zumstein
 	
 	This file is part of Zotero.
 
@@ -36,42 +36,32 @@
 */
 
 
-// attr() v2
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}
+// attr()/text() v2
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
 
 
 // the eli resource types are described at:
-// https://op.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/resource-type
-// all types not mapped below are saved as bills
+// http://publications.europa.eu/mdr/resource/authority/resource-type/html/resourcetypes-eng.html
 var typeMapping = {
-	"DIR": "bill", // directive
-	"REG": "statute", // regulation
-	"DEC": "statute", // decision
-	"RECO": "report", // recommendation
-	"OPI": "report", // opinion
-	"CONS": "statute", // consolidated text
-	"TREATY": "statute", // treaty
+	'DIR': 'bill', // directive
+	'REG': 'statute', // regulation
+	'DEC': 'statute', // decision
+	'RECO': 'report', // recommodation
+	'OPI': 'report' // opinion
 };
 
 
 function detectWeb(doc, url) {
-	var docSector = attr(doc, 'meta[name="WT.z_docSector"]', 'content');
 	var eliTypeURI = attr(doc, 'meta[property="eli:type_document"]', 'resource');
 	if (eliTypeURI) {
-		var eliType = eliTypeURI.split("/").pop();
-		var eliCategory = eliType.split("_")[0];
+		var eliType = eliTypeURI.split('/').pop();
+		var eliCategory = eliType.split('_')[0];
 		var type = typeMapping[eliCategory];
 		if (type) {
 			return type;
-		}
-		else {
+		} else {
 			Z.debug("Unknown eliType: " + eliType);
-			return "bill";
 		}
-	} else if (docSector == "6") {
-			return "case";
-	} else if (docSector && docSector !== "other") { 
-			return "bill";
 	} else if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
@@ -81,7 +71,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = doc.querySelectorAll("a.title");
+	var rows = doc.querySelectorAll('a.title');
 	for (let i=0; i<rows.length; i++) {
 		let href = rows[i].href;
 		let title = ZU.trimInternal(rows[i].textContent);
@@ -115,175 +105,112 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} 
-	else {
+	} else {
 		scrape(doc, url);
 	}
 }
 
 
-// this maps language codes from ISO 639-1 to 639-3 and adds court names
-// see https://op.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/court-type
+// this maps language codes from ISO 639-1 to 639-3
 var languageMapping = {
-	"BG": ["BUL", "Съд", "Общ съд", "Съд на публичната служба"],
-	"CS": ["CES", "Soudní dvůr", "Tribunál", "Soud pro veřejnou službu"],
-	"DA": ["DAN", "EU-Domstolen", "EU-Retten", "EU-Personalretten"],
-	"DE": ["DEU", "EuGH", "Gerichtshof", "Gericht für den öffentlichen Dienst"],
-	"EL": ["ELL", "Δικαστήριο", "Γενικό Δικαστήριο", "Δικαστήριο Δημόσιας Διοίκησης"],
-	"EN": ["ENG", "ECJ", "GC", "CST"],
-	"ES": ["SPA", "TJUE", "Tribunal General", "Tribunal de la Función Pública"],
-	"ET": ["EST", "Euroopa Kohus", "Üldkohus", "Avaliku Teenistuse Kohus"],
-	"FI": ["FIN", "Unionin tuomioistuin", "Unionin yleinen tuomioistuin", "Virkamiestuomioistuin"],
-	"FR": ["FRA", "Cour de justice", "Tribunal", "Tribunal de la fonction publique"],
-	"GA": ["GLE", "An Chúirt Bhreithiúnais", "Cúirt Ghinearálta", "An Binse um Sheirbhís Shibhialta"],
-	"HR": ["HRV", "Europski sud", "Opći sud", "Službenički sud"],
-	"HU": ["HUN", "A Bíróság", "Törvényszék", "Közszolgálati Törvényszék"],
-	"IT": ["ITA", "Corte di giustizia", "Tribunale", "Tribunale della funzione pubblica"],
-	"LV": ["LAV", "Tiesa", "Vispārējā tiesa", "Civildienesta tiesa"],
-	"LT": ["LIT", "Teisingumo Teismas", "Bendrasis Teismas", "Tarnautojų teismas"],
-	"MT": ["MLT", "Il-Qorti tal-Ġustizzja", "Il-Qorti Ġenerali", "Il-Tribunal għas-Servizz Pubbliku"],
-	"NL": ["NLD", "HvJ EU", "Gerecht EU", "GvA EU"],
-	"PL": ["POL", "Trybunał Sprawiedliwości", "Sąd", "Sąd do spraw Służby Publicznej"],
-	"PT": ["POR", "Tribunal Europeu de Justiça", "Tribunal Geral", "Tribunal da Função Pública"],
-	"RO": ["RON", "Curtea Europeană de Justiție", "Tribunalul", "Tribunalul Funcţiei Publice"],
-	"SK": ["SLK", "Súdny dvor", "Všeobecný súd", "Súd pre verejnú službu"],
-	"SL": ["SLV", "Sodišče", "Splošno sodišče", "Sodišče za uslužbence"],
-	"SV": ["SWE", "Domstolen", "Tribunalen", "Personaldomstolen"]
+	'BG': 'bul',
+	'CS': 'ces',
+	'DA': 'dan',
+	'DE': 'deu',
+	'EL': 'ell',
+	'EN': 'eng',
+	'ES': 'spa',
+	'ET': 'est',
+	'FI': 'fin',
+	'FR': 'fra',
+	'GA': 'gle',
+	'HR': 'hrv',
+	'HU': 'hun',
+	'IT': 'ita',
+	'LV': 'lav',
+	'LT': 'lit',
+	'MT': 'mlt',
+	'NL': 'nld',
+	'PL': 'pol',
+	'PT': 'por',
+	'RO': 'ron',
+	'SK': 'slk',
+	'SL': 'slv',
+	'SV': 'swe'
 };
 
 
 function scrape(doc, url) {
-	// declare meta variables present for all sectors
-	var docSector = attr(doc, 'meta[name="WT.z_docSector"]', 'content');
-	var docType = attr(doc, 'meta[name="WT.z_docType"]', 'content');
-	var celex = attr(doc, 'meta[name="WT.z_docID"]', 'content');
-	
-	var eliTypeUri = (attr(doc, 'meta[property="eli:type_document"]', "resource"));
-	
 	var type = detectWeb(doc, url);
 	var item = new Zotero.Item(type);
+	
 	// determine the language we are currently looking the document at
-	var languageUrl = url.split("/")[4].toUpperCase();
-	if (languageUrl == "AUTO") {
+	var languageUrl = url.split('/')[4];
+	if (languageUrl=="AUTO") {
 		languageUrl = autoLanguage || "EN";
 	}
-	var language = languageMapping[languageUrl][0] || "eng";
-	// Cases only return language; discard everything else
+	var language = languageMapping[languageUrl] || "eng";
+	
+	item.title = attr(doc, 'meta[property="eli:title"][lang=' + languageUrl.toLowerCase() + ']', 'content');
 	item.language = languageUrl.toLowerCase();
 	
-
-	if (eliTypeUri) {
-		// type: everything with ELI (see var typeMapping: bill, statute, report)
-		item.title = attr(doc, 'meta[property="eli:title"][lang=' + languageUrl.toLowerCase() + "]", "content");
-		var uri = attr(doc, "#format_language_table_digital_sign_act_" + languageUrl.toUpperCase(), "href");
-		if (uri) {
-			var uriParts = uri.split("/").pop().replace("?uri=", "").split(":");
-			// e.g. uriParts =  ["OJ", "L", "1995", "281", "TOC"]
-			// e.g. uriParts = ["DD", "03", "061", "TOC", "FI"]
-			if (uriParts.length >= 4) {
-				if (/\d+/.test(uriParts[1])) {
-					item.code = uriParts[0];
-					item.codeNumber = uriParts[1] + ", " + uriParts[2];
-				} 
-				else {
-					item.code = uriParts[0] + " " + uriParts[1];
-					item.codeNumber = uriParts[3];
-				}
-				if (type == "bill") {
-					item.codeVolume = item.codeNumber;
-					item.codeNumber = null;
-				}
+	var uri = attr(doc, '#format_language_table_digital_sign_act_' + languageUrl.toUpperCase(), 'href');
+	if (uri) {
+		var uriParts = uri.split('/').pop().replace('?uri=', '').split(':');
+		// e.g. uriParts =  ["OJ", "L", "1995", "281", "TOC"]
+		// e.g. uriParts = ["DD", "03", "061", "TOC", "FI"]
+		if (uriParts.length>=4) {
+			if (/\d+/.test(uriParts[1])) {
+				item.code = uriParts[0];
+				item.codeNumber = uriParts[1] + ', ' + uriParts[2];
+			} else {
+				item.code = uriParts[0] + ' ' + uriParts[1];
+				item.codeNumber = uriParts[3];
+			}
+			if (type=="bill") {
+				item.codeVolume = item.code;
+				item.code = item.codeNumber;
 			}
 		}
-
-		// item.number = attr(doc, 'meta[property="eli:id_local"]', 'content');
-
-		item.date = attr(doc, 'meta[property="eli:date_document"]', "content");
-		if (!item.date) {item.date = attr(doc, 'meta[property="eli:date_publication"]', "content")}
-		
-		var passedBy = doc.querySelectorAll('meta[property="eli:passed_by"]');
-		var passedByArray = [];
-		for (let i = 0; i < passedBy.length; i++) {
-			passedByArray.push(passedBy[i].getAttribute("resource").split("/").pop());
-		}
-		item.legislativeBody = passedByArray.join(", ");
-		
-		item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', "about") + "/" + language.toLowerCase();
-		// eli:is_about -> eurovoc -> tags
 	}
-	else if (docSector == "6") {
-		// type: case
-		// pretty hacky stuff, as there's little metadata available
-		var docCourt = docType.substr(0, 1);
-		if (docCourt == "C") {
-			item.court = languageMapping[languageUrl][1] || languageMapping["EN"][1];
-		}
-		else if (docCourt == "T") {
-			item.court = languageMapping[languageUrl][2] || languageMapping["EN"][2];
-		}
-		else if (docCourt == "F") {
-			item.court = languageMapping[languageUrl][3] || languageMapping["EN"][3];
-		}
-		item.url = url;
+	
+	item.number = attr(doc, 'meta[property="eli:id_local"]', 'content');
+	
+	item.date = attr(doc, 'meta[property="eli:date_publication"]', 'content');
+	// attr(doc, 'meta[property="eli:date_document"]', 'content');
 
-		if (docType.substr(1) == "J") { // Judgments
-			var titleParts = attr(doc, 'meta[name="WT.z_docTitle"]', "content").replace(/\./g,"").split("#");
-			item.caseName = titleParts[1];
-			item.abstractNote = titleParts[titleParts.length - 2];
-			item.docketNumber = titleParts.pop();
-			item.dateDecided = titleParts[0].substr(titleParts[0].search(/[0-9]/g));
-		}
-		else { // Orders, summaries, etc.
-			item.caseName = attr(doc, 'meta[name="WT.z_docTitle"]', "content").replace(/#/g," ");
-			item.dateDecided = celex.substr(1, 4);
-		}
+	var passedBy = doc.querySelectorAll('meta[property="eli:passed_by"]');
+	var passedByArray = [];
+	for (let i=0; i<passedBy.length; i++) {
+		passedByArray.push(passedBy[i].getAttribute('resource').split('/').pop());
 	}
-	else {
-		// type: bill
-		item.title = attr(doc, 'meta[name="WT.z_docTitle"]', "content");
-		item.date = celex.substr(1, 4);
-		item.url = url;
-		if (docType == "C") {
-			var celexCParts = celex.substr(1).split("/");
-			item.code = "OJ C";
-			item.codeVolume = celexCParts[1];
-			item.codePages = celexCParts[2];
-		}
-	}
-	// attachments
-	// type: all
-	var pdfurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/PDF/?uri=CELEX:" + celex;
-	var htmlurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/HTML/?uri=CELEX:" + celex;
-	item.attachments = [{ url: pdfurl, title: "EUR-Lex PDF (" + languageUrl + ")", mimeType: "application/pdf" }];
-	item.attachments.push({ url: htmlurl, title: "EUR-Lex HTML (" + languageUrl + ")", mimeType: "text/html" });
+	item.legislativeBody = passedByArray.join(', ');
+	
+	item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', 'about') + '/' + language;
+	
+	// eli:is_about -> eurovoc -> tags
 	
 	item.complete();
-}/** BEGIN TEST CASES **/
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31995L0046",
+		"url": "http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31995L0046",
 		"items": [
 			{
 				"itemType": "bill",
 				"title": "Directive 95/46/EC of the European Parliament and of the Council of 24 October 1995 on the protection of individuals with regard to the processing of personal data and on the free movement of such data",
 				"creators": [],
-				"date": "1995-10-24",
-				"code": "OJ L",
-				"codeVolume": "281",
+				"date": "1995-11-23",
+				"billNumber": "31995L0046",
+				"code": "281",
+				"codeVolume": "OJ L",
 				"language": "en",
 				"legislativeBody": "EP, CONSIL",
 				"url": "http://data.europa.eu/eli/dir/1995/46/oj/eng",
-				"attachments": [
-					{
-						"title": "EUR-Lex PDF (EN)",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "EUR-Lex HTML (EN)",
-						"mimeType": "text/html"
-					}
-				],
+				"attachments": [],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -292,27 +219,63 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:31994R2257",
+		"url": "http://eur-lex.europa.eu/legal-content/CS/TXT/?uri=CELEX:31995L0046&from=DE",
+		"items": [
+			{
+				"itemType": "bill",
+				"title": "Směrnice Evropského parlamentu a Rady 95/46/ES ze dne 24. října 1995 o ochraně fyzických osob v souvislosti se zpracováním osobních údajů a o volném pohybu těchto údajů",
+				"creators": [],
+				"date": "1995-11-23",
+				"billNumber": "31995L0046",
+				"code": "13, 015",
+				"codeVolume": "DD",
+				"language": "cs",
+				"legislativeBody": "EP, CONSIL",
+				"url": "http://data.europa.eu/eli/dir/1995/46/oj/ces",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:31995L0046",
+		"items": [
+			{
+				"itemType": "bill",
+				"title": "Richtlinie 95/46/EG des Europäischen Parlaments und des Rates vom 24. Oktober 1995 zum Schutz natürlicher Personen bei der Verarbeitung personenbezogener Daten und zum freien Datenverkehr",
+				"creators": [],
+				"date": "1995-11-23",
+				"billNumber": "31995L0046",
+				"code": "281",
+				"codeVolume": "OJ L",
+				"language": "de",
+				"legislativeBody": "EP, CONSIL",
+				"url": "http://data.europa.eu/eli/dir/1995/46/oj/deu",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:31994R2257",
 		"items": [
 			{
 				"itemType": "statute",
 				"nameOfAct": "Règlement (CE) n° 2257/94 de la Commission, du 16 septembre 1994, fixant des normes de qualité pour les bananes (Texte présentant de l'intérêt pour l'EEE)",
 				"creators": [],
-				"dateEnacted": "1994-09-16",
+				"dateEnacted": "1994-09-20",
 				"code": "OJ L",
 				"codeNumber": "245",
 				"language": "fr",
+				"publicLawNumber": "31994R2257",
 				"url": "http://data.europa.eu/eli/reg/1994/2257/oj/fra",
-				"attachments": [
-					{
-						"title": "EUR-Lex PDF (FR)",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "EUR-Lex HTML (FR)",
-						"mimeType": "text/html"
-					}
-				],
+				"attachments": [],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -321,95 +284,8 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://eur-lex.europa.eu/search.html?lang=en&text=%22open+access%22&qid=1513887127793&type=quick&scope=EURLEX&locale=nl",
+		"url": "http://eur-lex.europa.eu/search.html?lang=en&text=%22open+access%22&qid=1513887127793&type=quick&scope=EURLEX&locale=nl",
 		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX:62019CJ0245",
-		"items": [
-			{
-				"itemType": "case",
-				"caseName": "État luxembourgeois tegen B en État luxembourgeois tegen B ea",
-				"creators": [],
-				"dateDecided": "6 oktober 2020",
-				"abstractNote": "Prejudiciële verwijzing – Richtlijn 2011/16/EU – Administratieve samenwerking op het gebied van de belastingen – Artikelen 1 en 5 – Bevel tot het verstrekken van inlichtingen aan de bevoegde autoriteit van een lidstaat, die handelt naar aanleiding van een verzoek tot uitwisseling van inlichtingen van de bevoegde autoriteit van een andere lidstaat – Persoon die in het bezit is van de informatie waarvan de bevoegde autoriteit van eerstbedoelde lidstaat heeft bevolen dat deze moet worden verstrekt – Belastingplichtige tegen wie het onderzoek loopt dat aanleiding heeft gegeven tot het verzoek van de bevoegde autoriteit van de tweede lidstaat – Derden met wie deze belastingplichtige juridische, bancaire, financiële of, meer in het algemeen, economische banden onderhoudt – Rechtsbescherming – Handvest van de grondrechten van de Europese Unie – Artikel 47 – Recht op een doeltreffende voorziening in rechte – Artikel 52, lid 1 – Beperking – Rechtsgrondslag – Eerbiediging van de wezenlijke inhoud van het recht op een doeltreffende voorziening in rechte – Bestaan van een rechtsmiddel dat de betrokken justitiabelen de mogelijkheid biedt alle relevante feitelijke en juridische kwesties doeltreffend te laten toetsen en een daadwerkelijke rechtsbescherming van hun door het Unierecht gewaarborgde rechten te genieten – Door de Unie erkende doelstelling van algemeen belang – Bestrijding van internationale belastingfraude en ‑ontwijking – Evenredigheid – Criterium dat de informatie waarop het bevel tot het verstrekken van inlichtingen betrekking heeft ‚naar verwachting van belang is’ – Rechterlijke toetsing – Omvang – In aanmerking te nemen persoonlijke, temporele en materiële gegevens",
-				"court": "HvJ EU",
-				"docketNumber": "Gevoegde zaken C-245/19 en C-246/19",
-				"language": "nl",
-				"url": "https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX:62019CJ0245",
-				"attachments": [
-					{
-						"title": "EUR-Lex PDF (NL)",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "EUR-Lex HTML (NL)",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://eur-lex.europa.eu/legal-content/CS/TXT/?uri=uriserv%3AOJ.C_.2021.014.01.0001.01.CES&toc=OJ%3AC%3A2021%3A014%3ATOC",
-		"items": [
-			{
-				"itemType": "bill",
-				"title": "Bez námitek k navrhovanému spojení (Věc M.10068 — Brookfield/Mansa/Polenergia) (Text s významem pro EHP) 2021/C 14/01",
-				"creators": [],
-				"date": "2021",
-				"language": "cs",
-				"url": "https://eur-lex.europa.eu/legal-content/CS/TXT/?uri=uriserv%3AOJ.C_.2021.014.01.0001.01.CES&toc=OJ%3AC%3A2021%3A014%3ATOC",
-				"attachments": [
-					{
-						"title": "EUR-Lex PDF (CS)",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "EUR-Lex HTML (CS)",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://eur-lex.europa.eu/legal-content/MT/TXT/?uri=CELEX%3A62009TJ0201",
-		"items": [
-			{
-				"itemType": "case",
-				"caseName": "Rügen Fisch AG vs l-Uffiċċju għall-Armonizzazzjoni fis-Suq Intern (trademarks u disinni) (UASI)",
-				"creators": [],
-				"dateDecided": "21 ta' Settembru 2011",
-				"abstractNote": "Trade mark Komunitarja - Proċedimenti għal dikjarazzjoni ta’ invalidità - Trade mark Komunitarja verbali SCOMBER MIX - Raġuni assoluta għal rifjut - Karattru deskrittiv - Artikolu 7(1)(b) u (ċ) tar-Regolament (KE) Nru 40/94 [li sar l-Artikolu 7(1)(b) u (c) tar-Regolament (KE) Nru 207/2009]",
-				"court": "Il-Qorti Ġenerali",
-				"docketNumber": "Kawża T-201/09",
-				"language": "mt",
-				"url": "https://eur-lex.europa.eu/legal-content/MT/TXT/?uri=CELEX%3A62009TJ0201",
-				"attachments": [
-					{
-						"title": "EUR-Lex PDF (MT)",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "EUR-Lex HTML (MT)",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
 	}
 ]
 /** END TEST CASES **/

--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "bf053edc-a8c3-458c-93db-6d04ead2e636",
 	"label": "EUR-Lex",
-	"creator": "Philipp Zumstein",
-	"target": "^https?://(www\\.)?eur-lex\\.europa\\.eu/(legal-content/[A-Z][A-Z]/TXT/|search.html\\?)",
+	"creator": "Philipp Zumstein, Pieter van der Wees",
+	"target": "^https?://(www\\.)?eur-lex\\.europa\\.eu/(legal-content/[A-Z][A-Z]/(TXT|ALL)/|search.html\\?)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-12-21 20:27:07"
+	"lastUpdated": "2021-01-13 13:04:33"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017 Philipp Zumstein
+	Copyright © 2017-2020 Philipp Zumstein, Pieter van der Wees
 	
 	This file is part of Zotero.
 
@@ -41,27 +41,37 @@ function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelec
 
 
 // the eli resource types are described at:
-// http://publications.europa.eu/mdr/resource/authority/resource-type/html/resourcetypes-eng.html
+// https://op.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/resource-type
+// all types not mapped below are saved as bills
 var typeMapping = {
-	'DIR': 'bill', // directive
-	'REG': 'statute', // regulation
-	'DEC': 'statute', // decision
-	'RECO': 'report', // recommodation
-	'OPI': 'report' // opinion
+	"DIR": "bill", // directive
+	"REG": "statute", // regulation
+	"DEC": "statute", // decision
+	"RECO": "report", // recommendation
+	"OPI": "report", // opinion
+	"CONS": "statute", // consolidated text
+	"TREATY": "statute", // treaty
 };
 
 
 function detectWeb(doc, url) {
+	var docSector = attr(doc, 'meta[name="WT.z_docSector"]', 'content');
 	var eliTypeURI = attr(doc, 'meta[property="eli:type_document"]', 'resource');
 	if (eliTypeURI) {
-		var eliType = eliTypeURI.split('/').pop();
-		var eliCategory = eliType.split('_')[0];
+		var eliType = eliTypeURI.split("/").pop();
+		var eliCategory = eliType.split("_")[0];
 		var type = typeMapping[eliCategory];
 		if (type) {
 			return type;
-		} else {
-			Z.debug("Unknown eliType: " + eliType);
 		}
+		else {
+			Z.debug("Unknown eliType: " + eliType);
+			return "bill";
+		}
+	} else if (docSector == "6") {
+			return "case";
+	} else if (docSector && docSector !== "other") { 
+			return "bill";
 	} else if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
@@ -71,7 +81,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = doc.querySelectorAll('a.title');
+	var rows = doc.querySelectorAll("a.title");
 	for (let i=0; i<rows.length; i++) {
 		let href = rows[i].href;
 		let title = ZU.trimInternal(rows[i].textContent);
@@ -111,106 +121,167 @@ function doWeb(doc, url) {
 }
 
 
-// this maps language codes from ISO 639-1 to 639-3
+// this maps language codes from ISO 639-1 to 639-3 and adds court names
+// see https://op.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/court-type
 var languageMapping = {
-	'BG': 'bul',
-	'CS': 'ces',
-	'DA': 'dan',
-	'DE': 'deu',
-	'EL': 'ell',
-	'EN': 'eng',
-	'ES': 'spa',
-	'ET': 'est',
-	'FI': 'fin',
-	'FR': 'fra',
-	'GA': 'gle',
-	'HR': 'hrv',
-	'HU': 'hun',
-	'IT': 'ita',
-	'LV': 'lav',
-	'LT': 'lit',
-	'MT': 'mlt',
-	'NL': 'nld',
-	'PL': 'pol',
-	'PT': 'por',
-	'RO': 'ron',
-	'SK': 'slk',
-	'SL': 'slv',
-	'SV': 'swe'
+	"BG": ["BUL", "Съд", "Общ съд", "Съд на публичната служба"],
+	"CS": ["CES", "Soudní dvůr", "Tribunál", "Soud pro veřejnou službu"],
+	"DA": ["DAN", "EU-Domstolen", "EU-Retten", "EU-Personalretten"],
+	"DE": ["DEU", "EuGH", "Gerichtshof", "Gericht für den öffentlichen Dienst"],
+	"EL": ["ELL", "Δικαστήριο", "Γενικό Δικαστήριο", "Δικαστήριο Δημόσιας Διοίκησης"],
+	"EN": ["ENG", "ECJ", "GC", "CST"],
+	"ES": ["SPA", "TJUE", "Tribunal General", "Tribunal de la Función Pública"],
+	"ET": ["EST", "Euroopa Kohus", "Üldkohus" ,"Avaliku Teenistuse Kohus"],
+	"FI": ["FIN", "Unionin tuomioistuin", "Unionin yleinen tuomioistuin", "Virkamiestuomioistuin"],
+	"FR": ["FRA", "Cour de justice", "Tribunal", "Tribunal de la fonction publique"],
+	"GA": ["GLE", "An Chúirt Bhreithiúnais", "Cúirt Ghinearálta", "An Binse um Sheirbhís Shibhialta"],
+	"HR": ["HRV", "Europski sud", "Opći sud", "Službenički sud"],
+	"HU": ["HUN", "A Bíróság", "Törvényszék", "Közszolgálati Törvényszék"],
+	"IT": ["ITA", "Corte di giustizia", "Tribunale", "Tribunale della funzione pubblica"],
+	"LV": ["LAV", "Tiesa", "Vispārējā tiesa", "Civildienesta tiesa"],
+	"LT": ["LIT", "Teisingumo Teismas", "Bendrasis Teismas", "Tarnautojų teismas"],
+	"MT": ["MLT", "Il-Qorti tal-Ġustizzja", "Il-Qorti Ġenerali", "Il-Tribunal għas-Servizz Pubbliku"],
+	"NL": ["NLD", "HvJ EU", "Gerecht EU", "GvA EU"],
+	"PL": ["POL", "Trybunał Sprawiedliwości", "Sąd", "Sąd do spraw Służby Publicznej"],
+	"PT": ["POR", "Tribunal Europeu de Justiça", "Tribunal Geral", "Tribunal da Função Pública"],
+	"RO": ["RON", "Curtea Europeană de Justiție", "Tribunalul", "Tribunalul Funcţiei Publice"],
+	"SK": ["SLK", "Súdny dvor", "Všeobecný súd", "Súd pre verejnú službu"],
+	"SL": ["SLV", "Sodišče", "Splošno sodišče", "Sodišče za uslužbence"],
+	"SV": ["SWE", "Domstolen", "Tribunalen", "Personaldomstolen"]
 };
 
 
 function scrape(doc, url) {
+	// declare meta variables present for all sectors
+	var docSector = attr(doc, 'meta[name="WT.z_docSector"]', 'content');
+	var docType = attr(doc, 'meta[name="WT.z_docType"]', 'content');
+	var celex = attr(doc, 'meta[name="WT.z_docID"]', 'content');
+	
+	var eliTypeUri = (attr(doc, 'meta[property="eli:type_document"]', "resource"));
+	
 	var type = detectWeb(doc, url);
 	var item = new Zotero.Item(type);
-	
 	// determine the language we are currently looking the document at
-	var languageUrl = url.split('/')[4];
+	var languageUrl = url.split("/")[4].toUpperCase();
 	if (languageUrl=="AUTO") {
 		languageUrl = autoLanguage || "EN";
 	}
-	var language = languageMapping[languageUrl] || "eng";
-	
-	item.title = attr(doc, 'meta[property="eli:title"][lang=' + languageUrl.toLowerCase() + ']', 'content');
+	var language = languageMapping[languageUrl][0] || "eng";
+	// Cases only return language; discard everything else
 	item.language = languageUrl.toLowerCase();
 	
-	var uri = attr(doc, '#format_language_table_digital_sign_act_' + languageUrl.toUpperCase(), 'href');
-	if (uri) {
-		var uriParts = uri.split('/').pop().replace('?uri=', '').split(':');
-		// e.g. uriParts =  ["OJ", "L", "1995", "281", "TOC"]
-		// e.g. uriParts = ["DD", "03", "061", "TOC", "FI"]
-		if (uriParts.length>=4) {
-			if (/\d+/.test(uriParts[1])) {
-				item.code = uriParts[0];
-				item.codeNumber = uriParts[1] + ', ' + uriParts[2];
-			} else {
-				item.code = uriParts[0] + ' ' + uriParts[1];
-				item.codeNumber = uriParts[3];
-			}
-			if (type=="bill") {
-				item.codeVolume = item.code;
-				item.code = item.codeNumber;
+
+	if (eliTypeUri) {
+		// type: everything with ELI (see var typeMapping: bill, statute, report)
+		item.title = attr(doc, 'meta[property="eli:title"][lang=' + languageUrl.toLowerCase() + "]", "content");
+		var uri = attr(doc, "#format_language_table_digital_sign_act_" + languageUrl.toUpperCase(), "href");
+		if (uri) {
+			var uriParts = uri.split("/").pop().replace("?uri=", "").split(":");
+			// e.g. uriParts =  ["OJ", "L", "1995", "281", "TOC"]
+			// e.g. uriParts = ["DD", "03", "061", "TOC", "FI"]
+			if (uriParts.length>=4) {
+				if (/\d+/.test(uriParts[1])) {
+					item.code = uriParts[0];
+					item.codeNumber = uriParts[1] + ", " + uriParts[2];
+				} else {
+					item.code = uriParts[0] + " " + uriParts[1];
+					item.codeNumber = uriParts[3];
+				}
+				if (type=="bill") {
+					item.codeVolume = item.codeNumber;
+					item.codeNumber = null;
+				}
 			}
 		}
+		
+		// item.number = attr(doc, 'meta[property="eli:id_local"]', 'content');
+	  
+		item.date = attr(doc, 'meta[property="eli:date_document"]', "content");
+		if (!item.date) {item.date = attr(doc, 'meta[property="eli:date_publication"]', "content")}
+		
+		var passedBy = doc.querySelectorAll('meta[property="eli:passed_by"]');
+		var passedByArray = [];
+		for (let i=0; i<passedBy.length; i++) {
+			passedByArray.push(passedBy[i].getAttribute("resource").split("/").pop());
+		}
+		item.legislativeBody = passedByArray.join(", ");
+		
+		item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', "about") + "/" + language;
+		// eli:is_about -> eurovoc -> tags
 	}
-	
-	item.number = attr(doc, 'meta[property="eli:id_local"]', 'content');
-	
-	item.date = attr(doc, 'meta[property="eli:date_publication"]', 'content');
-	// attr(doc, 'meta[property="eli:date_document"]', 'content');
+	else if (docSector == "6") {
+		// type: case
+		// pretty hacky stuff, as there's little metadata available
+		var docCourt = docType.substr(0,1);
+		if (docCourt == "C") {
+			item.court = languageMapping[languageUrl][1] || "ECJ";	
+		}
+		else if (docCourt == "T") {
+			item.court = languageMapping[languageUrl][2] || "GC";
+		}
+		else if (docCourt == "F") {
+			item.court = languageMapping[languageUrl][3] || "CST";
+		}
+		item.url = url;
 
-	var passedBy = doc.querySelectorAll('meta[property="eli:passed_by"]');
-	var passedByArray = [];
-	for (let i=0; i<passedBy.length; i++) {
-		passedByArray.push(passedBy[i].getAttribute('resource').split('/').pop());
+		if (docType.substr(1) == "J") { // Judgments
+			var titleParts = attr(doc, 'meta[name="WT.z_docTitle"]', "content").replace(/\./g,"").split("#");
+			item.caseName = titleParts[1];
+			item.abstractNote = titleParts[titleParts.length - 2];
+			item.docketNumber = titleParts.pop();
+			item.dateDecided = titleParts[0].substr(titleParts[0].search(/[0-9]/g));
+		}
+		else { // Orders, summaries, etc.
+			item.caseName = attr(doc, 'meta[name="WT.z_docTitle"]', "content").replace(/#/g," ");
+			item.dateDecided = celex.substr(1,4);
+		}
 	}
-	item.legislativeBody = passedByArray.join(', ');
-	
-	item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', 'about') + '/' + language;
-	
-	// eli:is_about -> eurovoc -> tags
+	else {
+		// type: bill
+		item.title = attr(doc, 'meta[name="WT.z_docTitle"]', "content");
+		item.date = celex.substr(1,4);
+		item.url = url;
+		if (docType == "C") {
+			celexCParts = celex.substr(1).split("/");
+			item.code = "OJ C";
+			item.codeVolume = celexCParts[1];
+			item.codePages = celexCParts[2];
+		}
+	}
+	// attachments
+	// type: all
+	var pdfurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/PDF/?uri=CELEX:" + celex;
+	var htmlurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/HTML/?uri=CELEX:" + celex;
+	item.attachments = [{url: pdfurl, title: "EUR-Lex PDF (" + languageUrl + ")", mimeType: "application/pdf"}];
+	item.attachments.push({url: htmlurl, title: "EUR-Lex HTML (" + languageUrl + ")", mimeType: "text/html"});
 	
 	item.complete();
-}
-
-/** BEGIN TEST CASES **/
+}/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31995L0046",
+		"url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31995L0046",
 		"items": [
 			{
 				"itemType": "bill",
 				"title": "Directive 95/46/EC of the European Parliament and of the Council of 24 October 1995 on the protection of individuals with regard to the processing of personal data and on the free movement of such data",
 				"creators": [],
-				"date": "1995-11-23",
-				"billNumber": "31995L0046",
-				"code": "281",
-				"codeVolume": "OJ L",
+				"date": "1995-10-24",
+				"code": "OJ L",
+				"codeVolume": "281",
 				"language": "en",
 				"legislativeBody": "EP, CONSIL",
-				"url": "http://data.europa.eu/eli/dir/1995/46/oj/eng",
-				"attachments": [],
+				"url": "http://data.europa.eu/eli/dir/1995/46/oj/ENG",
+				"attachments": [
+					{
+						"title": "EUR-Lex PDF (EN)",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "EUR-Lex HTML (EN)",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -219,63 +290,27 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://eur-lex.europa.eu/legal-content/CS/TXT/?uri=CELEX:31995L0046&from=DE",
-		"items": [
-			{
-				"itemType": "bill",
-				"title": "Směrnice Evropského parlamentu a Rady 95/46/ES ze dne 24. října 1995 o ochraně fyzických osob v souvislosti se zpracováním osobních údajů a o volném pohybu těchto údajů",
-				"creators": [],
-				"date": "1995-11-23",
-				"billNumber": "31995L0046",
-				"code": "13, 015",
-				"codeVolume": "DD",
-				"language": "cs",
-				"legislativeBody": "EP, CONSIL",
-				"url": "http://data.europa.eu/eli/dir/1995/46/oj/ces",
-				"attachments": [],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:31995L0046",
-		"items": [
-			{
-				"itemType": "bill",
-				"title": "Richtlinie 95/46/EG des Europäischen Parlaments und des Rates vom 24. Oktober 1995 zum Schutz natürlicher Personen bei der Verarbeitung personenbezogener Daten und zum freien Datenverkehr",
-				"creators": [],
-				"date": "1995-11-23",
-				"billNumber": "31995L0046",
-				"code": "281",
-				"codeVolume": "OJ L",
-				"language": "de",
-				"legislativeBody": "EP, CONSIL",
-				"url": "http://data.europa.eu/eli/dir/1995/46/oj/deu",
-				"attachments": [],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:31994R2257",
+		"url": "https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:31994R2257",
 		"items": [
 			{
 				"itemType": "statute",
 				"nameOfAct": "Règlement (CE) n° 2257/94 de la Commission, du 16 septembre 1994, fixant des normes de qualité pour les bananes (Texte présentant de l'intérêt pour l'EEE)",
 				"creators": [],
-				"dateEnacted": "1994-09-20",
+				"dateEnacted": "1994-09-16",
 				"code": "OJ L",
 				"codeNumber": "245",
 				"language": "fr",
-				"publicLawNumber": "31994R2257",
-				"url": "http://data.europa.eu/eli/reg/1994/2257/oj/fra",
-				"attachments": [],
+				"url": "http://data.europa.eu/eli/reg/1994/2257/oj/FRA",
+				"attachments": [
+					{
+						"title": "EUR-Lex PDF (FR)",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "EUR-Lex HTML (FR)",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -284,8 +319,95 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://eur-lex.europa.eu/search.html?lang=en&text=%22open+access%22&qid=1513887127793&type=quick&scope=EURLEX&locale=nl",
+		"url": "https://eur-lex.europa.eu/search.html?lang=en&text=%22open+access%22&qid=1513887127793&type=quick&scope=EURLEX&locale=nl",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX:62019CJ0245",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "État luxembourgeois tegen B en État luxembourgeois tegen B ea",
+				"creators": [],
+				"dateDecided": "6 oktober 2020",
+				"abstractNote": "Prejudiciële verwijzing – Richtlijn 2011/16/EU – Administratieve samenwerking op het gebied van de belastingen – Artikelen 1 en 5 – Bevel tot het verstrekken van inlichtingen aan de bevoegde autoriteit van een lidstaat, die handelt naar aanleiding van een verzoek tot uitwisseling van inlichtingen van de bevoegde autoriteit van een andere lidstaat – Persoon die in het bezit is van de informatie waarvan de bevoegde autoriteit van eerstbedoelde lidstaat heeft bevolen dat deze moet worden verstrekt – Belastingplichtige tegen wie het onderzoek loopt dat aanleiding heeft gegeven tot het verzoek van de bevoegde autoriteit van de tweede lidstaat – Derden met wie deze belastingplichtige juridische, bancaire, financiële of, meer in het algemeen, economische banden onderhoudt – Rechtsbescherming – Handvest van de grondrechten van de Europese Unie – Artikel 47 – Recht op een doeltreffende voorziening in rechte – Artikel 52, lid 1 – Beperking – Rechtsgrondslag – Eerbiediging van de wezenlijke inhoud van het recht op een doeltreffende voorziening in rechte – Bestaan van een rechtsmiddel dat de betrokken justitiabelen de mogelijkheid biedt alle relevante feitelijke en juridische kwesties doeltreffend te laten toetsen en een daadwerkelijke rechtsbescherming van hun door het Unierecht gewaarborgde rechten te genieten – Door de Unie erkende doelstelling van algemeen belang – Bestrijding van internationale belastingfraude en ‑ontwijking – Evenredigheid – Criterium dat de informatie waarop het bevel tot het verstrekken van inlichtingen betrekking heeft ‚naar verwachting van belang is’ – Rechterlijke toetsing – Omvang – In aanmerking te nemen persoonlijke, temporele en materiële gegevens",
+				"court": "HvJ EU",
+				"docketNumber": "Gevoegde zaken C-245/19 en C-246/19",
+				"language": "nl",
+				"url": "https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX:62019CJ0245",
+				"attachments": [
+					{
+						"title": "EUR-Lex PDF (NL)",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "EUR-Lex HTML (NL)",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://eur-lex.europa.eu/legal-content/CS/TXT/?uri=uriserv%3AOJ.C_.2021.014.01.0001.01.CES&toc=OJ%3AC%3A2021%3A014%3ATOC",
+		"items": [
+			{
+				"itemType": "bill",
+				"title": "Bez námitek k navrhovanému spojení (Věc M.10068 — Brookfield/Mansa/Polenergia) (Text s významem pro EHP) 2021/C 14/01",
+				"creators": [],
+				"date": "2021",
+				"language": "cs",
+				"url": "https://eur-lex.europa.eu/legal-content/CS/TXT/?uri=uriserv%3AOJ.C_.2021.014.01.0001.01.CES&toc=OJ%3AC%3A2021%3A014%3ATOC",
+				"attachments": [
+					{
+						"title": "EUR-Lex PDF (CS)",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "EUR-Lex HTML (CS)",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://eur-lex.europa.eu/legal-content/MT/TXT/?uri=CELEX%3A62009TJ0201",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "Rügen Fisch AG vs l-Uffiċċju għall-Armonizzazzjoni fis-Suq Intern (trademarks u disinni) (UASI)",
+				"creators": [],
+				"dateDecided": "21 ta' Settembru 2011",
+				"abstractNote": "Trade mark Komunitarja - Proċedimenti għal dikjarazzjoni ta’ invalidità - Trade mark Komunitarja verbali SCOMBER MIX - Raġuni assoluta għal rifjut - Karattru deskrittiv - Artikolu 7(1)(b) u (ċ) tar-Regolament (KE) Nru 40/94 [li sar l-Artikolu 7(1)(b) u (c) tar-Regolament (KE) Nru 207/2009]",
+				"court": "Il-Qorti Ġenerali",
+				"docketNumber": "Kawża T-201/09",
+				"language": "mt",
+				"url": "https://eur-lex.europa.eu/legal-content/MT/TXT/?uri=CELEX%3A62009TJ0201",
+				"attachments": [
+					{
+						"title": "EUR-Lex PDF (MT)",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "EUR-Lex HTML (MT)",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -36,8 +36,8 @@
 */
 
 
-// attr()/text() v2
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
+// attr() v2
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}
 
 
 // the eli resource types are described at:
@@ -115,7 +115,8 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} else {
+	} 
+	else {
 		scrape(doc, url);
 	}
 }
@@ -131,7 +132,7 @@ var languageMapping = {
 	"EL": ["ELL", "Δικαστήριο", "Γενικό Δικαστήριο", "Δικαστήριο Δημόσιας Διοίκησης"],
 	"EN": ["ENG", "ECJ", "GC", "CST"],
 	"ES": ["SPA", "TJUE", "Tribunal General", "Tribunal de la Función Pública"],
-	"ET": ["EST", "Euroopa Kohus", "Üldkohus" ,"Avaliku Teenistuse Kohus"],
+	"ET": ["EST", "Euroopa Kohus", "Üldkohus", "Avaliku Teenistuse Kohus"],
 	"FI": ["FIN", "Unionin tuomioistuin", "Unionin yleinen tuomioistuin", "Virkamiestuomioistuin"],
 	"FR": ["FRA", "Cour de justice", "Tribunal", "Tribunal de la fonction publique"],
 	"GA": ["GLE", "An Chúirt Bhreithiúnais", "Cúirt Ghinearálta", "An Binse um Sheirbhís Shibhialta"],
@@ -163,7 +164,7 @@ function scrape(doc, url) {
 	var item = new Zotero.Item(type);
 	// determine the language we are currently looking the document at
 	var languageUrl = url.split("/")[4].toUpperCase();
-	if (languageUrl=="AUTO") {
+	if (languageUrl == "AUTO") {
 		languageUrl = autoLanguage || "EN";
 	}
 	var language = languageMapping[languageUrl][0] || "eng";
@@ -179,29 +180,30 @@ function scrape(doc, url) {
 			var uriParts = uri.split("/").pop().replace("?uri=", "").split(":");
 			// e.g. uriParts =  ["OJ", "L", "1995", "281", "TOC"]
 			// e.g. uriParts = ["DD", "03", "061", "TOC", "FI"]
-			if (uriParts.length>=4) {
+			if (uriParts.length >= 4) {
 				if (/\d+/.test(uriParts[1])) {
 					item.code = uriParts[0];
 					item.codeNumber = uriParts[1] + ", " + uriParts[2];
-				} else {
+				} 
+				else {
 					item.code = uriParts[0] + " " + uriParts[1];
 					item.codeNumber = uriParts[3];
 				}
-				if (type=="bill") {
+				if (type == "bill") {
 					item.codeVolume = item.codeNumber;
 					item.codeNumber = null;
 				}
 			}
 		}
-		
+
 		// item.number = attr(doc, 'meta[property="eli:id_local"]', 'content');
-	  
+
 		item.date = attr(doc, 'meta[property="eli:date_document"]', "content");
 		if (!item.date) {item.date = attr(doc, 'meta[property="eli:date_publication"]', "content")}
 		
 		var passedBy = doc.querySelectorAll('meta[property="eli:passed_by"]');
 		var passedByArray = [];
-		for (let i=0; i<passedBy.length; i++) {
+		for (let i = 0; i < passedBy.length; i++) {
 			passedByArray.push(passedBy[i].getAttribute("resource").split("/").pop());
 		}
 		item.legislativeBody = passedByArray.join(", ");
@@ -212,15 +214,15 @@ function scrape(doc, url) {
 	else if (docSector == "6") {
 		// type: case
 		// pretty hacky stuff, as there's little metadata available
-		var docCourt = docType.substr(0,1);
+		var docCourt = docType.substr(0, 1);
 		if (docCourt == "C") {
-			item.court = languageMapping[languageUrl][1] || "ECJ";	
+			item.court = languageMapping[languageUrl][1] || languageMapping["EN"][1];
 		}
 		else if (docCourt == "T") {
-			item.court = languageMapping[languageUrl][2] || "GC";
+			item.court = languageMapping[languageUrl][2] || languageMapping["EN"][2];
 		}
 		else if (docCourt == "F") {
-			item.court = languageMapping[languageUrl][3] || "CST";
+			item.court = languageMapping[languageUrl][3] || languageMapping["EN"][3];
 		}
 		item.url = url;
 
@@ -233,16 +235,16 @@ function scrape(doc, url) {
 		}
 		else { // Orders, summaries, etc.
 			item.caseName = attr(doc, 'meta[name="WT.z_docTitle"]', "content").replace(/#/g," ");
-			item.dateDecided = celex.substr(1,4);
+			item.dateDecided = celex.substr(1, 4);
 		}
 	}
 	else {
 		// type: bill
 		item.title = attr(doc, 'meta[name="WT.z_docTitle"]', "content");
-		item.date = celex.substr(1,4);
+		item.date = celex.substr(1, 4);
 		item.url = url;
 		if (docType == "C") {
-			celexCParts = celex.substr(1).split("/");
+			var celexCParts = celex.substr(1).split("/");
 			item.code = "OJ C";
 			item.codeVolume = celexCParts[1];
 			item.codePages = celexCParts[2];
@@ -252,8 +254,8 @@ function scrape(doc, url) {
 	// type: all
 	var pdfurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/PDF/?uri=CELEX:" + celex;
 	var htmlurl = "https://eur-lex.europa.eu/legal-content/" + languageUrl + "/TXT/HTML/?uri=CELEX:" + celex;
-	item.attachments = [{url: pdfurl, title: "EUR-Lex PDF (" + languageUrl + ")", mimeType: "application/pdf"}];
-	item.attachments.push({url: htmlurl, title: "EUR-Lex HTML (" + languageUrl + ")", mimeType: "text/html"});
+	item.attachments = [{ url: pdfurl, title: "EUR-Lex PDF (" + languageUrl + ")", mimeType: "application/pdf" }];
+	item.attachments.push({ url: htmlurl, title: "EUR-Lex HTML (" + languageUrl + ")", mimeType: "text/html" });
 	
 	item.complete();
 }/** BEGIN TEST CASES **/

--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -206,7 +206,7 @@ function scrape(doc, url) {
 		}
 		item.legislativeBody = passedByArray.join(", ");
 		
-		item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', "about") + "/" + language;
+		item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', "about") + "/" + language.toLowerCase();
 		// eli:is_about -> eurovoc -> tags
 	}
 	else if (docSector == "6") {
@@ -271,7 +271,7 @@ var testCases = [
 				"codeVolume": "281",
 				"language": "en",
 				"legislativeBody": "EP, CONSIL",
-				"url": "http://data.europa.eu/eli/dir/1995/46/oj/ENG",
+				"url": "http://data.europa.eu/eli/dir/1995/46/oj/eng",
 				"attachments": [
 					{
 						"title": "EUR-Lex PDF (EN)",
@@ -300,7 +300,7 @@ var testCases = [
 				"code": "OJ L",
 				"codeNumber": "245",
 				"language": "fr",
-				"url": "http://data.europa.eu/eli/reg/1994/2257/oj/FRA",
+				"url": "http://data.europa.eu/eli/reg/1994/2257/oj/fra",
 				"attachments": [
 					{
 						"title": "EUR-Lex PDF (FR)",

--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -13,7 +13,6 @@
 }
 
 /*
-Test
 	***** BEGIN LICENSE BLOCK *****
 
 	Copyright © 2017 Philipp Zumstein

--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -13,6 +13,7 @@
 }
 
 /*
+Test
 	***** BEGIN LICENSE BLOCK *****
 
 	Copyright © 2017 Philipp Zumstein

--- a/Rechtspraak.nl.js
+++ b/Rechtspraak.nl.js
@@ -2,7 +2,7 @@
 	"translatorID": "aede3fda-1894-4dfc-8bca-1c3463f11076",
 	"label": "Rechtspraak.nl",
 	"creator": "Pieter van der Wees",
-	"target": "^https?://*uitspraken\\.rechtspraak\\.nl/",
+	"target": "^https?://uitspraken\\.rechtspraak\\.nl/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,

--- a/Rechtspraak.nl.js
+++ b/Rechtspraak.nl.js
@@ -171,7 +171,8 @@ var testCases = [
 				"abstractNote": "Klimaatzaak Urgenda. Onrechtmatige daad. Schending zorgplicht ex artikelen 2 en 8 EVRM. Staat moet broeikasgassen nu verder terugdringen. Vonnis bekrachtigd\n\nVindplaatsen:\nRechtspraak.nl \nJM 2018/128 met annotatie van W.Th. Douma \nAB 2018/417 met annotatie van G.A. van der Veen, Ch.W. Backes \nO&A 2018/66 \nO&A 2018/51 met annotatie van G.A. van der Veen, T.G. Oztürk \nSEW 2019, afl. 1, p. 35 \nJB 2019/10 met annotatie van Sanderink, D.G.J. \nOGR-Updates.nl 2018-0234 \nPS-Updates.nl 2018-0814 \nJOM 2018/1182 \nJOM 2018/1154 \nJA 2019/37 \nJIN 2019/78 met annotatie van Sanderink, D.G.J.",
 				"court": "Hof Den Haag",
 				"docketNumber": "ECLI:NL:GHDHA:2018:2591",
-				"extra": "Soort: Uitspraak\nReferences: Eerste aanleg: ECLI:NL:RBDHA:2015:7145, Bekrachtiging/bevestiging; Cassatie: ECLI:NL:HR:2019:2006, Bekrachtiging/bevestiging",
+				"extra": "Soort: Uitspraak",
+				"history": "Eerste aanleg: ECLI:NL:RBDHA:2015:7145, Bekrachtiging/bevestiging; Cassatie: ECLI:NL:HR:2019:2006, Bekrachtiging/bevestiging",
 				"language": "nl",
 				"url": "https://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:GHDHA:2018:2591",
 				"attachments": [
@@ -202,7 +203,8 @@ var testCases = [
 				"abstractNote": "Conclusie P-G: Bedreiging. Voldoende bepaald vreesobject. Conclusie strekt tot verwerping.\n\nVindplaatsen:\nRechtspraak.nl",
 				"court": "Parket bij de HR",
 				"docketNumber": "ECLI:NL:PHR:2019:1016",
-				"extra": "Soort: Conclusie\nReferences: Arrest Hoge Raad: ECLI:NL:HR:2020:44",
+				"extra": "Soort: Conclusie",
+				"history": "Arrest Hoge Raad: ECLI:NL:HR:2020:44",
 				"language": "nl",
 				"url": "https://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:PHR:2019:1016",
 				"attachments": [

--- a/Rechtspraak.nl.js
+++ b/Rechtspraak.nl.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-01-19 12:14:04"
+	"lastUpdated": "2021-01-19 12:19:42"
 }
 
 /*
@@ -180,7 +180,7 @@ var testCases = [
 				"creators": [],
 				"dateDecided": "2018-10-09",
 				"abstractNote": "Klimaatzaak Urgenda. Onrechtmatige daad. Schending zorgplicht ex artikelen 2 en 8 EVRM. Staat moet broeikasgassen nu verder terugdringen. Vonnis bekrachtigd\n\nVindplaatsen:\nRechtspraak.nl \nJM 2018/128 met annotatie van W.Th. Douma \nAB 2018/417 met annotatie van G.A. van der Veen, Ch.W. Backes \nO&A 2018/66 \nO&A 2018/51 met annotatie van G.A. van der Veen, T.G. Oztürk \nSEW 2019, afl. 1, p. 35 \nJB 2019/10 met annotatie van Sanderink, D.G.J. \nOGR-Updates.nl 2018-0234 \nPS-Updates.nl 2018-0814 \nJOM 2018/1182 \nJOM 2018/1154 \nJA 2019/37 \nJIN 2019/78 met annotatie van Sanderink, D.G.J.",
-				"court": "Gerechtshof Den Haag",
+				"court": "Hof Den Haag",
 				"docketNumber": "ECLI:NL:GHDHA:2018:2591",
 				"extra": "Soort: Uitspraak",
 				"language": "nl",
@@ -215,7 +215,7 @@ var testCases = [
 				"creators": [],
 				"dateDecided": "2019-10-08",
 				"abstractNote": "Conclusie P-G: Bedreiging. Voldoende bepaald vreesobject. Conclusie strekt tot verwerping.\n\nVindplaatsen:\nRechtspraak.nl",
-				"court": "Parket bij de Hoge Raad",
+				"court": "Parket bij de HR",
 				"docketNumber": "ECLI:NL:PHR:2019:1016",
 				"extra": "Soort: Conclusie",
 				"language": "nl",
@@ -233,6 +233,44 @@ var testCases = [
 				"tags": [
 					{
 						"tag": "Strafrecht"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://uitspraken.rechtspraak.nl/inziendocument?id=ECLI:NL:ORBAACM:2020:30&showbutton=true",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "ECLI:NL:ORBAACM:2020:30, Raad van Beroep in Ambtenarenzaken van Aruba, Curaçao, Sint Maarten en van Bonaire, Sint Eustatius en Saba, CUR2019H00160",
+				"creators": [],
+				"dateDecided": "2020-12-16",
+				"abstractNote": "Ontslag wegens strafrechtelijke veroordeling. Geen procesbelang bij het opschuiven van de datum van ontslag. Bevestiging aangevallen uitspraak.\n\nVindplaatsen:\nRechtspraak.nl",
+				"court": "RvB in Ambtenarenzaken Aruba, Curaçao, Sint Maarten en Bonaire, Sint Eustatius en Saba",
+				"docketNumber": "ECLI:NL:ORBAACM:2020:30",
+				"extra": "Soort: Uitspraak",
+				"language": "nl",
+				"url": "https://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:ORBAACM:2020:30",
+				"attachments": [
+					{
+						"title": "Rechtspraak.nl PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Ambtenarenrecht"
+					},
+					{
+						"tag": "Bestuursrecht"
 					}
 				],
 				"notes": [],

--- a/Rechtspraak.nl.js
+++ b/Rechtspraak.nl.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-01-19 12:19:42"
+	"lastUpdated": "2021-01-20 09:37:49"
 }
 
 /*
@@ -39,25 +39,25 @@
 function attr (docOrElem, selector, attr, index) { var elem = index ? docOrElem.querySelectorAll(selector).item(index) : docOrElem.querySelector(selector); return elem ? elem.getAttribute(attr) : null; }
 
 var courtAbbrevs = {
-	"Hoge Raad": "HR",
-	"Raad van State": "ABRvS",
-	"Centrale Raad van Beroep": "CRvB",
-	"College van Beroep voor het bedrijfsleven": "CBb",
-	"Gerechtshof": "Hof",
-	"Rechtbank": "Rb.",
-	"Raad van Beroep": "RvB",
-	"Gerecht in eerste aanleg van": "GiEA",
-	"Gerecht in Eerste Aanleg van": "GiEA",
-	"Gemeenschappelijk Hof van Justitie": "Gem. Hof",
+	"hoge raad": "HR",
+	"raad van state": "ABRvS",
+	"centrale raad van beroep": "CRvB",
+	"college van beroep voor het bedrijfsleven": "CBb",
+	"gerechtshof": "Hof",
+	"rechtbank": "Rb.",
+	"raad van beroep": "RvB",
+	"gerecht in eerste aanleg van": "GiEA",
+	"gemeenschappelijk hof van justitie": "Gem. Hof",
 	"van ": ""
 };
 
 // ReplaceAll solution from https://stackoverflow.com/questions/15604140/replace-multiple-strings-with-multiple-other-strings
+// All keys should be lowercase.
 function replaceAll (str, mapObj) {
 	var re = new RegExp(Object.keys(mapObj).join("|"), "gi");
 
 	return str.replace(re, function (matched) {
-		return mapObj[matched];
+		return mapObj[matched.toLowerCase()];
 	});
 }
 

--- a/Rechtspraak.nl.js
+++ b/Rechtspraak.nl.js
@@ -1,0 +1,244 @@
+{
+	"translatorID": "aede3fda-1894-4dfc-8bca-1c3463f11076",
+	"label": "Rechtspraak.nl",
+	"creator": "Pieter van der Wees",
+	"target": "^https?://*uitspraken\\.rechtspraak\\.nl/",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2021-01-19 12:14:04"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2021 Pieter van der Wees
+	
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+// attr() v2
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}
+
+var courtAbbrevs = {
+	"Hoge Raad": "HR",
+	"Raad van State": "ABRvS",
+	"Centrale Raad van Beroep": "CRvB",
+	"College van Beroep voor het bedrijfsleven": "CBb",
+	"Gerechtshof": "Hof",
+	"Rechtbank": "Rb.",
+	"Raad van Beroep": "RvB",
+	"Gerecht in eerste aanleg van": "GiEA",
+	"Gerecht in Eerste Aanleg van": "GiEA",
+	"Gemeenschappelijk Hof van Justitie": "Gem. Hof",
+	"van ": ""
+	};
+
+// ReplaceAll solution from https://stackoverflow.com/questions/15604140/replace-multiple-strings-with-multiple-other-strings
+function replaceAll(str,mapObj){
+	var re = new RegExp(Object.keys(mapObj).join("|"),"gi");
+
+	return str.replace(re, function(matched){
+		return mapObj[matched];
+	});
+}
+
+var esc = ZU.unescapeHTML;
+
+
+// Custom cleaning function for scraping, adapted from utilities.js
+function cleanTags(x) {
+	if(x === null) { // account for cases without abstractNote
+		return;
+	}
+	else if(typeof(x) != "string") {
+		throw "cleanTags: argument must be a string";
+	}
+	x = x.replace(/<(\/para|br)[^>]*>/gi, "\n"); // account for dcterms:abstract newlines
+	x = x.replace(/<[^>]+>/g, "");
+	return esc(x);
+}
+
+function detectWeb(doc, url) {
+	if (url.includes('inziendocument')) {
+		return "case";
+	}
+	else if (getSearchResults(doc, true)) {
+		return "multiple";
+	}
+	else if (url.includes('zoekverfijn')) {
+		Z.monitorDOMChanges(doc.getElementById('content'));
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('h3>a.titel[href*="inziendocument"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (items) ZU.processDocuments(Object.keys(items), scrape);
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, url) {
+	var newItem = new Zotero.Item("case");
+
+	// First, scrape easy properties
+	newItem.title = esc(attr(doc, 'meta[property="dcterms:title"]', 'content')); // no party names, unfortunately
+	newItem.docketNumber = esc(attr(doc, 'meta[property="dcterms:identifier"]', 'content'));
+	newItem.dateDecided = attr(doc, 'meta[property="dcterms:created"]', 'content');
+	newItem.extra = "Soort: " + esc(attr(doc, 'link[rel="dcterms:type"]', 'title'));
+	newItem.language = attr(doc, 'meta[property="dcterms:language"]', 'content');
+	newItem.abstractNote = cleanTags(attr(doc, 'meta[property="dcterms:abstract"]', 'content'));
+	newItem.url = "https://deeplink.rechtspraak.nl/uitspraak?id=" + newItem.docketNumber;
+	newItem.shortTitle = null;
+
+	// Pursuant to most citation styles (including Leidraad voor juridische auteurs), we abbreviate the court names
+	var fullCourtName = cleanTags(attr(doc, 'meta[property="dcterms:creator"]', 'content'));
+	newItem.court = replaceAll(fullCourtName,courtAbbrevs);
+
+	// Because we do not know which reporter the user wants to cite, add them all to abstractNote
+	newItem.abstractNote = newItem.abstractNote.concat("\nVindplaatsen:", cleanTags(ZU.xpathText(doc, "//dt[text()='Vindplaatsen']//following::dd[1]")));
+
+	// References, though CSL-specified and having an according zotero field (History), do not show up in the library. Fetch them anyway
+	var relation = doc.querySelectorAll('link[rel="dcterms:relation"]');
+	var relationArray = [];
+	for (let i = 0; i < relation.length; i++) {
+		relationArray.push(relation[i].getAttribute('title'));
+	}
+	newItem.references = relationArray.join('; '); 
+
+	// Add fields of law as tags
+	var tags = attr(doc, 'link[rel="dcterms:subject"]', 'title');
+	if (tags.length) { 
+		newItem.tags = tags.split('; ');
+	}
+	
+	// Attachments: PDF and Snapshot
+	var pdfurl = "https://uitspraken.rechtspraak.nl" + attr(doc, 'a.pdfUitspraak', 'href');
+	newItem.attachments = [{
+		url: pdfurl,
+		title: "Rechtspraak.nl PDF",
+		mimeType: "application/pdf",
+	}];
+	newItem.attachments.push({
+		title:"Snapshot",
+		document:doc
+	});
+	
+	newItem.complete();
+}/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://uitspraken.rechtspraak.nl/#zoekverfijn/zt[0][zt]=urgenda&zt[0][fi]=AlleVelden&zt[0][ft]=Alle+velden&so=Relevance&ps[]=ps1",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://uitspraken.rechtspraak.nl/inziendocument?id=ECLI:NL:GHDHA:2018:2591",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "ECLI:NL:GHDHA:2018:2591, Gerechtshof Den Haag, 200.178.245/01",
+				"creators": [],
+				"dateDecided": "2018-10-09",
+				"abstractNote": "Klimaatzaak Urgenda. Onrechtmatige daad. Schending zorgplicht ex artikelen 2 en 8 EVRM. Staat moet broeikasgassen nu verder terugdringen. Vonnis bekrachtigd\n\nVindplaatsen:\nRechtspraak.nl \nJM 2018/128 met annotatie van W.Th. Douma \nAB 2018/417 met annotatie van G.A. van der Veen, Ch.W. Backes \nO&A 2018/66 \nO&A 2018/51 met annotatie van G.A. van der Veen, T.G. Oztürk \nSEW 2019, afl. 1, p. 35 \nJB 2019/10 met annotatie van Sanderink, D.G.J. \nOGR-Updates.nl 2018-0234 \nPS-Updates.nl 2018-0814 \nJOM 2018/1182 \nJOM 2018/1154 \nJA 2019/37 \nJIN 2019/78 met annotatie van Sanderink, D.G.J.",
+				"court": "Gerechtshof Den Haag",
+				"docketNumber": "ECLI:NL:GHDHA:2018:2591",
+				"extra": "Soort: Uitspraak",
+				"language": "nl",
+				"url": "https://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:GHDHA:2018:2591",
+				"attachments": [
+					{
+						"title": "Rechtspraak.nl PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Civiel recht"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://uitspraken.rechtspraak.nl/inziendocument?id=ECLI:NL:PHR:2019:1016",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "ECLI:NL:PHR:2019:1016, Parket bij de Hoge Raad, 18/01333",
+				"creators": [],
+				"dateDecided": "2019-10-08",
+				"abstractNote": "Conclusie P-G: Bedreiging. Voldoende bepaald vreesobject. Conclusie strekt tot verwerping.\n\nVindplaatsen:\nRechtspraak.nl",
+				"court": "Parket bij de Hoge Raad",
+				"docketNumber": "ECLI:NL:PHR:2019:1016",
+				"extra": "Soort: Conclusie",
+				"language": "nl",
+				"url": "https://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:PHR:2019:1016",
+				"attachments": [
+					{
+						"title": "Rechtspraak.nl PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Strafrecht"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/


### PR DESCRIPTION
This translator translates the Dutch judiciary's case law database at uitspraken.rechtspraak.nl. Please excuse the messy commit history, I'm new to git.