### PR TITLE
Trove: Handle books, articles, art, and multiples

### DIFF
--- a/Trove.js
+++ b/Trove.js
@@ -1,20 +1,21 @@
 {
 	"translatorID": "8efcb7cb-4180-4555-969a-08e8b34066c4",
 	"label": "Trove",
-	"creator": "Tim Sherratt",
-	"target": "^https?://trove\\.nla\\.gov\\.au/(?:newspaper|gazette|work|book|article|picture|music|map|collection)/",
+	"creator": "Tim Sherratt and Abe Jellinek",
+	"target": "^https?://trove\\.nla\\.gov\\.au/(?:newspaper|gazette|work|book|article|picture|music|map|collection|search)/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-09-15 01:24:23"
+	"lastUpdated": "2021-06-11 04:08:30"
 }
 
 /*
    Trove Translator
-   Copyright (C) 2016 Tim Sherratt (tim@discontents.com.au, @wragge)
+   Copyright (C) 2016-2021 Tim Sherratt (tim@discontents.com.au, @wragge)
+                           and Abe Jellinek
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published by
@@ -32,38 +33,62 @@
 
 
 function detectWeb(doc, url) {
-	// Note that the url for search results has changed,
-	// so the first pattern will never match.
-	// However, results scraping needs to be rewritten due to the redesign,
-	// so leave this as is for now.
-	if (url.includes('/result?') || url.includes('/newspaper/page')) {
+	if (url.includes('/search/') || url.includes('/newspaper/page')) {
 		return getSearchResults(doc, url, true) ? 'multiple' : false;
 	}
 	else if (url.includes('/newspaper/article')) {
 		return "newspaperArticle";
 	}
-	//  Scraping from works is very brokened due to site redesign
-	//  Prevent detection until a fix is available
-	//	else if (url.includes('/work/')) {
-	//		return "book";
-	//	}
+	else if (url.includes('/work/')) {
+		let format = text('#workContainer .format');
+		if (!format && doc.querySelector('.versions')) {
+			return "multiple";
+		}
+		else if (format.includes('Journal or magazine article')) {
+			return "magazineArticle";
+		}
+		else if (format.includes('Photograph')) {
+			return "artwork";
+		}
+		else if (format.includes('Book chapter')) {
+			return "bookSection";
+		}
+		else {
+			return "book";
+		}
+	}
 	return false;
 }
 
 
 function getSearchResults(doc, url, checkOnly) {
 	var items = {};
-	var results;
+	var urls = [];
+	var titles = [];
 	var found = false;
-	if (url.includes('/result?')) {
-		results = ZU.xpath(doc, "//div[@id='mainresults']//li/dl/dt/a");
+	if (url.includes('/search/')) {
+		for (let container of doc.querySelectorAll('.result')) {
+			let link = container.querySelector('.title a');
+			urls.push(link.href);
+			titles.push(link.textContent);
+		}
+	}
+	else if (url.includes('/work/')) {
+		for (let container of doc.querySelectorAll('.version-container')) {
+			urls.push(attr(container, 'a', 'href'));
+			// titles are usually the same, so we'll disambiguate using the publication year
+			titles.push(text(container, '.year') + ': ' + text(container, '.title'));
+		}
 	}
 	else {
-		results = ZU.xpath(doc, "//ol[@class='list-unstyled articles']/li/h4/a");
+		for (let container of doc.querySelectorAll('ol.articles li a.link')) {
+			urls.push(container.href);
+			titles.push(container.textContent);
+		}
 	}
-	for (var i = 0; i < results.length; i++) {
-		var link = results[i].href;
-		var title = ZU.trimInternal(results[i].textContent);
+	for (var i = 0; i < urls.length; i++) {
+		var link = urls[i];
+		var title = ZU.trimInternal(titles[i]);
 		if (!title || !link) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -112,6 +137,8 @@ function scrapeNewspaper(doc, url) {
 		translator.setHandler("itemDone", function (obj, item) {
 			item.itemType = 'newspaperArticle';
 			item.pages = item.numPages;
+			item.publicationTitle = cleanPublicationTitle(item.publicationTitle);
+			item.place = cleanPlace(item.place);
 			delete item.numPages;
 			delete item.type;
 			delete item.itemID;
@@ -157,6 +184,42 @@ function scrapeNewspaper(doc, url) {
 		});
 		translator.translate();
 	});
+}
+
+
+function cleanPublicationTitle(pubTitle) {
+	if (!pubTitle) return pubTitle;
+	// Australian Worker (Sydney, NSW : 1913 - 1950) -> Australian Worker
+	// the place info is duplicated in the place field
+	return pubTitle.replace(/\([^)]+\)/, '');
+}
+
+
+function cleanPlace(place) {
+	if (!place) return place;
+	
+	let replacements = {
+		'Vic.': 'Victoria',
+		'Qld.': 'Queensland',
+		SA: 'South Australia',
+		'S.A.': 'South Australia',
+		'S.Aust.': 'South Australia',
+		'Tas.': 'Tasmania',
+		WA: 'Western Australia',
+		'W.A.': 'Western Australia',
+		NSW: 'New South Wales',
+		'N.S.W.': 'New South Wales',
+		ACT: 'Australian Capital Territory',
+		'A.C.T.': 'Australian Capital Territory',
+		NT: 'Northern Territory',
+		'N.T.': 'Northern Territory'
+	};
+	
+	for (let [from, to] of Object.entries(replacements)) {
+		place = place.replace(from, to);
+	}
+	
+	return place;
 }
 
 
@@ -206,9 +269,14 @@ function checkType(string) {
 // results in
 //   "firstName": "1910-1981, William A. (William Alan)",
 //   "lastName": "Bayley"
+// Trove occasionally gives us author strings like "Australian Institute of
+// Health and Welfare" that the BibTeX translator will split, but there's not
+// much we can do, because that's the correct behavior. we could try to compare
+// BibTeX authors to the HTML, but that won't work for multiples.
 function cleanCreators(creators) {
-	for (var i = 0; i < creators.length; i++) {
-		var name = creators[i].firstName;
+	for (let creator of creators) {
+		if (creator.fieldMode || !creator.firstName) continue;
+		var name = creator.firstName;
 		name = name.replace(/\(?\d{4}-\d{0,4}\)?,?/, "").trim();
 		var posParenthesis = name.indexOf("(");
 		if (posParenthesis > -1) {
@@ -221,43 +289,99 @@ function cleanCreators(creators) {
 				name = first;
 			}
 		}
-		creators[i].firstName = name.trim();
+		creator.firstName = name.trim();
 	}
 	return creators;
 }
 
 
+function cleanPublisher(publisher) {
+	if (!publisher) return publisher;
+	
+	let parts = publisher.split(':').map(s => s.trim());
+	if (parts.length == 2) {
+		return { place: cleanPlace(parts[0]), publisher: parts[1] };
+	}
+	else {
+		return { place: parts[0] };
+	}
+}
+
+
+function cleanEdition(text) {
+	if (!text) return text;
+	
+	// from Taylor & Francis eBooks translator, slightly adapted
+	
+	const ordinals = {
+		first: "1",
+		second: "2",
+		third: "3",
+		fourth: "4",
+		fifth: "5",
+		sixth: "6",
+		seventh: "7",
+		eighth: "8",
+		ninth: "9",
+		tenth: "10"
+	};
+	
+	text = ZU.trimInternal(text).replace(/[[\]]/g, '');
+	// this somewhat complicated regex tries to isolate the number (spelled out
+	// or not) and make sure that it isn't followed by any extra info
+	let matches = text
+		.match(/^(?:(?:([0-9]+)(?:st|nd|rd|th)?)|(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth))(?:\s?ed?\.?|\sedition)?$/i);
+	if (matches) {
+		let edition = matches[1] || matches[2];
+		edition = ordinals[edition.toLowerCase()] || edition;
+		return edition == "1" ? null : edition;
+	}
+	else {
+		return text;
+	}
+}
+
 function scrapeWork(doc, url) {
 	var thumbnailURL;
 
-	// Remove all params from url
-	var workURL = url.replace(/[?#].*/, '');
-	var bibtexURL = workURL + '?citationFormat=BibTeX';
+	var workID = url.match(/\/work\/([0-9]+)/)[1];
+	var bibtexURL = `https://trove.nla.gov.au/api/citation/work/${workID}?version=undefined`;
 	
 	if (doc) {
-		// Need to get version identifier for the BibText url
-		var versionID = doc.body.innerHTML.match(/displayCiteDialog\('(.+?)'/);
-		if (versionID !== null) {
-			bibtexURL += '&selectedversion=' + versionID[1];
-			thumbnailURL = ZU.xpathText(doc, "//a/img[@class='mosaic ui-shdw']/@src");
-		}
-		else {
-			// It's a work -- so thumbnails are different
-			thumbnailURL = ZU.xpathText(doc, "//li[@class='imgfirst']//img/@src");
-		}
+		// version ID seems to always be undefined now
+		thumbnailURL = attr(doc, '.thumbnail img', 'src');
 	}
 
 	// Get the BibTex and feed it to the translator.
-	ZU.HTTP.doGet(bibtexURL, function (bibtex) {
+	ZU.HTTP.doGet(bibtexURL, function (respText) {
+		// bibtex puts tags in the wrong field, but it's alright, they're mostly... bad
+		// we should restore if we can come up with a good cleaning method
+		// (exclude dates, tags that are the same as the item title or author,
+		//  approximate duplicates, ...)
+		var bibtex = JSON.parse(respText).bibtex;
 		var translator = Zotero.loadTranslator("import");
 		translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
 		translator.setString(bibtex);
 		translator.setHandler("itemDone", function (obj, item) {
 			item.itemType = checkType(item.type);
 			item.creators = cleanCreators(item.creators);
+			item.edition = cleanEdition(item.edition);
+			
+			Object.assign(item, cleanPublisher(item.publisher));
+			
+			if (item.itemType == 'artwork' && item.type) {
+				item.artworkMedium = item.type;
+				delete item.type;
+			}
+			
+			if (item.notes && item.notes.length == 1) {
+				// abstract goes into a note, but we want it in abstractNote
+				// (with HTML tags removed)
+				item.abstractNote = ZU.cleanTags(item.notes.pop().note);
+			}
 
 			// Attach a link to the contributing repository if available
-			if (item.hasOwnProperty('url')) {
+			if (item.url) {
 				item.attachments.push({
 					title: "Record from contributing repository",
 					url: item.url,
@@ -266,20 +390,7 @@ function scrapeWork(doc, url) {
 				});
 			}
 
-			if (doc) {
-				// This gives a better version-aware url.
-				item.url = ZU.xpathText(doc, "//meta[@property='og:url']/@content");
-				item.abstractNote = ZU.xpathText(doc, "//meta[@property='og:description']/@content");
-				
-				// Add tags
-				let tags = ZU.xpath(doc, "//div[@id='tagswork' or @id='content-tags']/ul/li");
-				for (var i = 0; i < tags.length; i++) {
-					let tag = ZU.xpathText(tags[i], "a");
-					item.tags.push(tag);
-				}
-			}
-
-			if (thumbnailURL !== null) {
+			if (thumbnailURL) {
 				item.attachments.push({
 					url: thumbnailURL,
 					title: 'Trove thumbnail image',
@@ -289,6 +400,11 @@ function scrapeWork(doc, url) {
 			item.complete();
 		});
 		translator.translate();
+	}, null, null, {
+		Referer: 'https://trove.nla.gov.au/',
+		apikey: '3b84ac7cec64f3e346f9a8f063230949'
+		// the API key is the one that the site uses for client-side requests,
+		// so it and the Referer have to be exactly right.
 	});
 }
 
@@ -296,7 +412,8 @@ function scrapeWork(doc, url) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "https://trove.nla.gov.au/work/9958833?q&versionId=11567057",
+		"url": "https://trove.nla.gov.au/work/9958833",
+		"defer": true,
 		"items": [
 			{
 				"itemType": "book",
@@ -310,19 +427,15 @@ var testCases = [
 				],
 				"date": "1980",
 				"ISBN": "9780908065073",
-				"abstractNote": "In 14 libraries. 24 p. : ill. ; 22 cm. Wragge, Clement L. (Clement Lindley), 1852-1922. South Australia. Climate, 1883-1884. Meteorologists -- South Australia -- Biography. South Australia -- Description and travel. South Australia -- Climate -- History.",
+				"abstractNote": "Reprinted from Good words for 1887/ edited by Donald Macleod, published: London: Isbister and Co",
 				"itemID": "trove.nla.gov.au/work/9958833",
 				"language": "English",
 				"libraryCatalog": "Trove",
-				"publisher": "Warradale, S.Aust. : Pioneer Books",
-				"url": "https://trove.nla.gov.au/version/11567057",
+				"place": "Warradale, South Australia",
+				"publisher": "Pioneer Books",
 				"attachments": [],
 				"tags": [],
-				"notes": [
-					{
-						"note": "<p> Reprinted from Good words for 1887/ edited by Donald Macleod, published: London: Isbister and Co </p>"
-					}
-				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]
@@ -330,6 +443,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://trove.nla.gov.au/newspaper/article/70068753",
+		"defer": true,
 		"items": [
 			{
 				"itemType": "newspaperArticle",
@@ -338,9 +452,8 @@ var testCases = [
 				"date": "7 Feb 1903",
 				"abstractNote": "We have received a copy of the above which is a journal devoted chiefly to the science of meteorology. It is owned and conducted by Mr. Clement ...",
 				"libraryCatalog": "Trove",
-				"pages": "4",
-				"place": "Vic.",
-				"publicationTitle": "Sunbury News (Vic. : 1900 - 1927)",
+				"place": "Victoria",
+				"publicationTitle": "Sunbury News",
 				"url": "http://nla.gov.au/nla.news-article70068753",
 				"attachments": [
 					{
@@ -364,47 +477,139 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://trove.nla.gov.au/newspaper/result?l-australian=y&q=wragge",
+		"url": "https://trove.nla.gov.au/search/advanced/category/newspapers?l-artType=newspapers&l-australian=y&keyword=wragge",
+		"defer": true,
 		"items": "multiple"
 	},
 	{
 		"type": "web",
-		"url": "http://trove.nla.gov.au/book/result?l-australian=y&q=wragge",
+		"url": "https://trove.nla.gov.au/search/category/books?keyword=wragge",
+		"defer": true,
 		"items": "multiple"
 	},
 	{
 		"type": "web",
 		"url": "https://trove.nla.gov.au/newspaper/page/7013947",
+		"defer": true,
 		"items": "multiple"
 	},
 	{
 		"type": "web",
 		"url": "https://trove.nla.gov.au/work/9531118?q&sort=holdings+desc&_=1483112824975&versionId=14744047",
+		"defer": true,
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://trove.nla.gov.au/work/208456891",
+		"defer": true,
 		"items": [
 			{
-				"itemType": "book",
-				"title": "Lithgow zig zag railway, Blue Mountains, New South Wales",
+				"itemType": "artwork",
+				"title": "Walter Wragge",
+				"creators": [],
+				"date": "1912",
+				"artworkMedium": "Photograph",
+				"itemID": "trove.nla.gov.au/work/208456891",
+				"language": "en",
+				"libraryCatalog": "Trove",
+				"url": "http://collections.slsa.sa.gov.au/resource/B+49301",
+				"attachments": [
+					{
+						"title": "Record from contributing repository",
+						"mimeType": "text/html",
+						"snapshot": false
+					},
+					{
+						"title": "Trove thumbnail image",
+						"mimeType": "image/jpeg"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://trove.nla.gov.au/work/11424419/version/264796991%20264796992",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "AUSTRALIA'S WELFARE 1993 Services and Assistance (30 June 1994)",
 				"creators": [
 					{
-						"firstName": "William Alan",
-						"lastName": "Bayley",
+						"firstName": "Australian Institute of",
+						"lastName": "Health",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Welfare",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "1994-06-30",
+				"ISSN": "1321-1455",
+				"issue": "14 of 1994",
+				"itemID": "trove.nla.gov.au/work/11424419",
+				"language": "English",
+				"libraryCatalog": "Trove",
+				"publicationTitle": "Australia's welfare : services and assistance",
+				"attachments": [
+					{
+						"title": "Trove thumbnail image",
+						"mimeType": "image/jpeg"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://trove.nla.gov.au/work/245696250",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "bookSection",
+				"title": "Conducting a systematic review : a practical guide",
+				"creators": [
+					{
+						"firstName": "Freya",
+						"lastName": "MacMillan",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Kate A.",
+						"lastName": "McBride",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Emma S.",
+						"lastName": "George",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Genevieve Z.",
+						"lastName": "Steiner",
 						"creatorType": "author"
 					}
 				],
-				"date": "1969",
-				"abstractNote": "In 19 libraries. 40 p. : ill., map ; 22 cm. Great Zig Zag Railway (Lithgow, N.S.W.) Railroads -- Blue Mountains (N.S.W. : Mountains) Zig Zag Railway -- Lithgow, Australia. Railroads -- New South Wales. Railroads -- New South Wales -- Blue Mountains. Blue Mountains (N.S.W.)",
-				"itemID": "trove.nla.gov.au/work/9531118",
-				"language": "English",
+				"date": "2018",
+				"itemID": "trove.nla.gov.au/work/245696250",
+				"language": "eng",
 				"libraryCatalog": "Trove",
-				"publisher": "[Bulli, N.S.W. : Zig Zag Press",
-				"url": "https://trove.nla.gov.au/version/14744047",
+				"place": "Singapore, Springer",
+				"publisher": "Singapore, Springer",
+				"shortTitle": "Conducting a systematic review",
 				"attachments": [],
 				"tags": [],
-				"notes": [
-					{
-						"note": "<p> Cover title </p>"
-					}
-				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]


### PR DESCRIPTION
We lost tags on works - they're difficult to clean and usually a mix of LoC subject headings, restatements of the title, date ranges, and various permutations of the authors' names. Just not very meaningful.

We emulate a browser and use the same API key as the site's JS in order to grab the BibTeX. I'd like to find a better approach. I don't understand why citation generation is locked behind an API key wall.