### PR TITLE
Map Bibtex "@misc" to Document type

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -226,7 +226,7 @@ var bibtex2zoteroTypeMap = {
 	"booklet":"book",
 	"manual":"book",
 	"mastersthesis":"thesis",
-	"misc":"book",
+	"misc":"document",
 	"proceedings":"book",
 	"online":"webpage",
 	// alias for online from BibLaTeX:


### PR DESCRIPTION
Book is certainly the wrong type for a "misc" bibtex item, as the Bibtex item (whatever it actually is) would have had "book" or "booklet" or "manual" type if it were truly a book. Since Zotero has a "miscellaneous" type, why not use it?