### PR TITLE
PICA: Adding links to the online document

### DIFF
--- a/Library Catalog (PICA).js
+++ b/Library Catalog (PICA).js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "1b9ed730-69c7-40b0-8a06-517a89a3a278",
 	"label": "Library Catalog (PICA)",
-	"creator": "Sean Takats, Michael Berkowitz, Sylvain Machefert, Sebastian Karcher, Stéphane Gully",
+	"creator": "Sean Takats, Michael Berkowitz, Sylvain Machefert, Sebastian Karcher, Stéphane Gully, Mathis Eon",
 	"target": "^https?://[^/]+(/[^/]+)*//?DB=\\d",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsb",
-	"lastUpdated": "2020-11-07 11:02:01"
+	"lastUpdated": "2021-03-03 10:06:49"
 }
 
 /*
@@ -577,6 +577,17 @@ function scrape(doc, url) {
 					});
 				}
 				break;
+
+			case 'links zum titel': // gso.gbv.de
+			case 'volltext': // stabikat.de
+			case 'link zum volltext': // swb.bsz-bw.de
+			case 'link': // opac.tib.eu opac.sub.uni-goettingen.de lhclz.gbv.de
+			case 'zugang': // cbsopac.rz.uni-frankfurt.de
+			case 'accès en ligne': // sudoc.abes.fr
+				///Some time link are inside the third cell : https://kxp.k10plus.de/DB=2.1/DB=2.1/PPNSET?PPN=600530787
+				url = doc.evaluate('./td[3]//a | ./td[2]//a', tableRow, null, XPathResult.ANY_TYPE, null).iterateNext();
+				newItem.url = url;
+				break;
 		}
 	}
 
@@ -689,7 +700,7 @@ var testCases = [
 					}
 				],
 				"date": "2010",
-				"ISBN": "978-2-7472-1729-3",
+				"ISBN": "9782747217293",
 				"language": "français",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"numPages": "290",
@@ -713,11 +724,21 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Conditions de travail -- France",
-					"Harcèlement -- France",
-					"Psychologie du travail",
-					"Stress lié au travail -- France",
-					"Violence en milieu de travail"
+					{
+						"tag": "Conditions de travail -- France"
+					},
+					{
+						"tag": "Harcèlement -- France"
+					},
+					{
+						"tag": "Psychologie du travail"
+					},
+					{
+						"tag": "Stress lié au travail -- France"
+					},
+					{
+						"tag": "Violence en milieu de travail"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -739,11 +760,11 @@ var testCases = [
 					}
 				],
 				"date": "2011",
-				"ISBN": "978-0-83898589-2",
+				"ISBN": "9780838985892",
 				"language": "anglais",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"numPages": "159",
-				"place": "Chicago, Etats-Unis",
+				"place": "Chicago, Etats-Unis d'Amérique",
 				"publisher": "Association of College and Research Libraries",
 				"shortTitle": "Zotero",
 				"attachments": [
@@ -764,7 +785,9 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Bibliographie -- Méthodologie -- Informatique"
+					{
+						"tag": "Bibliographie -- Méthodologie -- Informatique"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -794,9 +817,8 @@ var testCases = [
 				"language": "français",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"numPages": "87",
-				"numberOfVolumes": "1",
-				"place": "Lille, France",
-				"type": "Thèse d'exercice",
+				"place": "Lille ; 1969-2017, France",
+				"thesisType": "Thèse d'exercice",
 				"university": "Université du droit et de la santé",
 				"attachments": [
 					{
@@ -816,17 +838,23 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Leucémie chronique lymphocytaire à cellules B -- Dissertations universitaires",
-					"Leucémie lymphoïde chronique -- Thèses et écrits académiques",
-					"Lymphocytes B -- Dissertations universitaires",
-					"Lymphocytes B -- Thèses et écrits académiques",
-					"Lymphome malin non hodgkinien -- Dissertations universitaires"
-				],
-				"notes": [
 					{
-						"note": "<div><span>Publication autorisée par le jury</span></div>"
+						"tag": "Leucémie chronique lymphocytaire à cellules B -- Dissertation universitaire"
+					},
+					{
+						"tag": "Leucémie lymphoïde chronique"
+					},
+					{
+						"tag": "Lymphocytes B"
+					},
+					{
+						"tag": "Lymphocytes B -- Dissertation universitaire"
+					},
+					{
+						"tag": "Lymphome malin non hodgkinien -- Dissertation universitaire"
 					}
 				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]
@@ -845,15 +873,13 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2008",
+				"date": "impr. 2008",
 				"ISSN": "1359-0987",
 				"issue": "3",
 				"language": "anglais",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"pages": "515-534",
-				"place": "London, Royaume-Uni",
 				"publicationTitle": "Journal of the Royal Anthropological Institute",
-				"publisher": "Royal Anthropological Institute",
 				"shortTitle": "Mobile technology in the village",
 				"volume": "14",
 				"attachments": [
@@ -869,9 +895,15 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Communes rurales -- Et la technique -- Aspect social -- Inde",
-					"Inde -- Conditions sociales -- 20e siècle",
-					"Téléphonie mobile -- Aspect social -- Inde"
+					{
+						"tag": "Communes rurales -- Et la technique -- Aspect social -- Inde"
+					},
+					{
+						"tag": "Conditions sociales -- Inde -- 20e siècle"
+					},
+					{
+						"tag": "Téléphonie mobile -- Aspect social -- Inde"
+					}
 				],
 				"notes": [
 					{
@@ -901,14 +933,13 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2006",
-				"ISBN": "0-8153-4223-3",
+				"date": "cop. 2006",
 				"abstractNote": "Ensemble de 20 films permettant de découvrir les protagonistes de la découverte de la théorie cellulaire, l'évolution, la diversité, la structure et le fonctionnement des cellules. Ce DVD aborde aussi en images les recherches en cours dans des laboratoires internationaux et les débats que ces découvertes sur la cellule provoquent. Les films sont regroupés en 5 chapitres complétés de fiches informatives et de liens Internet.",
+				"distributor": "CNRS Images",
 				"language": "anglais",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
-				"place": "Meudon, France",
-				"publisher": "CNRS Images",
 				"runningTime": "180 min",
+				"url": "http://bioclips.com/dvd/index.html",
 				"attachments": [
 					{
 						"title": "Worldcat Link",
@@ -927,24 +958,52 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Biogenèse",
-					"Biologie cellulaire",
-					"Cell membranes",
-					"Cells",
-					"Cells -- Evolution",
-					"Cells -- Moral and ethical aspects",
-					"Cellules",
-					"Cellules -- Aspect moral",
-					"Cellules -- Évolution",
-					"Cytologie -- Recherche",
-					"Cytology -- Research",
-					"Membrane cellulaire",
-					"QH582.4",
-					"Ultrastructure (biologie)"
+					{
+						"tag": "Biogenèse des organelles"
+					},
+					{
+						"tag": "Biologie cellulaire"
+					},
+					{
+						"tag": "Cell membranes"
+					},
+					{
+						"tag": "Cells"
+					},
+					{
+						"tag": "Cells -- Evolution"
+					},
+					{
+						"tag": "Cells -- Moral and ethical aspects"
+					},
+					{
+						"tag": "Cellules"
+					},
+					{
+						"tag": "Cellules -- Aspect moral"
+					},
+					{
+						"tag": "Cellules -- Évolution"
+					},
+					{
+						"tag": "Cytologie -- Recherche"
+					},
+					{
+						"tag": "Cytology -- Research"
+					},
+					{
+						"tag": "Membrane cellulaire"
+					},
+					{
+						"tag": "QH582.4"
+					},
+					{
+						"tag": "Ultrastructure"
+					}
 				],
 				"notes": [
 					{
-						"note": "<div><span>Les différents films qui composent ce DVD sont réalisés avec des prises de vue réelles, ou des images microcinématographiques ou des images de synthèse, ou des images fixes tirées de livres. La bande son est essentiellement constituée de commentaires en voix off et d'interviews (les commentaires sont en anglais et les interviews sont en langue originales : anglais, français ou allemand, sous-titrée en anglais). - Discovering the cell : participation de Paul Nurse (Rockefeller university, New York), Claude Debru (ENS : Ecole normale supérieure, Paris) et Werner Franke (DKFZ : Deutsches Krebsforschungszentrum, Heidelberg) ; Membrane : participation de Kai Simons, Soizig Le Lay et Lucas Pelkmans (MPI-CBG : Max Planck institute of molecular cell biology and genetics, Dresden) ; Signals and calcium : participation de Christian Sardet et Alex Mc Dougall (CNRS / UPMC : Centre national de la recherche scientifique / Université Pierre et Marie Curie, Villefrance-sur-Mer) ; Membrane traffic : participation de Thierry Galli et Phillips Alberts (Inserm = Institut national de la santé et de la recherche médicale, Paris) ; Mitochondria : participation de Michael Duchen, Rémi Dumollard et Sean Davidson (UCL : University college of London) ; Microfilaments : participation de Cécile Gauthier Rouvière et Alexandre Philips (CNRS-CRBM : CNRS-Centre de recherche de biochimie macromoléculaire, Montpellier) ; Microtubules : participation de Johanna Höög, Philip Bastiaens et Jonne Helenius (EMBL : European molecular biology laboratory, Heidelberg) ; Centrosome : participation de Michel Bornens et Manuel Théry (CNRS-Institut Curie, Paris) ; Proteins : participation de Dino Moras et Natacha Rochel-Guiberteau (IGBMC : Institut de génétique et biologie moléculaire et cellulaire, Strasbourg) ; Nocleolus and nucleus : participation de Daniele Hernandez-Verdun, Pascal Rousset, Tanguy Lechertier (CNRS-UPMC / IJM : Institut Jacques Monod, Paris) ; The cell cycle : participation de Paul Nurse (Rockefeller university, New York) ; Mitosis and chromosomes : participation de Jan Ellenberg, Felipe Mora-Bermudez et Daniel Gerlich (EMBL, Heidelberg) ; Mitosis and spindle : participation de Eric Karsenti, Maiwen Caudron et François Nedelec (EMBL, Heidelberg) ; Cleavage : participation de Pierre Gönczy, Marie Delattre et Tu Nguyen Ngoc (Isrec : Institut suisse de recherche expérimentale sur le cancer, Lausanne) ; Cellules souches : participation de Göran Hermerén (EGE : European group on ethics in science and new technologies, Brussels) ; Cellules libres : participation de Jean-Jacques Kupiec (ENS, Paris) ; Cellules et évolution : participation de Paule Nurse (Rockefeller university, New York)</span></div><div><span>&nbsp;</span></div>"
+						"note": "<div><span>Les différents films qui composent ce DVD sont réalisés avec des prises de vue réelles, ou des images microcinématographiques ou des images de synthèse, ou des images fixes tirées de livres. La bande son est essentiellement constituée de commentaires en voix off et d'interviews (les commentaires sont en anglais et les interviews sont en langue originales : anglais, français ou allemand, sous-titrée en anglais). - Discovering the cell : participation de Paul Nurse (Rockefeller university, New York), Claude Debru (ENS : Ecole normale supérieure, Paris) et Werner Franke (DKFZ : Deutsches Krebsforschungszentrum, Heidelberg) ; Membrane : participation de Kai Simons, Soizig Le Lay et Lucas Pelkmans (MPI-CBG : Max Planck institute of molecular cell biology and genetics, Dresden) ; Signals and calcium : participation de Christian Sardet et Alex Mc Dougall (CNRS / UPMC : Centre national de la recherche scientifique / Université Pierre et Marie Curie, Villefrance-sur-Mer) ; Membrane traffic : participation de Thierry Galli et Phillips Alberts (Inserm = Institut national de la santé et de la recherche médicale, Paris) ; Mitochondria : participation de Michael Duchen, Rémi Dumollard et Sean Davidson (UCL : University college of London) ; Microfilaments : participation de Cécile Gauthier Rouvière et Alexandre Philips (CNRS-CRBM : CNRS-Centre de recherche de biochimie macromoléculaire, Montpellier) ; Microtubules : participation de Johanna Höög, Philip Bastiaens et Jonne Helenius (EMBL : European molecular biology laboratory, Heidelberg) ; Centrosome : participation de Michel Bornens et Manuel Théry (CNRS-Institut Curie, Paris) ; Proteins : participation de Dino Moras et Natacha Rochel-Guiberteau (IGBMC : Institut de génétique et biologie moléculaire et cellulaire, Strasbourg) ; Nocleolus and nucleus : participation de Daniele Hernandez-Verdun, Pascal Rousset, Tanguy Lechertier (CNRS-UPMC / IJM : Institut Jacques Monod, Paris) ; The cell cycle : participation de Paul Nurse (Rockefeller university, New York) ; Mitosis and chromosomes : participation de Jan Ellenberg, Felipe Mora-Bermudez et Daniel Gerlich (EMBL, Heidelberg) ; Mitosis and spindle : participation de Eric Karsenti, Maiwen Caudron et François Nedelec (EMBL, Heidelberg) ; Cleavage : participation de Pierre Gönczy, Marie Delattre et Tu Nguyen Ngoc (Isrec : Institut suisse de recherche expérimentale sur le cancer, Lausanne) ; Cellules souches : participation de Göran Hermerén (EGE : European group on ethics in science and new technologies, Brussels) ; Cellules libres : participation de Jean-Jacques Kupiec (ENS, Paris) ; Cellules et évolution : participation de Paule Nurse (Rockefeller university, New York)</span></div>"
 					}
 				],
 				"seeAlso": []
@@ -960,7 +1019,7 @@ var testCases = [
 				"title": "Wind and wave atlas of the Mediterranean sea",
 				"creators": [],
 				"date": "2004",
-				"ISBN": "2-11-095674-7",
+				"ISBN": "9782110956743",
 				"language": "anglais",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"publisher": "Western European Union, Western European armaments organisation research cell",
@@ -982,11 +1041,21 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Méditerranée (mer) -- Atlas",
-					"Météorologie maritime -- Méditerranée (mer) -- Atlas",
-					"Vagues -- Méditerranée (mer) -- Atlas",
-					"Vent de mer -- Méditerranée (mer) -- Atlas",
-					"Vents -- Méditerranée (mer) -- Atlas"
+					{
+						"tag": "Méditerranée (mer)"
+					},
+					{
+						"tag": "Météorologie maritime -- Méditerranée (mer)"
+					},
+					{
+						"tag": "Vagues -- Méditerranée (mer)"
+					},
+					{
+						"tag": "Vent de mer -- Méditerranée (mer)"
+					},
+					{
+						"tag": "Vents -- Méditerranée (mer)"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -1004,25 +1073,24 @@ var testCases = [
 					{
 						"firstName": "Ernest H.",
 						"lastName": "Sanders",
-						"creatorType": "author"
+						"creatorType": "editor"
 					},
 					{
 						"firstName": "Frank Llewellyn",
 						"lastName": "Harrison",
-						"creatorType": "author"
+						"creatorType": "editor"
 					},
 					{
-						"firstName": "Peter",
+						"firstName": "Peter M.",
 						"lastName": "Lefferts",
-						"creatorType": "author"
+						"creatorType": "editor"
 					}
 				],
 				"date": "1986",
+				"label": "Éditions de l'oiseau-lyre",
 				"language": "latin",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
-				"numPages": "243",
 				"place": "Monoco, Monaco",
-				"publisher": "Éditions de l'oiseau-lyre",
 				"attachments": [
 					{
 						"title": "Worldcat Link",
@@ -1041,12 +1109,16 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Messes (musique) -- Partitions",
-					"Motets -- Partitions"
+					{
+						"tag": "Messes (musique) -- Partitions"
+					},
+					{
+						"tag": "Motets -- Partitions"
+					}
 				],
 				"notes": [
 					{
-						"note": "<div><span>Modern notation. - \"Critical apparatus\": p. 174-243</span></div><div><span>&nbsp;</span></div>"
+						"note": "\n<div><span>Modern notation. - \"Critical apparatus\": p. 174-243</span></div>\n<div><span>&nbsp;</span></div>\n"
 					}
 				],
 				"seeAlso": []
@@ -1085,11 +1157,9 @@ var testCases = [
 				"date": "2012",
 				"ISSN": "1931-4361",
 				"issue": "1",
-				"libraryCatalog": "Library Catalog - gso.gbv.de",
+				"libraryCatalog": "Library Catalog - kxp.k10plus.de",
 				"pages": "88-107",
-				"place": "Walla Walla, Wash.",
-				"publicationTitle": "Journal of wine economics",
-				"publisher": "AAWE",
+				"publicationTitle": "Journal of wine economics / American Association of Wine Economists",
 				"volume": "7",
 				"attachments": [
 					{
@@ -1121,30 +1191,13 @@ var testCases = [
 						"firstName": "Carl",
 						"lastName": "Phillips",
 						"creatorType": "author"
-					},
-					{
-						"firstName": "Marion",
-						"lastName": "Gibson",
-						"creatorType": "editor"
-					},
-					{
-						"firstName": "Shelley",
-						"lastName": "Trower",
-						"creatorType": "editor"
-					},
-					{
-						"firstName": "Garry",
-						"lastName": "Tregidga",
-						"creatorType": "editor"
 					}
 				],
 				"date": "2013",
-				"ISBN": "978-0-415-62868-6, 978-0-415-62869-3, 978-0-203-08018-4",
-				"bookTitle": "Mysticism, myth and Celtic identity",
-				"libraryCatalog": "Library Catalog - gso.gbv.de",
+				"ISBN": "9780415628686 9780415628693 9780203080184",
+				"bookTitle": "Mysticism, myth and Celtic identity / Gibson, Marion *1970-*",
+				"libraryCatalog": "Library Catalog - kxp.k10plus.de",
 				"pages": "70-83",
-				"place": "London",
-				"publisher": "Routledge ,",
 				"shortTitle": "'The truth against the world'",
 				"attachments": [
 					{
@@ -1190,25 +1243,22 @@ var testCases = [
 					{
 						"firstName": "Wilfried",
 						"lastName": "Henze",
-						"creatorType": "author"
+						"creatorType": "editor"
 					},
 					{
 						"firstName": "Helmut",
 						"lastName": "Tschöke",
-						"creatorType": "author"
+						"creatorType": "editor"
 					}
 				],
 				"date": "2013",
-				"ISBN": "978-3-642-33832-8",
-				"journalAbbreviation": "Lecture Notes in Electrical Engineering",
-				"libraryCatalog": "Library Catalog - gso.gbv.de",
+				"ISBN": "9783642338328",
+				"bookTitle": "Proceedings of the FISITA 2012 World Automotive Congress ; Vol. 13:Noise, vibration and harshness (NVH) / Zhongguo qi che gong cheng xue hui",
+				"libraryCatalog": "Library Catalog - kxp.k10plus.de",
 				"pages": "291-304",
-				"place": "Berlin",
-				"publicationTitle": "Proceedings of the FISITA 2012 World Automotive Congress; Vol. 13: Noise, vibration and harshness (NVH)",
-				"publisher": "Springer Berlin",
 				"series": "Lecture notes in electrical engineering",
 				"seriesNumber": "201",
-				"seriesTitle": "Lecture notes in electrical engineering",
+				"url": "http://dx.doi.org/10.1007/978-3-642-33832-8_23",
 				"attachments": [
 					{
 						"title": "Link to Library Catalog Entry",
@@ -1237,22 +1287,16 @@ var testCases = [
 				"creators": [
 					{
 						"lastName": "Organisation mondiale de la santé",
-						"creatorType": "author",
-						"fieldMode": true
-					},
-					{
-						"lastName": "Congrès",
-						"creatorType": "author",
+						"creatorType": "editor",
 						"fieldMode": true
 					}
 				],
-				"date": "1992-1993",
+				"date": "1992",
 				"ISSN": "0003-9578",
 				"issue": "1/4",
 				"language": "français",
 				"libraryCatalog": "Library Catalog - www.sudoc.abes.fr",
 				"pages": "3-232",
-				"place": "Belgique",
 				"publicationTitle": "Archives belges de médecine sociale, hygiène, médecine du travail et médecine légale",
 				"volume": "51",
 				"attachments": [
@@ -1273,108 +1317,14 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Famille -- Actes de congrès",
-					"Santé publique -- Actes de congrès"
+					{
+						"tag": "Famille"
+					},
+					{
+						"tag": "Santé publique"
+					}
 				],
 				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://catalogue.rug.nl/DB=1/XMLPRS=Y/PPN?PPN=33112484X",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "Naar een nieuwe 'onderwijsvrede': de onderhandelingen tussen kardinaal Van Roey en de Duitse bezetter over de toekomst van het vrij katholiek onderwijs, 1942-1943",
-				"creators": [
-					{
-						"firstName": "Sarah Van",
-						"lastName": "Ruyskensvelde",
-						"creatorType": "author"
-					}
-				],
-				"date": "2010",
-				"ISSN": "0035-0869",
-				"issue": "4",
-				"libraryCatalog": "Library Catalog - catalogue.rug.nl",
-				"pages": "603-643",
-				"publicationTitle": "Revue belge d'histoire contemporaine = Belgisch tijdschrift voor nieuwste geschiedenis = Belgian review for contemporary history",
-				"shortTitle": "Naar een nieuwe 'onderwijsvrede'",
-				"volume": "40",
-				"attachments": [
-					{
-						"title": "Link to Library Catalog Entry",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "Library Catalog Entry Snapshot",
-						"mimeType": "text/html",
-						"snapshot": true
-					}
-				],
-				"tags": [
-					"(GTR) Belgie",
-					"(GTR) Conflicten",
-					"(GTR) Katholiek onderwijs",
-					"(GTR) Tweede Wereldoorlog",
-					"(GTR) Vrijheid van onderwijs"
-				],
-				"notes": [
-					{
-						"note": "<div><span>Met lit. opg</span></div><div><span>Met samenvattingen in het Engels en Frans</span></div>"
-					}
-				],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://catalogue.rug.nl/DB=1/XMLPRS=Y/PPN?PPN=339552697",
-		"items": [
-			{
-				"itemType": "film",
-				"title": "Medianeras",
-				"creators": [
-					{
-						"firstName": "Gustavo",
-						"lastName": "Taretto",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Pilar López de",
-						"lastName": "Ayala",
-						"creatorType": "author"
-					}
-				],
-				"date": "2012",
-				"libraryCatalog": "Library Catalog - catalogue.rug.nl",
-				"place": "Amsterdam",
-				"publisher": "Homescreen",
-				"runningTime": "92 min",
-				"attachments": [
-					{
-						"title": "Link to Library Catalog Entry",
-						"mimeType": "text/html",
-						"snapshot": false
-					},
-					{
-						"title": "Library Catalog Entry Snapshot",
-						"mimeType": "text/html",
-						"snapshot": true
-					}
-				],
-				"tags": [
-					"(GTR) Argentinië"
-				],
-				"notes": [
-					{
-						"note": "<div><span>Spaans gesproken, Nederlands en Frans ondertiteld</span></div>"
-					}
-				],
 				"seeAlso": []
 			}
 		]
@@ -1441,7 +1391,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://opac.tib.uni-hannover.de/DB=1/XMLPRS=N/PPN?PPN=620088028",
+		"url": "http://opac.tib.eu/DB=1/XMLPRS=N/PPN?PPN=620088028",
 		"items": [
 			{
 				"itemType": "book",
@@ -1454,11 +1404,10 @@ var testCases = [
 					}
 				],
 				"date": "2009",
-				"ISBN": "978-3-941300-14-9",
+				"ISBN": "9783941300149",
 				"callNumber": "F 10 B 2134",
-				"libraryCatalog": "Library Catalog - opac.tib.uni-hannover.de",
+				"libraryCatalog": "Library Catalog - opac.tib.eu",
 				"numPages": "140",
-				"pages": "140",
 				"place": "Remagen",
 				"publisher": "Kessel",
 				"shortTitle": "Phönix auf Asche",
@@ -1475,7 +1424,9 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Waldsterben / Schadstoffimmission / Dübener Heide / Bitterfeld <Region>"
+					{
+						"tag": "Waldsterben / Schadstoffimmission / Dübener Heide / Bitterfeld <Region>"
+					}
 				],
 				"notes": [
 					{
@@ -1495,23 +1446,21 @@ var testCases = [
 				"title": "Das war das Waldsterben!",
 				"creators": [
 					{
-						"firstName": "Elmar",
 						"lastName": "Klein",
-						"creatorType": "author"
+						"creatorType": "author",
+						"firstName": "Elmar"
 					}
 				],
 				"date": "2008",
-				"ISBN": "978-3-7930-9526-2",
+				"ISBN": "9783793095262",
 				"callNumber": "48 Kle",
 				"edition": "1",
 				"libraryCatalog": "Library Catalog - opac.sub.uni-goettingen.de",
 				"numPages": "164",
-				"pages": "164",
-				"place": "Freiburg im Breisgau [u.a.]",
+				"place": "Freiburg i. Br[eisgau]",
 				"publisher": "Rombach",
-				"series": "Rombach Wissenschaft Ökologie",
+				"series": "Rombach-Wissenschaften. Reihe Ökologie. - Freiburg, Br. : Rombach, 1992- ; ZDB-ID: 1139339-7",
 				"seriesNumber": "8",
-				"seriesTitle": "Rombach Wissenschaft Ökologie",
 				"attachments": [
 					{
 						"title": "Link to Library Catalog Entry",
@@ -1525,9 +1474,15 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"*Baumkrankheit",
-					"*Waldsterben",
-					"*Waldsterben / Geschichte"
+					{
+						"tag": "*Baumkrankheit"
+					},
+					{
+						"tag": "*Waldsterben"
+					},
+					{
+						"tag": "*Waldsterben / Geschichte"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -1559,11 +1514,11 @@ var testCases = [
 					}
 				],
 				"date": "1990",
-				"ISBN": "3-923120-26-5",
+				"ISBN": "9783923120260",
+				"abstractNote": "Bettina Reckter, Rolf H. Simen, Karl-Heinz Preuß (Hrsg.): Geschichten, die die Forschung schreibt. Ein Umweltlesebuch des Deutschen Forschungsdienstes. Verlag Deutscher Forschungsdienst, Bonn-Bad Godesberg 1990, 320 Seiten, 29,80 Mark",
 				"callNumber": "CL 13 : IfW13 40 W 2",
 				"libraryCatalog": "Library Catalog - lhclz.gbv.de",
 				"numPages": "319",
-				"pages": "319",
 				"place": "Bonn - Bad Godesberg",
 				"publisher": "Verlag Deutscher Forschungsdienst",
 				"shortTitle": "Geschichten, die die Forschung schreibt",
@@ -1580,28 +1535,72 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Algenpest",
-					"Aufsatzsammlung",
-					"Aufsatzsammlung / Umweltschutz",
-					"Bienen",
-					"Gewässerverschmutzung",
-					"Gleichgewicht",
-					"Lebensräume",
-					"Mülldeponie",
-					"Perlmuscheln",
-					"Saurer Regen",
-					"Schmetterlinge",
-					"Sonnenenergie",
-					"Süßwasserfische",
-					"Tiere",
-					"Trinkwasser",
-					"Umweltgifte",
-					"Umweltschaden",
-					"Umweltschutz",
-					"Umweltsignale",
-					"Vogelarten",
-					"Waldsterben",
-					"Ökomonie"
+					{
+						"tag": "Algenpest"
+					},
+					{
+						"tag": "Aufsatzsammlung"
+					},
+					{
+						"tag": "Aufsatzsammlung / Umweltschutz"
+					},
+					{
+						"tag": "Bienen"
+					},
+					{
+						"tag": "Gewässerverschmutzung"
+					},
+					{
+						"tag": "Gleichgewicht"
+					},
+					{
+						"tag": "Lebensräume"
+					},
+					{
+						"tag": "Mülldeponie"
+					},
+					{
+						"tag": "Perlmuscheln"
+					},
+					{
+						"tag": "Saurer Regen"
+					},
+					{
+						"tag": "Schmetterlinge"
+					},
+					{
+						"tag": "Sonnenenergie"
+					},
+					{
+						"tag": "Süßwasserfische"
+					},
+					{
+						"tag": "Tiere"
+					},
+					{
+						"tag": "Trinkwasser"
+					},
+					{
+						"tag": "Umweltgifte"
+					},
+					{
+						"tag": "Umweltschaden"
+					},
+					{
+						"tag": "Umweltschutz"
+					},
+					{
+						"tag": "Umweltsignale"
+					},
+					{
+						"tag": "Vogelarten"
+					},
+					{
+						"tag": "Waldsterben"
+					},
+					{
+						"tag": "Ökomonie"
+					}
 				],
 				"notes": [
 					{
@@ -1621,8 +1620,13 @@ var testCases = [
 				"title": "Borges por el mismo",
 				"creators": [
 					{
+						"lastName": "Rodríguez Monegal",
+						"creatorType": "author",
+						"firstName": "Emir"
+					},
+					{
 						"firstName": "Emir",
-						"lastName": "Rodríguez Monegal",
+						"lastName": "Rodri%CC%81guez Monegal",
 						"creatorType": "author"
 					},
 					{
@@ -1632,14 +1636,13 @@ var testCases = [
 					}
 				],
 				"date": "1984",
-				"ISBN": "84-7222-967-X",
+				"ISBN": "9788472229679",
+				"edition": "1. ed",
 				"libraryCatalog": "Library Catalog - swb.bsz-bw.de",
 				"numPages": "255",
-				"pages": "255",
 				"place": "Barcelona",
 				"publisher": "Ed. laia",
 				"series": "Laia literatura",
-				"seriesTitle": "Laia literatura",
 				"attachments": [
 					{
 						"title": "Link to Library Catalog Entry",
@@ -1653,11 +1656,7 @@ var testCases = [
 					}
 				],
 				"tags": [],
-				"notes": [
-					{
-						"note": "<div>Enth. Werke von und über Borges</div>"
-					}
-				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]
@@ -1781,7 +1780,7 @@ var testCases = [
 				"ISSN": "1515-4017",
 				"libraryCatalog": "Library Catalog - lhiai.gbv.de",
 				"pages": "61-71",
-				"publicationTitle": "Proa : en las letras y en las artes",
+				"publicationTitle": "Proa",
 				"volume": "83",
 				"attachments": [
 					{
@@ -1877,12 +1876,12 @@ var testCases = [
 					}
 				],
 				"date": "2012",
-				"ISBN": "978-85-314-1374-2, 85-314-1374-5",
-				"libraryCatalog": "Library Catalog - gso.gbv.de",
+				"ISBN": "9788531413742",
+				"libraryCatalog": "Library Catalog - kxp.k10plus.de",
 				"numPages": "397",
-				"pages": "397",
 				"place": "São Paulo, SP, Brasil",
 				"publisher": "EDUSP",
+				"url": "http://www.gbv.de/dms/spk/iai/toc/770481450.pdf",
 				"attachments": [
 					{
 						"title": "Link to Library Catalog Entry",
@@ -1896,9 +1895,9 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Brazil -- Religion",
-					"Religious pluralism -- Brazil",
-					"Spiritualism -- Brazil -- History"
+					{
+						"tag": "Brazil -- Religious life and customs"
+					}
 				],
 				"notes": [
 					{
@@ -1915,7 +1914,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "book",
-				"title": "Conférences sur l'administration et le droit administratif faites à l'Ecole impériale des ponts et chaussées. Tome premier",
+				"title": "Conférences sur l'administration et le droit administratif faites à l'Ecole impériale des ponts et chaussées",
 				"creators": [
 					{
 						"firstName": "Léon",
@@ -1976,7 +1975,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "book",
-				"title": "Traité de la juridiction administrative et des recours contentieux",
+				"title": "Traité de la juridiction administrative et des recours contentieux",
 				"creators": [
 					{
 						"firstName": "Édouard",
@@ -1984,7 +1983,7 @@ var testCases = [
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Roland",
+						"firstName": "Roland Préfacier",
 						"lastName": "Drago",
 						"creatorType": "author"
 					}
@@ -2098,6 +2097,278 @@ var testCases = [
 						"note": "<div>\n<span>Table des matières disponible en ligne (</span><span><a class=\"\n\t\t\tlink_gen\n\t\t    \" target=\"\" href=\"http://catdir.loc.gov/catdir/toc/casalini11/13192019.pdf\">http://catdir.loc.gov/catdir/toc/casalini11/13192019.pdf</a></span><span>)</span>\n</div>"
 					}
 				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://stabikat.de/DB=1/XMLPRS=N/PPN?PPN=1748358820",
+		"items": [
+			{
+				"itemType": "webpage",
+				"title": "Modern and contemporary Taiwanese philosophy: traditional foundations and new developments",
+				"creators": [],
+				"date": "2021",
+				"abstractNote": "This collection contains 13 essays on modern and contemporary Taiwanese philosophy, written by outstanding scholars working in this field. It highlights the importance of Taiwanese philosophy in the second half of the 20th century. While the Chinese conceptual tradition (especially Confucianism) fell out of favor from the 1950s onwards and was often banned or at least severely criticized on the mainland, Taiwanese philosophers constantly strove to preserve and develop it. Many of them tried to modernize their own traditions through dialogs with Western thought, especially with the ideas of the European Enlightenment. However, it was not only about preserving tradition; in the second half of the 20th century, several complex and coherent philosophical systems emerged in Taiwan. The creation of these discourses is evidence of the great creativity and innovative power of many Taiwanese theorists, whose work is still largely unknown in the Western world.Intro -- Table of Contents -- Acknowledgements -- Editor's Foreword -- Introduction -- Modern and Contemporary Confucianism -- The Problem of \"Inner Sageliness and Outer Kingliness\" Revisited -- A Debate on Confucian Orthodoxy in Contemporary Taiwanese Confucian Thought -- A Phenomenological Interpretation of Mou Zongsan's Use of \"Transcendence\" and \"Immanence\" -- Modern Confucianism and the Methodology of Chinese Aesthetics -- Research on Daoist Philosophy -- Laozi's View of Presence and Absence, Movement and Stillness, and Essence and Function -- Characteristics of Laozi's \"Complementary Opposition\" Thought Pattern -- A General Survey of Taiwanese Studies on the Philosophy of the Wei-Jin Period in the Last Fifty Years of the 20th Century -- Logic and Methodology -- Qinghua School of Logic and the Origins of Taiwanese Studies in Modern Logic -- Discussing the Functions and Limitations of Conveying \"Concepts\" in Philosophical Thinking -- Taiwanese Philosophy from the East Asian and Global Perspective -- How is it Possible to \"Think from the Point of View of East Asia?\" -- Between Philosophy and Religion -- The Global Significance of Chinese/Taiwanese Philosophy in a Project -- Index of Special Terms and Proper Names.",
+				"shortTitle": "Modern and contemporary Taiwanese philosophy",
+				"url": "http://erf.sbb.spk-berlin.de/han/872773256/ebookcentral.proquest.com/lib/staatsbibliothek-berlin/detail.action?docID=6416045",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [
+					{
+						"tag": "*Electronic books"
+					},
+					{
+						"tag": "*Taiwan / Philosophie"
+					}
+				],
+				"notes": [
+					{
+						"note": "<div>Description based on publisher supplied metadata and other sources.</div>"
+					},
+					{
+						"note": "<div>Einzelnutzerlizenz</div>"
+					}
+				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://swb.bsz-bw.de/DB=2.1/PPNSET?PPN=1703871782",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Calculation of the electronic, nuclear, rotational, and vibrational stopping cross sections for H atoms irradiation on H2, N2 and O2 gas targets at low collision energies",
+				"creators": [
+					{
+						"firstName": "Abdel Ghafour",
+						"lastName": "El Hachimi",
+						"creatorType": "editor"
+					}
+				],
+				"date": "2020",
+				"ISSN": "1361-6455",
+				"issue": "13",
+				"libraryCatalog": "Library Catalog - swb.bsz-bw.de",
+				"publicationTitle": "Journal of physics  B",
+				"url": "http://dx.doi.org/10.1088/1361-6455/ab8834",
+				"volume": "53",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [
+					{
+						"note": "<div>Gesehen am 06.07.2020. - Im Titel ist die Zahl \"2\" jeweils tiefgestellt</div>"
+					}
+				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://opac.tib.eu/DB=1/XMLPRS=N/PPN?PPN=1749375400",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "An investigation into WEEE arising and not arising in Ireland (EEE2WEEE): (2017-RE-MS-9)",
+				"creators": [
+					{
+						"firstName": "Yvonne",
+						"creatorType": "author",
+						"lastName": "Ryan-Fogarty"
+					}
+				],
+				"date": "February 2021",
+				"ISBN": "9781840959819",
+				"edition": "Online version",
+				"libraryCatalog": "Library Catalog - opac.tib.eu",
+				"place": "Johnstown Castle, Co. Wexford, Ireland",
+				"publisher": "Environmental Protection Agency",
+				"series": "EPA Research report. - Johnstown Castle, Co. Wexford, Ireland : Environmental Protection Agency, 2014- ; ZDB-ID: 3045798-1",
+				"seriesNumber": "366",
+				"shortTitle": "An investigation into WEEE arising and not arising in Ireland (EEE2WEEE)",
+				"url": "https://edocs.tib.eu/files/e01mr21/1749375400.pdf",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [
+					{
+						"note": "<div>WEEE = Waste Electrical and Electronic Equipment</div><div>Literaturverzeichnis: Seite 39-43</div><div>Archivierung/Langzeitarchivierung gewährleistet ; TIB Hannover</div>"
+					},
+					{
+						"note": "<div>Es gilt deutsches Urheberrecht. Das Werk bzw. der Inhalt darf zum eigenen Gebrauch kostenfrei heruntergeladen, konsumiert, gespeichert oder ausgedruckt, aber nicht im Internet bereitgestellt oder an Außenstehende weitergegeben werden. - German copyright law applies. The work or content may be downloaded, consumed, stored or printed for your own use but it may not be distributed via the internet or passed on to external parties.</div>"
+					}
+				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://opac.sub.uni-goettingen.de/DB=1/XMLPRS=N/PPN?PPN=174526969X",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "12 Strokes: A Case-Based Guide to Acute Ischemic Stroke Management",
+				"creators": [
+					{
+						"firstName": "Ferdinand K.",
+						"creatorType": "author",
+						"lastName": "Hui"
+					}
+				],
+				"date": "2021",
+				"ISBN": "9783030568573",
+				"libraryCatalog": "Library Catalog - opac.sub.uni-goettingen.de",
+				"place": "Cham",
+				"publisher": "Springer International Publishing AG",
+				"shortTitle": "12 Strokes",
+				"url": "http://han.sub.uni-goettingen.de/han/ebookcentral1/ebookcentral.proquest.com/lib/subgoettingen/detail.action?docID=6454869",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [
+					{
+						"tag": "Electronic books"
+					}
+				],
+				"notes": [
+					{
+						"note": "<div>Description based on publisher supplied metadata and other sources.</div>"
+					},
+					{
+						"note": "<div>Im Campus-Netz sowie für Angehörige der Universität Göttingen auch extern über Authentifizierungsmodul zugänglich. Vervielfältigungen (z.B. Kopien, Downloads) sind nur von einzelnen Kapiteln oder Seiten und nur zum eigenen wissenschaftlichen Gebrauch erlaubt. Keine Weitergabe an Dritte. Kein systematisches Downloaden durch Robots.</div>"
+					}
+				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://lhclz.gbv.de/DB=1/XMLPRS=N/PPN?PPN=839046855",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Customer Value Generation in Banking: The Zurich Model of Customer-Centricity",
+				"creators": [
+					{
+						"firstName": "Bernhard",
+						"lastName": "Koye",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Axel",
+						"lastName": "Liebetrau",
+						"creatorType": "author"
+					}
+				],
+				"date": "2024",
+				"libraryCatalog": "Library Catalog - lhclz.gbv.de",
+				"numPages": "209",
+				"place": "Cham",
+				"publisher": "Springer International Publishing",
+				"series": "Management for Professionals",
+				"shortTitle": "Customer Value Generation in Banking",
+				"url": "https://ebookcentral.proquest.com/lib/tuclausthal-ebooks/detail.action?docID=3567812",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [
+					{
+						"tag": "Electronic books"
+					}
+				],
+				"notes": [
+					{
+						"note": "<div>Description based upon print version of record</div>"
+					},
+					{
+						"note": "<div>Campusweiter Zugriff. - Vervielfältigungen (z.B. Kopien, Downloads) sind nur von einzelnen Kapiteln oder Seiten und nur zum eigenen wissenschaftlichen Gebrauch erlaubt. Keine Weitergabe an Dritte. Kein systematisches Downloaden durch Robots.</div>"
+					}
+				],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=318490412",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Daten- und Identitätsschutz in Cloud Computing, E-Government und E-Commerce",
+				"creators": [],
+				"ISBN": "9783642301025",
+				"edition": "1st ed. 2012",
+				"libraryCatalog": "Library Catalog - cbsopac.rz.uni-frankfurt.de",
+				"url": "https://doi.org/10.1007/978-3-642-30102-5",
+				"attachments": [
+					{
+						"title": "Link to Library Catalog Entry",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Library Catalog Entry Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [],
 				"seeAlso": []
 			}
 		]

--- a/Library Catalog (PICA).js
+++ b/Library Catalog (PICA).js
@@ -578,13 +578,13 @@ function scrape(doc, url) {
 				}
 				break;
 
-			case 'links zum titel': // gso.gbv.de
-			case 'volltext': // stabikat.de
-			case 'link zum volltext': // swb.bsz-bw.de
-			case 'link': // opac.tib.eu opac.sub.uni-goettingen.de lhclz.gbv.de
-			case 'zugang': // cbsopac.rz.uni-frankfurt.de
-			case 'accès en ligne': // sudoc.abes.fr
-				///Some time link are inside the third cell : https://kxp.k10plus.de/DB=2.1/DB=2.1/PPNSET?PPN=600530787
+			case 'links zum titel':
+			case 'volltext':
+			case 'link zum volltext':
+			case 'link':
+			case 'zugang':
+			case 'accès en ligne':
+				// Some time links are inside the third cell : https://kxp.k10plus.de/DB=2.1/DB=2.1/PPNSET?PPN=600530787
 				url = doc.evaluate('./td[3]//a | ./td[2]//a', tableRow, null, XPathResult.ANY_TYPE, null).iterateNext();
 				newItem.url = url;
 				break;


### PR DESCRIPTION
This PR adds links to online document for PICA based catalogs. Links are stored in the url field of Zotero.

__About tests :__

* For links extraction : I added tests for all PICA catalogs already cited in the tests.
* When possible I updated the tests. I keep three of them untouched because of errors (these error are not related to link extraction but to UI changes) :
http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=318490412
http://gso.gbv.de/DB=2.1/PPNSET?PPN=768059798
* I deleted tests for catalogue.rug.nl which seems not  to be active anymore. It's looks like they're using a new catalog system (https://rug.on.worldcat.org/)

Best regards