### PR TITLE
Snapshot added to translator for Heise

### DIFF
--- a/Heise.js
+++ b/Heise.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "54c3bec7-c1bc-4ffa-b103-53759845b6c4",
 	"label": "Heise",
-	"creator": "optiprime",
+	"creator": "optiprime, ApoB-100",
 	"target": "^https?://www\\.heise\\.de/(suche|select)/",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -9,14 +9,14 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2021-03-21 14:21:09"
+	"lastUpdated": "2021-05-27 00:40:31"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
 	Heise Translator
-	Copyright © 2021 optiprime
+	Copyright © 2021 optiprime, ApoB-100
 
 	This file is part of Zotero.
 
@@ -119,6 +119,12 @@ function scrape(doc) {
 			}
 		}
 		item.shortTitle = data.headline;
+		item.attachments = [{
+			url: data.mainEntityOfPage,
+			title: 'Snapshot',
+			mimeType: 'text/html',
+			snapshot: true
+		}];
 		item.creators = [];
 		if (data.author.name) {
 			item.creators.push(ZU.cleanAuthor(data.author.name, 'author'));
@@ -173,7 +179,13 @@ var testCases = [
 				"publicationTitle": "c't",
 				"url": "https://www.heise.de/select/ct/2021/7/2031014484690149069",
 				"volume": 2021,
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
 				"tags": [
 					{
 						"tag": "Impressum"


### PR DESCRIPTION
The translator for Heise is now able to automatically create and properly name snapshots of the respective article. The (modified) test has been passed successfully. 

Zotero <3