### PR TITLE
eLife: Deal with campaign links

### DIFF
--- a/eLife.js
+++ b/eLife.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2018-09-27 13:36:20"
+	"lastUpdated": "2021-01-28 14:40:53"
 }
 
 /*
@@ -84,7 +84,7 @@ function doWeb(doc, url) {
 
 
 function scrape(doc, url) {
-
+	url = url.split('?')[0] // Remove URL parameters like ?utm_source
 	var risURL = url.replace(/#.+/, "") + ".ris";
 	var pdfURL = attr(doc, 'a[data-download-type=pdf-article', 'href');
 	// Z.debug("pdfURL: " + pdfURL);
@@ -231,6 +231,216 @@ var testCases = [
 					},
 					{
 						"tag": "research"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://elifesciences.org/articles/54967?utm_source=content_alert&utm_medium=email&utm_content=fulltext&utm_campaign=24-August-20-elife-alert",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "A community-maintained standard library of population genetic models",
+				"creators": [
+					{
+						"lastName": "Adrion",
+						"firstName": "Jeffrey R",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Cole",
+						"firstName": "Christopher B",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Dukler",
+						"firstName": "Noah",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Galloway",
+						"firstName": "Jared G",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Gladstein",
+						"firstName": "Ariella L",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Gower",
+						"firstName": "Graham",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Kyriazis",
+						"firstName": "Christopher C",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Ragsdale",
+						"firstName": "Aaron P",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Tsambos",
+						"firstName": "Georgia",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Baumdicker",
+						"firstName": "Franz",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Carlson",
+						"firstName": "Jedidiah",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Cartwright",
+						"firstName": "Reed A",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Durvasula",
+						"firstName": "Arun",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Gronau",
+						"firstName": "Ilan",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Kim",
+						"firstName": "Bernard Y",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "McKenzie",
+						"firstName": "Patrick",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Messer",
+						"firstName": "Philipp W",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Noskova",
+						"firstName": "Ekaterina",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Ortega-Del Vecchyo",
+						"firstName": "Diego",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Racimo",
+						"firstName": "Fernando",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Struck",
+						"firstName": "Travis J",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Gravel",
+						"firstName": "Simon",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Gutenkunst",
+						"firstName": "Ryan N",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Lohmueller",
+						"firstName": "Kirk E",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Ralph",
+						"firstName": "Peter L",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Schrider",
+						"firstName": "Daniel R",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Siepel",
+						"firstName": "Adam",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Kelleher",
+						"firstName": "Jerome",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Kern",
+						"firstName": "Andrew D",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Coop",
+						"firstName": "Graham",
+						"creatorType": "editor"
+					},
+					{
+						"lastName": "Wittkopp",
+						"firstName": "Patricia J",
+						"creatorType": "editor"
+					},
+					{
+						"lastName": "Novembre",
+						"firstName": "John",
+						"creatorType": "editor"
+					},
+					{
+						"lastName": "Sethuraman",
+						"firstName": "Arun",
+						"creatorType": "editor"
+					},
+					{
+						"lastName": "Mathieson",
+						"firstName": "Sara",
+						"creatorType": "editor"
+					}
+				],
+				"date": "June 23, 2020",
+				"DOI": "10.7554/eLife.54967",
+				"ISSN": "2050-084X",
+				"abstractNote": "The explosion in population genomic data demands ever more complex modes of analysis, and increasingly, these analyses depend on sophisticated simulations. Recent advances in population genetic simulation have made it possible to simulate large and complex models, but specifying such models for a particular simulation engine remains a difficult and error-prone task. Computational genetics researchers currently re-implement simulation models independently, leading to inconsistency and duplication of effort. This situation presents a major barrier to empirical researchers seeking to use simulations for power analyses of upcoming studies or sanity checks on existing genomic data. Population genetics, as a field, also lacks standard benchmarks by which new tools for inference might be measured. Here, we describe a new resource, stdpopsim, that attempts to rectify this situation. Stdpopsim is a community-driven open source project, which provides easy access to a growing catalog of published simulation models from a range of organisms and supports multiple simulation engine backends. This resource is available as a well-documented python library with a simple command-line interface. We share some examples demonstrating how stdpopsim can be used to systematically compare demographic inference methods, and we encourage a broader community of developers to contribute to this growing resource.",
+				"libraryCatalog": "eLife",
+				"pages": "e54967",
+				"publicationTitle": "eLife",
+				"url": "https://doi.org/10.7554/eLife.54967",
+				"volume": "9",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "open source"
+					},
+					{
+						"tag": "reproducibility"
+					},
+					{
+						"tag": "simulation"
 					}
 				],
 				"notes": [],

--- a/eLife.js
+++ b/eLife.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2021-01-28 14:40:53"
+	"lastUpdated": "2021-01-28 15:20:33"
 }
 
 /*
@@ -84,8 +84,7 @@ function doWeb(doc, url) {
 
 
 function scrape(doc, url) {
-	url = url.split('?')[0] // Remove URL parameters like ?utm_source
-	var risURL = url.replace(/#.+/, "") + ".ris";
+	var risURL = url.replace(/[#?].+/, "") + ".ris";
 	var pdfURL = attr(doc, 'a[data-download-type=pdf-article', 'href');
 	// Z.debug("pdfURL: " + pdfURL);
 	ZU.doGet(risURL, function(text) {


### PR DESCRIPTION
This fixes the eLife translator for links directly taken from the eLife newsletter, e.g.
https://elifesciences.org/articles/54967?utm_source=content_alert&utm_medium=email&utm_content=fulltext&utm_campaign=24-August-20-elife-alert

Closes #2133