### PR TITLE
GitHub: Cover all repo pages, un-break URL, license, and search

### DIFF
--- a/GitHub.js
+++ b/GitHub.js
@@ -3,6 +3,7 @@
 	"label": "GitHub",
 	"creator": "Martin Fenner, Philipp Zumstein",
 	"target": "^https?://(www\\.)?github\\.com/[^/]+/[^/]+",
+	"target": "^https?://(www\\.)?github\\.com/([^/]+/[^/]+|search\\?)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
@@ -47,7 +48,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//*[contains(@class, "repo-list-item")]//h3/a');
+	var rows = doc.querySelectorAll('.repo-list-item .f4 a');
 	for (var i = 0; i < rows.length; i++) {
 		var href = rows[i].href;
 		var title = ZU.trimInternal(rows[i].textContent);

--- a/GitHub.js
+++ b/GitHub.js
@@ -151,9 +151,9 @@ var testCases = [
 				"itemType": "computerProgram",
 				"title": "zotero/zotero",
 				"creators": [],
-				"date": "2019-08-29T02:15:36Z",
+				"date": "2021-05-25T16:50:57Z",
 				"abstractNote": "Zotero is a free, easy-to-use tool to help you collect, organize, cite, and share your research sources.",
-				"company": "zotero",
+				"company": "Zotero",
 				"extra": "original-date: 2011-10-27T07:46:48Z",
 				"libraryCatalog": "GitHub",
 				"programmingLanguage": "JavaScript",
@@ -178,7 +178,7 @@ var testCases = [
 				"itemType": "computerProgram",
 				"title": "datacite/schema",
 				"creators": [],
-				"date": "2019-08-16T13:21:08Z",
+				"date": "2021-05-25T20:33:01Z",
 				"abstractNote": "DataCite Metadata Schema Repository. Contribute to datacite/schema development by creating an account on GitHub.",
 				"company": "DataCite",
 				"extra": "original-date: 2011-04-13T07:08:41Z",
@@ -206,7 +206,7 @@ var testCases = [
 						"creatorType": "programmer"
 					}
 				],
-				"date": "2019-08-23T12:32:51Z",
+				"date": "2021-05-26T10:08:22Z",
 				"abstractNote": "OCR engine for all the languages. Contribute to mittagessen/kraken development by creating an account on GitHub.",
 				"extra": "original-date: 2015-05-19T09:24:38Z",
 				"libraryCatalog": "GitHub",
@@ -250,7 +250,7 @@ var testCases = [
 						"creatorType": "programmer"
 					}
 				],
-				"date": "2019-07-12T17:57:05Z",
+				"date": "2021-03-20T15:33:50Z",
 				"abstractNote": "Zotero extension for creating Zotero to CSL item type and field mappings.",
 				"extra": "original-date: 2012-05-20T07:53:58Z",
 				"libraryCatalog": "GitHub",

--- a/GitHub.js
+++ b/GitHub.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-05-27 06:08:33"
+	"lastUpdated": "2021-05-27 15:22:04"
 }
 
 /**
@@ -94,7 +94,13 @@ function scrape(doc, url) {
 		// long-term, but for now, let's just grab the user-facing permalink
 		let permalink = attr(doc, '.js-permalink-shortcut', 'href');
 		if (permalink) {
-			item.url = 'https://' + doc.location.host + permalink;
+			item.url = 'https://github.com' + permalink;
+		}
+		else {
+			let clipboardCopyPermalink = attr(doc, '#blob-more-options-details clipboard-copy', 'value');
+			if (clipboardCopyPermalink) {
+				item.url = clipboardCopyPermalink;
+			}
 		}
 	}
 	item.title = ZU.xpathText(doc, '//meta[@property="og:title"]/@content');

--- a/GitHub.js
+++ b/GitHub.js
@@ -2,7 +2,6 @@
 	"translatorID": "a7747ba7-42c6-4a22-9415-1dafae6262a9",
 	"label": "GitHub",
 	"creator": "Martin Fenner, Philipp Zumstein",
-	"target": "^https?://(www\\.)?github\\.com/[^/]+/[^/]+",
 	"target": "^https?://(www\\.)?github\\.com/([^/]+/[^/]+|search\\?)",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -10,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-05-26 17:53:36"
+	"lastUpdated": "2021-05-27 06:08:33"
 }
 
 /**
@@ -99,7 +98,8 @@ function scrape(doc, url) {
 		}
 	}
 	item.title = ZU.xpathText(doc, '//meta[@property="og:title"]/@content');
-	item.abstractNote = ZU.xpathText(doc, '//meta[@property="og:description"]/@content').split(' - ')[0];
+	item.abstractNote = ZU.xpathText(doc, '//meta[@property="og:description"]/@content').split(' - ')[0]
+		.replace(` Contribute to ${repo} development by creating an account on GitHub.`, '');
 	item.libraryCatalog = "GitHub";
 	var topics = doc.getElementsByClassName('topic-tag');
 	for (var i = 0; i < topics.length; i++) {
@@ -124,6 +124,8 @@ function scrape(doc, url) {
 		if (json.license && json.license.spdx_id != "NOASSERTION") {
 			item.rights = json.license.spdx_id;
 		}
+		item.abstractNote = json.description;
+		// always the best source, so use it if we can get it
 
 		ZU.doGet(apiUrl + "users/" + owner, function (user) {
 			var jsonUser = JSON.parse(user);
@@ -179,7 +181,7 @@ var testCases = [
 				"title": "datacite/schema",
 				"creators": [],
 				"date": "2021-05-25T20:33:01Z",
-				"abstractNote": "DataCite Metadata Schema Repository. Contribute to datacite/schema development by creating an account on GitHub.",
+				"abstractNote": "DataCite Metadata Schema Repository",
 				"company": "DataCite",
 				"extra": "original-date: 2011-04-13T07:08:41Z",
 				"libraryCatalog": "GitHub",
@@ -207,7 +209,7 @@ var testCases = [
 					}
 				],
 				"date": "2021-05-26T10:08:22Z",
-				"abstractNote": "OCR engine for all the languages. Contribute to mittagessen/kraken development by creating an account on GitHub.",
+				"abstractNote": "OCR engine for all the languages",
 				"extra": "original-date: 2015-05-19T09:24:38Z",
 				"libraryCatalog": "GitHub",
 				"programmingLanguage": "Python",
@@ -271,13 +273,13 @@ var testCases = [
 				"itemType": "computerProgram",
 				"title": "zotero/translators",
 				"creators": [],
-				"date": "2021-05-26T17:17:38Z",
-				"abstractNote": "Zotero Translators. Contribute to zotero/translators development by creating an account on GitHub.",
+				"date": "2021-05-27T00:08:19Z",
+				"abstractNote": "Zotero Translators",
 				"company": "Zotero",
 				"extra": "original-date: 2011-07-03T17:40:38Z",
 				"libraryCatalog": "GitHub",
 				"programmingLanguage": "JavaScript",
-				"url": "https://github.com/zotero/translators/blob/a913f0c31c61770abe24b4726c76582db61a46e0/GitHub.js",
+				"url": "https://github.com/zotero/translators/blob/5de63ff6404fb439ac9c66ef26af057804b2e2fa/GitHub.js",
 				"attachments": [],
 				"tags": [],
 				"notes": [],


### PR DESCRIPTION
Fixes #2390