### PR TITLE
Trim off the (Published XXXX) suffix from NYTimes.com titles

### DIFF
--- a/NYTimes.com.js
+++ b/NYTimes.com.js
@@ -113,6 +113,11 @@ function scrape(doc, url) {
 		if (item.title == item.title.toUpperCase()) {
 			item.title = ZU.capitalizeTitle(item.title, true);
 		}
+		// Trim off the (Published xxxx) from the end of titles
+		publishedRegexMatch = item.title.match(/(.*) \(Published \d{4}\)/)
+		if (publishedRegexMatch) {
+			item.title = publishedRegexMatch[1]
+		}
 		// Only force all caps to title case when all tags are all caps
 		var allcaps = true;
 		for (let i = 0; i < item.tags.length; i++) {


### PR DESCRIPTION
This is currently causing most of the NYTimes.com tests to fail; the suffix is indeed present in the HTML title, but isn't properly speaking part of the article title.