### PR TITLE
Embedded Metadata: Strip irrelevant tags in byline

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-03-07 18:58:39"
+	"lastUpdated": "2021-05-26 00:42:27"
 }
 
 /*
@@ -790,6 +790,17 @@ function getAuthorFromByline(doc, newItem) {
 	}
 
 	if (actualByline) {
+		// are any of these actual likely to appear in the real world?
+		// well, no, but things happen:
+		//   https://github.com/zotero/translators/issues/2001
+		let irrelevantTags = 'time, button, textarea, script';
+		if (actualByline.querySelector(irrelevantTags)) {
+			actualByline = actualByline.cloneNode(true);
+			for (let child of actualByline.querySelectorAll(irrelevantTags)) {
+				child.parentNode.removeChild(child);
+			}
+		}
+		
 		byline = ZU.trimInternal(actualByline.textContent);
 		Z.debug("Extracting author(s) from byline: " + byline);
 		var li = actualByline.getElementsByTagName('li');


### PR DESCRIPTION
Fixes #2001. We could potentially add more tags to the list and apply this transformation to more fields, but this is a start and it fixes the case that the bug report ran into.