### PR TITLE
CI: Check deleted.txt and lint even if earlier steps fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Check deleted.txt
         run: ./checkDeletedTxt.sh
         working-directory: .ci
+        if: ${{ success() || failure() }}
       
       - name: Lint
         run: ./lint.sh
         working-directory: .ci
+        if: ${{ success() || failure() }}


### PR DESCRIPTION
Unless your `if:` expression contains either `success()` or `failure()`, GitHub will default to running only on success. We probably can't run tests if the setup steps fail, but we can usually still lint and check deleted.txt even if tests fail. It's nice to get as much information as possible in one CI run when making a PR.