### PR TITLE
NASA ADS: Generate token for new API, correct PDF ordering

### DIFF
--- a/NASA ADS.js
+++ b/NASA ADS.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "7987b420-e8cb-4bea-8ef7-61c2377cd686",
 	"label": "NASA ADS",
-	"creator": "Tim Hostetler",
+	"creator": "Tim Hostetler and Abe Jellinek",
 	"target": "^https://ui\\.adsabs\\.harvard\\.edu/(search|abs)/",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-11-25 18:11:28"
+	"lastUpdated": "2021-06-15 15:35:37"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2019 Tim Hostetler
+	Copyright © 2019-2021 Tim Hostetler and Abe Jellinek
 
 	This file is part of Zotero.
 
@@ -79,11 +79,11 @@ function doWeb(doc, url) {
 	if (detectWeb(doc, url) === "multiple") {
 		Zotero.selectItems(getSearchResults(doc), function (items) {
 			if (!items) return true;
-			return scrape(Object.keys(items), doc);
+			return scrape(Object.keys(items));
 		});
 	}
 	else {
-		scrape([extractId(url)], url);
+		scrape([extractId(url)], doc);
 	}
 }
 
@@ -92,28 +92,38 @@ function makePdfUrl(id) {
 }
 
 function scrape(ids, doc) {
-	const exportUrl = "http://adsabs.harvard.edu/cgi-bin/nph-bib_query?"
-		+ ids.join("&")
-		+ "&data_type=REFMAN&nocookieset=1";
-	ZU.doGet(exportUrl, function (text) {
-		const translator = Zotero.loadTranslator("import");
-		translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
-		translator.setString(text);
-		translator.setHandler("itemDone", function (obj, item) {
-			const id = ids.pop();
-			item.itemType = getTypeFromId(id);
-			item.attachments.push({
-				url: makePdfUrl(id),
-				title: "Full Text PDF",
-				mimeType: "application/pdf"
-			});
-			item.attachments.push({
-				title: "Snapshot",
-				document: doc
-			});
-			item.complete();
+	ZU.doGet('https://api.adsabs.harvard.edu/v1/accounts/bootstrap', function (respText) {
+		let json = JSON.parse(respText);
+		let token = json.access_token;
+		
+		let exportUrl = "https://ui.adsabs.harvard.edu/v1/export/ris";
+		let body = JSON.stringify({
+			bibcode: ids,
+			sort: ['date desc, bibcode desc']
 		});
-		translator.translate();
+	
+		ZU.doPost(exportUrl, body, function (respText) {
+			let json = JSON.parse(respText);
+	
+			const translator = Zotero.loadTranslator("import");
+			translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7"); // RIS
+			translator.setString(json.export);
+			translator.setHandler("itemDone", function (obj, item) {
+				const id = ids.pop();
+				item.itemType = getTypeFromId(id);
+				item.attachments.push({
+					url: makePdfUrl(id),
+					title: "Full Text PDF",
+					mimeType: "application/pdf"
+				});
+				item.attachments.push({
+					title: "Snapshot",
+					document: doc
+				});
+				item.complete();
+			});
+			translator.translate();
+		}, { Authorization: 'Bearer:' + token });
 	});
 }
 
@@ -122,6 +132,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://ui.adsabs.harvard.edu/search/q=star&sort=date%20desc%2C%20bibcode%20desc&p_=0",
+		"defer": true,
 		"items": "multiple"
 	},
 	{
@@ -161,13 +172,13 @@ var testCases = [
 				"date": "March 1, 2020",
 				"DOI": "10.1016/j.cnsns.2019.105014",
 				"ISSN": "1007-5704",
-				"abstractNote": "Cerebellar stellate cells are inhibitory molecular interneurons that \nregulate the firing properties of Purkinje cells, the sole output of\ncerebellar cortex. Recent evidence suggests that these cells exhibit\ntemporal increase in excitability during whole-cell patch-clamp\nconfiguration in a phenomenon termed runup. They also exhibit a\nnon-monotonic first-spike latency profile as a function of the holding\npotential in response to a fixed step-current. In this study, we use\nmodeling approaches to unravel the dynamics of runup and categorize the\nfiring behavior of cerebellar stellate cells as either type I or type II\noscillators. We then extend this analysis to investigate how the\nnon-monotonic latency profile manifests itself during runup. We employ a\npreviously developed, but revised, Hodgkin-Huxley type model to show\nthat stellate cells are indeed type I oscillators possessing a saddle\nnode on an invariant cycle (SNIC) bifurcation. The SNIC in the model\nacts as a \"threshold\" for tonic firing and produces a slow region in the\nphase space called the ghost of the SNIC. The model reveals that (i) the\nSNIC gets left-shifted during runup with respect to Iapp\n=Itest in the current-step protocol, and (ii) both the\ndistance from the stable limit cycle along with the slow region produce\nthe non-monotonic latency profile as a function of holding potential.\nUsing the model, we elucidate how latency can be made arbitrarily large\nfor a specific range of holding potentials close to the SNIC during\npre-runup (post-runup). We also demonstrate that the model can produce\ntransient single spikes in response to step-currents entirely below\nISNIC, and that a pair of dynamic inhibitory and excitatory\npost-synaptic inputs can robustly evoke action potentials, provided that\nthe magnitude of the inhibition is either low or high but not\nintermediate. Our results show that the topology of the SNIC is the key\nto explaining such behaviors.",
+				"abstractNote": "Cerebellar stellate cells are inhibitory molecular interneurons that regulate the firing properties of Purkinje cells, the sole output of cerebellar cortex. Recent evidence suggests that these cells exhibit temporal increase in excitability during whole-cell patch-clamp configuration in a phenomenon termed runup. They also exhibit a non-monotonic first-spike latency profile as a function of the holding potential in response to a fixed step-current. In this study, we use modeling approaches to unravel the dynamics of runup and categorize the firing behavior of cerebellar stellate cells as either type I or type II oscillators. We then extend this analysis to investigate how the non-monotonic latency profile manifests itself during runup. We employ a previously developed, but revised, Hodgkin-Huxley type model to show that stellate cells are indeed type I oscillators possessing a saddle node on an invariant cycle (SNIC) bifurcation. The SNIC in the model acts as a \"threshold\" for tonic firing and produces a slow region in the phase space called the ghost of the SNIC. The model reveals that (i) the SNIC gets left-shifted during runup with respect to Iapp =Itest in the current-step protocol, and (ii) both the distance from the stable limit cycle along with the slow region produce the non-monotonic latency profile as a function of holding potential. Using the model, we elucidate how latency can be made arbitrarily large for a specific range of holding potentials close to the SNIC during pre-runup (post-runup). We also demonstrate that the model can produce transient single spikes in response to step-currents entirely below ISNIC, and that a pair of dynamic inhibitory and excitatory post-synaptic inputs can robustly evoke action potentials, provided that the magnitude of the inhibition is either low or high but not intermediate. Our results show that the topology of the SNIC is the key to explaining such behaviors.",
 				"journalAbbreviation": "Communications in Nonlinear Science and Numerical Simulations",
 				"libraryCatalog": "NASA ADS",
 				"pages": "105014",
 				"publicationTitle": "Communications in Nonlinear Science and Numerical Simulations",
 				"shortTitle": "Modeling excitability in cerebellar stellate cells",
-				"url": "http://adsabs.harvard.edu/abs/2020CNSNS..8205014M",
+				"url": "https://ui.adsabs.harvard.edu/abs/2020CNSNS..8205014M",
 				"volume": "82",
 				"attachments": [
 					{
@@ -175,7 +186,8 @@ var testCases = [
 						"mimeType": "application/pdf"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -213,17 +225,16 @@ var testCases = [
 				],
 				"date": "July 1, 2019",
 				"abstractNote": "During the last years, with the evolution of technology enabling the control of nano-mesoscopic systems, the possibility of experimentally implementing a Maxwell's demon has aroused much interest. Its classical version has already been implemented, in photonic and electronic systems, and currently its quantum version is being broadly studied. In this context, the purpose of this work is the development of a protocol for the implementation of the quantum version of an autonomous Maxwell's demon in a system of superconducting qubits. The system is composed of an Asymmetrical Single-Cooper-Pair Transistor, ASCPT, which has its extremities in contact with heat baths, such that the left one has a lower temperature than the right one. And of a device of two interacting Cooper-Pair Boxes, CPB's, named as an ECPB, for Extended Cooper-Pair Box. The ECPB is also in contact with a heat bath and possess a genuine quantum feature, entanglement, being described by its antisymmetric and symmetric states, that couple capacitively to the ASCPT with different strengths. A specific operating regime was found where the spontaneous dynamics of the tunneling of Cooper pairs through the ASCPT, will led to a heat transport from the bath in contact with the left extremity of the ASCPT to the bath at the right. And so, as in Maxwell's original thought experiment, the demon, which is composed by the ECPB and the island of the ASCPT, mediates a heat flux from a cold to a hot bath, without the expense of work. However as expected, the violation of the 2nd law of thermodynamics does not occur, as during the dynamics heat is also released to the bath in contact with the ECPB, compensating the decrease of entropy that occurs in the baths in contact with the ASCPT.",
-				"journalAbbreviation": "Masters Thesis",
 				"libraryCatalog": "NASA ADS",
-				"publicationTitle": "Masters Thesis",
-				"url": "http://adsabs.harvard.edu/abs/2019MsT.........15M",
+				"url": "https://ui.adsabs.harvard.edu/abs/2019MsT.........15M",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -247,21 +258,98 @@ var testCases = [
 					}
 				],
 				"date": "September 1, 2019",
-				"abstractNote": "Cosmology is the science that studies the Universe as whole, aiming to understand its origin, composition and evolution. During the last decades, cosmology has transitioned from a \"data staved\" to a \"data driven\" science, inaugurating what is known as precision cosmology. This huge observational effort has confirmed and fostered theoretical research, and established the standard model of cosmology: Lambda-Cold Dark Matter (LCDM). This model successfully reproduces most of the observations. However, there are some persistent tensions between experiments that might be smoking guns of new physics beyond this model. Anyways, there is a difference between modeling and understanding, and LCDM is a phenomenological model that, for instance, does not describe the nature of the dark matter or dark energy. This thesis collects part of my research focused on pushing the limits of the standard\ncosmological model and its assumptions, regarding also existing tensions between experiments. New strategies to optimize the performance of future experiments are also proposed and discussed. The largest existing tension is between the direct measurements of the Hubble constant using the distance ladder in the local Universe and the inferred value obtained from observations of the Cosmic Microwave Background when LCDM is assumed. A model independent reconstruction of the late-time\nexpansion history of the Universe is carried out, which allows us to identify possible sources and solutions of the tension. We also\nintroduce the concept of the low redshift standard ruler, and measure it in a model independent way. Finally, we introduce a statistical\nmethodology to analyze several data sets in a conservative way, no matter the level of discrepancy between them, accounting for the potential presence of systematic errors. The role of primordial black holes as candidates for dark matter is addressed in this thesis, too. Concretely, the impact of an abundant population of primordial black holes in the rest of cosmological parameters is discussed, considering also populations with extended mass distributions. In addition, massive primordial black holes might be the seeds that are needed to explain the origin of the supermassive black holes located in the center of the galaxies. We predict the contribution of a population of massive primordial black holes to the 21 cm radiation from the dark ages. This way, observations of the 21 cm intensity mapping observations of the dark ages could be used to ascertain if the seeds of the supermassive black holes are primordial. Finally, we estimate the potential of radio-continuum galaxy surveys to constrain LCDM. These kind of\nexperiments can survey the sky quicker than spectroscopic and optical photometric surveys and cover much larger volumes. Therefore, they will be specially powerful to constrain physics which has impact on the largest observable scales, such as primordial non Gaussianity. On the other hand, intensity mapping experiments can reach higher redshifts than galaxy surveys, but the cosmological information of this signal is coupled with astrophysics. We propose a methodology to disentangle astrophysics and optimally extract cosmological information from the intensity mapping spectrum. Thanks to this methodology, intensity mapping will constrain the expansion history of the Universe up to reionization, as shown in this thesis.",
-				"journalAbbreviation": "Ph.D. Thesis",
+				"abstractNote": "Cosmology is the science that studies the Universe as whole, aiming to understand its origin, composition and evolution. During the last decades, cosmology has transitioned from a \"data staved\" to a \"data driven\" science, inaugurating what is known as precision cosmology. This huge observational effort has confirmed and fostered theoretical research, and established the standard model of cosmology: Lambda-Cold Dark Matter (LCDM). This model successfully reproduces most of the observations. However, there are some persistent tensions between experiments that might be smoking guns of new physics beyond this model. Anyways, there is a difference between modeling and understanding, and LCDM is a phenomenological model that, for instance, does not describe the nature of the dark matter or dark energy. This thesis collects part of my research focused on pushing the limits of the standard cosmological model and its assumptions, regarding also existing tensions between experiments. New strategies to optimize the performance of future experiments are also proposed and discussed. The largest existing tension is between the direct measurements of the Hubble constant using the distance ladder in the local Universe and the inferred value obtained from observations of the Cosmic Microwave Background when LCDM is assumed. A model independent reconstruction of the late-time expansion history of the Universe is carried out, which allows us to identify possible sources and solutions of the tension. We also introduce the concept of the low redshift standard ruler, and measure it in a model independent way. Finally, we introduce a statistical methodology to analyze several data sets in a conservative way, no matter the level of discrepancy between them, accounting for the potential presence of systematic errors. The role of primordial black holes as candidates for dark matter is addressed in this thesis, too. Concretely, the impact of an abundant population of primordial black holes in the rest of cosmological parameters is discussed, considering also populations with extended mass distributions. In addition, massive primordial black holes might be the seeds that are needed to explain the origin of the supermassive black holes located in the center of the galaxies. We predict the contribution of a population of massive primordial black holes to the 21 cm radiation from the dark ages. This way, observations of the 21 cm intensity mapping observations of the dark ages could be used to ascertain if the seeds of the supermassive black holes are primordial. Finally, we estimate the potential of radio-continuum galaxy surveys to constrain LCDM. These kind of experiments can survey the sky quicker than spectroscopic and optical photometric surveys and cover much larger volumes. Therefore, they will be specially powerful to constrain physics which has impact on the largest observable scales, such as primordial non Gaussianity. On the other hand, intensity mapping experiments can reach higher redshifts than galaxy surveys, but the cosmological information of this signal is coupled with astrophysics. We propose a methodology to disentangle astrophysics and optimally extract cosmological information from the intensity mapping spectrum. Thanks to this methodology, intensity mapping will constrain the expansion history of the Universe up to reionization, as shown in this thesis.",
 				"libraryCatalog": "NASA ADS",
-				"publicationTitle": "Ph.D. Thesis",
-				"url": "http://adsabs.harvard.edu/abs/2019PhDT........69B",
+				"url": "https://ui.adsabs.harvard.edu/abs/2019PhDT........69B",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://ui.adsabs.harvard.edu/abs/2022MSSP..16208010Y/abstract",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Bio-inspired toe-like structure for low-frequency vibration isolation",
+				"creators": [
+					{
+						"lastName": "Yan",
+						"firstName": "Ge",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Zou",
+						"firstName": "Hong-Xiang",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Wang",
+						"firstName": "Sen",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Zhao",
+						"firstName": "Lin-Chuan",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Wu",
+						"firstName": "Zhi-Yuan",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Zhang",
+						"firstName": "Wen-Ming",
+						"creatorType": "author"
+					}
+				],
+				"date": "January 1, 2022",
+				"DOI": "10.1016/j.ymssp.2021.108010",
+				"ISSN": "0888-3270",
+				"abstractNote": "Inspired by the cushioning effect of the felid paws in contact with the ground, a novel bio-inspired toe-like structure (TLS) is developed and systematically studied for low-frequency vibration isolation. The TLS consists of two rods with different length (as phalanxes) and a linear spring (as muscle). Based on Hamiltonian principle, the dynamic model is established considering spring deformation and joint rotation damping. The derived equivalent stiffness reveals that the proposed TLS possesses favorable high static and low dynamic stiffness (HSLDS) characteristics in a wide displacement range. Besides, displacement transmissibility suggests that the proposed TLS isolator has low resonance frequency and can effectively isolate base excitation at low frequencies. Comprehensive parameter analysis shows that the inherent nonlinearities in stiffness and damping is conductive to vibration isolation and can be designed/adjusted on demand by selecting suitable structural parameters. This flexibility gives TLS advantages and great potential in extensive engineering applications when subjected to variable vibration loads. A prototype is fabricated and tested for a comprehensive recognize of its advantageous vibration isolation performance in low frequency band. The vibration with excitation frequency higher than 3 Hz can be effectively isolated. This novel bio-inspired TLS provides a feasible approach to passive vibration control and isolation in low frequency band.",
+				"journalAbbreviation": "Mechanical Systems and Signal Processing",
+				"libraryCatalog": "NASA ADS",
+				"pages": "108010",
+				"publicationTitle": "Mechanical Systems and Signal Processing",
+				"url": "https://ui.adsabs.harvard.edu/abs/2022MSSP..16208010Y",
+				"volume": "162",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Bio-inspired structure"
+					},
+					{
+						"tag": "Low-frequency vibration"
+					},
+					{
+						"tag": "Nonlinear dynamics"
+					},
+					{
+						"tag": "Vibration isolation"
+					}
+				],
 				"notes": [],
 				"seeAlso": []
 			}

--- a/NASA ADS.js
+++ b/NASA ADS.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-06-15 15:35:37"
+	"lastUpdated": "2021-06-15 15:43:55"
 }
 
 /*
@@ -53,7 +53,7 @@ function getSearchResults(doc) {
 }
 
 function extractId(url) {
-	return /\/abs\/(.*)\/abstract/.exec(url)[1];
+	return /\/abs\/([^/]+)/.exec(url)[1];
 }
 
 function getTypeFromId(id) {
@@ -109,7 +109,7 @@ function scrape(ids, doc) {
 			translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7"); // RIS
 			translator.setString(json.export);
 			translator.setHandler("itemDone", function (obj, item) {
-				const id = ids.pop();
+				const id = extractId(item.url);
 				item.itemType = getTypeFromId(id);
 				item.attachments.push({
 					url: makePdfUrl(id),


### PR DESCRIPTION
ADS has a nice new API, but it requires a token to access. I experimented with creating an account and writing a proxy, but I realized that there's a much simpler way: we can just generate a temporary token exactly as the site does when you generate a citation in the browser, by calling the '/accounts/bootstrap' endpoint. Works great.

Updated old tests and added a new one, fixed a race condition that was causing PDFs to be attached to the wrong items. Everything now seems to be working just as it was before the update.

Fixes #2111, fixes #2457.