### PR TITLE
COinS: Optimize detectWeb and lint

### DIFF
--- a/COinS.js
+++ b/COinS.js
@@ -9,25 +9,14 @@
 	"inRepository": true,
 	"translatorType": 6,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2015-06-04 03:25:10"
+	"lastUpdated": "2021-06-01 17:17:55"
 }
 
 function detectWeb(doc, url) {
-	var spanTags = doc.getElementsByTagName("span");
-
 	var encounteredType = false;
 	
-	// This and the x: prefix in the XPath are to work around an issue with pages
-	// served as application/xhtml+xml
-	//
-	// https://developer.mozilla.org/en/Introduction_to_using_XPath_in_JavaScript#Implementing_a_default_namespace_for_XML_documents
-	function nsResolver() {
-		return 'http://www.w3.org/1999/xhtml';
-	}
-	
-	var spans = doc.evaluate('//x:span[contains(@class, " Z3988") or contains(@class, "Z3988 ") or @class="Z3988"][@title]', doc, nsResolver, XPathResult.ANY_TYPE, null);
-	var span;
-	while (span = spans.iterateNext()) {
+	var spans = doc.querySelectorAll('span.Z3988[title]');
+	for (let span of spans) {
 		// determine if it's a valid type
 		var item = new Zotero.Item;
 		var success = Zotero.Utilities.parseContextObject(span.title, item);
@@ -190,16 +179,9 @@ function doWeb(doc, url) {
 	var newItems = new Array();
 	var needFullItems = new Array();
 	var couldUseFullItems = new Array();
-	
-	
-	// See note in detectWeb()
-	function nsResolver() {
-		return 'http://www.w3.org/1999/xhtml';
-	}
-	
-	var spans = doc.evaluate('//x:span[contains(@class, " Z3988") or contains(@class, "Z3988 ") or @class="Z3988"][@title]', doc, nsResolver, XPathResult.ANY_TYPE, null);
-	var span;
-	while (span = spans.iterateNext()) {
+
+	var spans = doc.querySelectorAll('span.Z3988[title]');
+	for (let span of spans) {
 		var spanTitle = span.title;
 		var newItem = new Zotero.Item();
 		newItem.repository = false;	// do not save repository

--- a/COinS.js
+++ b/COinS.js
@@ -9,22 +9,46 @@
 	"inRepository": true,
 	"translatorType": 6,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2021-06-01 17:17:55"
+	"lastUpdated": "2021-06-01 17:38:46"
 }
 
-function detectWeb(doc, url) {
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2021 Simon Kornblith and Abe Jellinek
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, _url) {
 	var encounteredType = false;
 	
 	var spans = doc.querySelectorAll('span.Z3988[title]');
 	for (let span of spans) {
 		// determine if it's a valid type
-		var item = new Zotero.Item;
-		var success = Zotero.Utilities.parseContextObject(span.title, item);
+		var item = new Zotero.Item();
+		Zotero.Utilities.parseContextObject(span.title, item);
 		
 		if (item.itemType) {
 			if (encounteredType) {
 				return "multiple";
-			} else {
+			}
+			else {
 				encounteredType = item.itemType;
 			}
 		}
@@ -39,17 +63,18 @@ function supplementItem(item, supp, prefer, ignore) {
 	if (!ignore) ignore = [];
 	
 	for (var i in supp) {
-		if (ignore.indexOf(i) != -1)  continue;
+		if (ignore.includes(i)) continue;
 		if (i == 'creators' || i == 'attachments' || i == 'notes'
 			|| i == 'tags' || i == 'seeAlso'
 		) {
-			if ( (item.hasOwnProperty(i) && item[i].length) // Supplement only if completely empty
+			if ((item.hasOwnProperty(i) && item[i].length) // Supplement only if completely empty
 				|| (!supp[i].length || typeof supp[i] == 'string')
 			) {
 				continue;
 			}
-		} else if (!supp.hasOwnProperty(i)
-			|| (item.hasOwnProperty(i) && prefer.indexOf(i) == -1)) {
+		}
+		else if (!supp.hasOwnProperty(i)
+			|| (item.hasOwnProperty(i) && !prefer.includes(i))) {
 			continue;
 		}
 
@@ -68,31 +93,33 @@ function retrieveNextCOinS(needFullItems, newItems, couldUseFullItems, doc) {
 		
 		Zotero.debug("Looking up contextObject");
 		var search = Zotero.loadTranslator("search");
-		search.setHandler("itemDone", function(obj, newItem) {
+		search.setHandler("itemDone", function (obj, newItem) {
 			supplementItem(newItem, item, [], ['contextObject', 'repository']);
 			newItems.push(newItem);
 		});
-		search.setHandler("done", function() {
+		search.setHandler("done", function () {
 			retrieveNextCOinS(needFullItems, newItems, couldUseFullItems, doc);
 		});
 		// Don't throw on error
-		search.setHandler("error", function() {
+		search.setHandler("error", function () {
 			Zotero.debug("Failed to look up item:");
 			Zotero.debug(item);
 		});
 		// look for translators
-		search.setHandler("translators", function(obj, translators) {
+		search.setHandler("translators", function (obj, translators) {
 			if (translators.length) {
 				search.setTranslator(translators);
 				search.translate();
-			} else {
+			}
+			else {
 				retrieveNextCOinS(needFullItems, newItems, couldUseFullItems, doc);
 			}
 		});
 		
 		search.setSearch(item);
 		search.getTranslators();
-	} else {
+	}
+	else {
 		completeCOinS(newItems, couldUseFullItems, doc);
 		Zotero.done();
 	}
@@ -107,14 +134,15 @@ function completeCOinS(newItems, couldUseFullItems, doc) {
 		}
 		
 		Zotero.selectItems(selectArray, function (selectArray) {
-			if (!selectArray) return true;
-			var useIndices = new Array();
+			if (!selectArray) return;
+			var useIndices = [];
 			for (var i in selectArray) {
 				useIndices.push(i);
 			}
 			completeItems(newItems, useIndices, couldUseFullItems, doc);
 		});
-	} else if (newItems.length) {
+	}
+	else if (newItems.length) {
 		completeItems(newItems, [0], couldUseFullItems, doc);
 	}
 }
@@ -131,16 +159,16 @@ function completeItems(newItems, useIndices, couldUseFullItems, doc) {
 		var search = Zotero.loadTranslator("search");
 		
 		var firstItem = false;
-		search.setHandler("itemDone", function(obj, newItem) {
+		search.setHandler("itemDone", function (obj, newItem) {
 			supplementItem(newItem, newItems[i], [], ['contextObject', 'repository']);
 			if (!firstItem) {
 				// add doc as attachment
-				newItem.attachments.push({document:doc});
+				newItem.attachments.push({ document: doc });
 				newItem.complete();
 				firstItem = true;
 			}
 		});
-		search.setHandler("done", function(obj) {
+		search.setHandler("done", function (_obj) {
 			// if we didn't find anything, use what we had before (even if it
 			// lacks the creator)
 			if (!firstItem) {
@@ -150,14 +178,15 @@ function completeItems(newItems, useIndices, couldUseFullItems, doc) {
 			completeItems(newItems, useIndices, couldUseFullItems);
 		});
 		// Don't throw on error
-		search.setHandler("error", function() {});
-		search.setHandler("translators", function(obj, translators) {
+		search.setHandler("error", function () {});
+		search.setHandler("translators", function (obj, translators) {
 			if (translators.length) {
 				search.setTranslator(translators);
 				search.translate();
-			} else {
+			}
+			else {
 				// add doc as attachment
-				newItems[i].attachments.push({document:doc});
+				newItems[i].attachments.push({ document: doc });
 				newItems[i].complete();
 				// call next
 				completeItems(newItems, useIndices, couldUseFullItems);
@@ -166,19 +195,20 @@ function completeItems(newItems, useIndices, couldUseFullItems, doc) {
 		
 		search.setSearch(newItems[i]);
 		search.getTranslators();
-	} else {
+	}
+	else {
 		// add doc as attachment
-		newItems[i].attachments.push({document:doc});
+		newItems[i].attachments.push({ document: doc });
 		newItems[i].complete();
 		// call next
 		completeItems(newItems, useIndices, couldUseFullItems);
 	}
 }
 
-function doWeb(doc, url) {
-	var newItems = new Array();
-	var needFullItems = new Array();
-	var couldUseFullItems = new Array();
+function doWeb(doc, _url) {
+	var newItems = [];
+	var needFullItems = [];
+	var couldUseFullItems = [];
 
 	var spans = doc.querySelectorAll('span.Z3988[title]');
 	for (let span of spans) {
@@ -196,7 +226,8 @@ function doWeb(doc, url) {
 				
 				// title and creators are minimum data to avoid looking up
 				newItems.push(newItem);
-			} else {
+			}
+			else {
 				// retrieve full item
 				newItem.contextObject = spanTitle;
 				needFullItems.push(newItem);
@@ -209,7 +240,8 @@ function doWeb(doc, url) {
 		// retrieve full items asynchronously
 		Zotero.wait();
 		retrieveNextCOinS(needFullItems, newItems, couldUseFullItems, doc);
-	} else {
+	}
+	else {
 		completeCOinS(newItems, couldUseFullItems, doc);
 	}
 }
@@ -218,21 +250,23 @@ function doExport() {
 	var item;
 	var co;
 	
-	while (item = Zotero.nextItem()) {
+	while ((item = Zotero.nextItem())) {
 		co = Zotero.Utilities.createContextObject(item, "1.0");
 		if (co) {
-			Zotero.write("<span class='Z3988' title='"+ Zotero.Utilities.htmlSpecialChars(co) +"'></span>\n");
+			Zotero.write("<span class='Z3988' title='" + Zotero.Utilities.htmlSpecialChars(co) + "'></span>\n");
 		}
 	}
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://www.husdal.com/2011/06/19/disruptions-in-supply-networks/",
+		"url": "http://husdal.com/2011/06/19/disruptions-in-supply-networks/",
 		"items": [
 			{
 				"itemType": "journalArticle",
+				"title": "Disruptions and supply networks: a multi-level, multi-theoretical relational perspective",
 				"creators": [
 					{
 						"firstName": "Phil",
@@ -245,20 +279,20 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [],
-				"tags": [],
-				"seeAlso": [],
-				"attachments": [
-					{}
-				],
-				"publicationTitle": "International Journal of Logistics Management",
-				"title": "Disruptions and supply networks: a multi-level, multi-theoretical relational perspective",
 				"date": "2011",
-				"volume": "22",
 				"issue": "1",
 				"pages": "104-126",
-				"libraryCatalog": false,
-				"shortTitle": "Disruptions and supply networks"
+				"publicationTitle": "International Journal of Logistics Management",
+				"shortTitle": "Disruptions and supply networks",
+				"volume": "22",
+				"attachments": [
+					{
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	},
@@ -269,34 +303,32 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.hubmed.org/display.cgi?uids=21665052",
+		"url": "https://www.worldcat.org/title/genealogy-of-the-royal-family-of-great-britain-shewing-the-descent-of-queen-victoria-through-five-of-the-saxon-kings-who-were-crowned-at-kingston-upon-thames/oclc/559794003&referer=brief_results",
 		"items": [
 			{
-				"itemType": "journalArticle",
+				"itemType": "book",
+				"title": "The Genealogy of the Royal Family of Great Britain, shewing the descent of ... Queen Victoria, through five of the Saxon Kings who were crowned ... at Kingston-upon-Thames.",
 				"creators": [
 					{
-						"creatorType": "author",
-						"firstName": "Hui-Wen Vivian",
-						"lastName": "Tang"
+						"lastName": "Royal Families (England)",
+						"isInstitution": true
+					},
+					{
+						"lastName": "GENEALOGY",
+						"creatorType": "author"
 					}
 				],
-				"notes": [],
-				"tags": [],
-				"seeAlso": [],
+				"date": "1850",
+				"place": "London",
+				"publisher": "C. & E. Layton",
 				"attachments": [
-					{}
+					{
+						"mimeType": "text/html"
+					}
 				],
-				"publicationTitle": "Evaluation and Program Planning",
-				"volume": "34",
-				"issue": "4",
-				"language": "en",
-				"ISSN": "01497189",
-				"date": "11/2011",
-				"pages": "343-352",
-				"DOI": "10.1016/j.evalprogplan.2011.04.002",
-				"url": "http://linkinghub.elsevier.com/retrieve/pii/S0149718911000449",
-				"title": "Optimizing an immersion ESL curriculum using analytic hierarchy process",
-				"libraryCatalog": "CrossRef"
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	}


### PR DESCRIPTION
Since this translator targets everything, we want a fast `detectWeb`. This removes an unneeded query for every span tag on the page and replaces an XPath matching on spans' class attribute with a CSS selector that should be faster in modern browsers.

Also linted, added copyright, and updated tests.