### PR TITLE
Add (incomplete) API/type defs for TypeScript-aware editors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,167 @@
+declare namespace Zotero {
+    namespace Utilities {
+        function debounce<Type>(fn: Type, delay: number = 500): Type;
+        function throttle<Type>(fn: Type, wait: number, options: { leading: boolean, trailing: boolean }): Type;
+        function capitalizeName(s: string): string;
+        function cleanAuthor(author: string, creatorType: string, useComma: boolean): { firstName: string, lastName: string, creatorType: string };
+        function trim(s: string): string;
+        function trimInternal(s: string): string;
+        function superCleanString(s: string): string;
+        function isHTTPURL(url: string, allowNoScheme: boolean = false): boolean;
+        function cleanURL(url: string, tryHttp: boolean = false): string;
+        function cleanTags(s: string): string;
+        function cleanDOI(s: string): string;
+        function cleanISBN(s: string, dontValidate: boolean = false): string | false;
+        function toISBN13(isbnStr: string): string;
+        function cleanISSN(issnStr: string): string | false;
+        function text2html(s: string, singleNewlineIsParagraph: boolean = false): string;
+        function htmlSpecialChars(s: string): string;
+        function unescapeHTML(s: string): string;
+        // unimplemented: dom2text
+        function autoLink(s: string): string;
+        function parseMarkup(s: string): string;
+        function levenshtein(a: string, b: string): number;
+        function isEmpty(o: object): boolean;
+        function arrayDiff<Type>(array1: Type[], array2: Type[], useIndex?: false): Type[];
+        function arrayDiff<Type>(array1: Type[], array2: Type[], useIndex: true): number[];
+        function arrayEquals<Type>(array1: Type[], array2: Type[]): boolean;
+        function arrayShuffle<Type>(array: Type[]): Type[];
+        function arrayUnique<Type>(array: Type[]): Type[];
+        function forEachChunk<Type, RetType>(array: Type[], chunkSize: number, func: (chunk: Type[]) => RetType): RetType[];
+        function assignProps(target: any, source: any, props?: string[]): void;
+        function rand(min: number, max: number): number;
+        function getPageRange(pages: string): [fromPage: number, toPage: number];
+        function lpad(s: string, pad: string, length: number): string;
+        function ellipsize(s: string, len: number, wordBoundary: boolean = false, countChars: boolean = false): string;
+        function pluralize(num: number, forms: [singular: string, plural: string] | string): string;
+        function numberFormat(num: number, decimalPlaces: number, decimalPoint: string = '.', thousandsSep: string = ',');
+        function removeDiacritics(s: string, lowercaseOnly: boolean = false): string;
+        // processAsync
+        function deepCopy<Type>(obj: type): type;
+        function itemTypeExists(itemType: ItemType): boolean;
+        function getCreatorsForType(itemType: ItemType): string[];
+        function fieldIsValidForType(field: string, itemType: ItemType): boolean;
+        function getLocalizedCreatorType(itemType: ItemType): string;
+        function quotemeta(literal: string): string;
+        function xpath(elements: Element | Element[], xpath: string, namespaces?: { [prefix: string]: string }): Element[];
+        function xpathText(node: Element | Element[], xpath: string, namespaces?: { [prefix: string]: string }, delimiter?: string): string | null;
+        function randomString(len: number = 8, chars: string = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'): string;
+        // varDump
+        function itemToCSLJSON(item: Zotero.Item): any | Promise<any>;
+        function itemFromCSLJSON(item: Zotero.Item, cslItem: any): void;
+        function parseURL(url: string): { fileName: string, fileExtension: string, fileBaseName: string };
+        function resolveIntermediateURL(url: string): string;
+        function stringToUTF8Array(s: string, array: number[] | Uint8Array, offset: number = 0);
+        function getStringByteLength(s: string): number;
+        function determineAttachmentIcon(attachment: Attachment): string;
+        function generateObjectKey(): string;
+        function isValidObjectKey(s: string): boolean;
+        // XRegExp
+
+        function capitalizeTitle(s: string, force: boolean = false): string;
+        function getVersion(): string;
+        function getItemArray(doc: Document, inHere: Element | Element[], urlRe?: RegExp, rejectRe?: RegExp): { [link: string]: string };
+        async function processDocuments(urls: string | string[], processor: (doc: Document) => any, noCompleteOnError: boolean = false): void;
+        function doGet(urls: string | string[], processor?: (string) => void, done?: () => void, responseCharset?: string, requestHeaders?: { [header: string]: string }, successCodes?: number[]): boolean;
+        function doPost(url: string, body: string, onDone: (text: string, xmlhttp: XMLHttpRequest) => void, responseCharset?: string, requestHeaders?: { [header: string]: string }, successCodes?: number[]): boolean;
+        function urlToProxy(url: string): string;
+        function urlToProper(url: string): string;
+    }
+
+    interface Attachment {
+        title: string,
+        snapshot: bool,
+        mimeType: string,
+        url: string,
+        document: Document
+    }
+
+    type ItemType = 'artwork' | 'attachment' | 'audioRecording' | 'bill' | 'blogPost' | 'book' | 'bookSection' | 'case' | 'computerProgram' | 'conferencePaper' | 'dictionaryEntry' | 'document' | 'email' | 'encyclopediaArticle' | 'film' | 'forumPost' | 'hearing' | 'instantMessage' | 'interview' | 'journalArticle' | 'letter' | 'magazineArticle' | 'manuscript' | 'map' | 'newspaperArticle' | 'note' | 'patent' | 'podcast' | 'presentation' | 'radioBroadcast' | 'report' | 'statute' | 'thesis' | 'tvBroadcast' | 'videoRecording' | 'webpage';
+
+    class Item {
+        constructor(itemType?: ItemType);
+        itemType: ItemType;
+        attachments: Attachment[];
+        complete(): void;
+    }
+
+    interface Translator {
+        translatorID: string;
+        translatorType: number;
+        label: string;
+        creator: string;
+        target: string;
+        minVersion: string;
+        maxVersion: string;
+        priority: number;
+        browserSupport: string;
+        configOptions: object;
+        displayOptions: object;
+        hiddenPrefs: object;
+        inRepository: boolean;
+        lastUpdated: string;
+        metadata: object;
+        code: string;
+        cacheCode: boolean;
+        path: string?;
+        fileName: string?;
+
+        getCode(): Promise<string>;
+        serialize(): object;
+        logError(message: string, errorType?: 'error' | 'warning' | 'exception' | 'strict', lineNumber: number, colNumber: number): void;
+        replaceDeprecatedStatements(code: string): string;
+
+        detectWeb(doc: Document, url: string): string | false;
+        doWeb(doc: Document, url: string): void;
+    }
+
+    interface Translate {
+        setLocation(location: String | nsIFile): void;
+        setTranslator(translator: Zotero.Translator[] | Zotero.Translator | string): boolean;
+        getTranslatorObject(receiver: (obj: Zotero.Translator) => void): void;
+        setHandler<ID>(type: "select", handler: (translate: Zotero.Translate, items: { [id: ID]: string }) => ID[]): void;
+        setHandler(type: "itemDone", handler: (translate: Zotero.Translate, item: Zotero.Item) => void): void;
+        setHandler(type: "collectionDone", handler: (translate: Zotero.Translate, collection: Zotero.Collection) => void): void;
+        setHandler(type: "done", handler: (translate: Zotero.Translate, success: boolean) => void): void;
+        setHandler(type: "debug", handler: (translate: Zotero.Translate, message: string) => boolean): void;
+        setHandler(type: "error", handler: (translate: Zotero.Translate, error: Error | string) => void): void;
+        setHandler(type: "translators", handler: (translate: Zotero.Translate, translators: Zotero.Translator[]) => void): void;
+        setHandler(type: "pageModified", handler: (translate: Zotero.Translate, doc: Document) => void): void;
+        clearHandlers(type: "select" | "itemDone" | "collectionDone" | "done" | "debug" | "error" | "translators" | "pageModified"): void;
+        removeHandler<ID>(type: "select", handler: (translate: Zotero.Translate, items: { [id: ID]: string }) => ID[]): void;
+        removeHandler(type: "itemDone", handler: (translate: Zotero.Translate, item: Zotero.Item) => void): void;
+        removeHandler(type: "collectionDone", handler: (translate: Zotero.Translate, collection: Zotero.Collection) => void): void;
+        removeHandler(type: "done", handler: (translate: Zotero.Translate, success: boolean) => void): void;
+        removeHandler(type: "debug", handler: (translate: Zotero.Translate, message: string) => boolean): void;
+        removeHandler(type: "error", handler: (translate: Zotero.Translate, error: Error | string) => void): void;
+        removeHandler(type: "translators", handler: (translate: Zotero.Translate, translators: Zotero.Translator[]) => void): void;
+        removeHandler(type: "pageModified", handler: (translate: Zotero.Translate, doc: Document) => void): void;
+        setTranslatorProvider(translatorProvider: object): void;
+        incrementAsyncProcesses(f: string): void;
+        decrementAsyncProcesses(f: string, by?: number): void;
+        getTranslators(getAllTranslators?: boolean = false, checkSetTranslator?: boolean = false): Promise<Zotero.Translator[]>;
+        translate(libraryID?: number | false, saveAttachments?: boolean = true, linkFiles?: boolean = false): Promise<Zotero.Item[]>;
+        getProgress(): number | null;
+        resolveURL(url: string, dontUseProxy: boolean = true): string;
+        setDocument(doc: Document): void;
+        setLocation(location: string, rootLocation: string = location): void;
+        setString(s: string): void;
+        setItems(items: Zotero.Item[]): void;
+        setLibraryID(libraryID: string): void;
+        setCollection(collection: Zotero.Collection);
+        setDisplayOptions(displayOptions: object);
+        setSearch(item: Zotero.Item): void;
+        setIdentifier(identifier: { DOI?: string, ISBN?: string, PMID?: string }): void;
+    }
+
+    function selectItems<ID>(items: { [id: ID]: string }, callback: (items: { [id: ID]: string }) => void): void;
+    function monitorDOMChanges(target: Node, config: MutationObserverInit): void;
+    function loadTranslator(translatorType: 'web' | 'import' | 'export' | 'search'): Zotero.Translate;
+}
+
+declare var Z = Zotero;
+declare var ZU = Zotero.Utilities;
+
+declare function attr(node?: ParentNode, selector: string, attr: string, index?: number): string;
+declare function text(node?: ParentNode, selector: string, index?: number): string;
+declare function innerText(node?: ParentNode, selector: string, index?: number): string;

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "checkJs": true,
+    "lib": ["dom", "es2017"],
+    "types": ["index.d.ts"]
+  }
+}


### PR DESCRIPTION
This doesn't change any translator behavior and doesn't affect Scaffold, but it makes the editing experience slightly easier in VSCode, Emacs (with Tide), and other editors that can use TypeScript definitions to enhance JavaScript editing (providing type hints, warnings for wrongly-typed arguments, and basic go-to-definition). A future Scaffold could use them, too.

