### PR TITLE
Amazon compatibility fixes and data cleaning improvements

### DIFF
--- a/Amazon.js
+++ b/Amazon.js
@@ -386,9 +386,10 @@ function scrape(doc, url) {
 			item.edition = m[2].trim()
 				.replace(/^(Auflage|Édition)\s?:/, '')
 				// "FISCHER Taschenbuch; 15. Auflage (1. Mai 1992)""
-				.replace(/\. (Auflage|Édition)\s*/, '');
+				.replace(/\. (Auflage|[EÉ]dition)\s*/, '');
 		}
-		if (m[3] && m[3].search(/\b\d{4}\b/) != -1) item.date = m[3].trim(); // Looks like a date
+		// Looks like a date
+		if (m[3] && m[3].search(/\b\d{4}\b/) != -1) item.date = ZU.strToISO(m[3].trim());
 	}
 	var pages = getField(info, 'Hardcover') || getField(info, 'Paperback') || getField(info, 'Print Length');
 	if (pages) item.numPages = parseInt(pages);

--- a/Amazon.js
+++ b/Amazon.js
@@ -8,14 +8,9 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsbv",
-	"lastUpdated": "2020-09-04 21:40:05"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2021-06-24 16:06:30"
 }
-
-// attr()/text() v2
-// eslint-disable-next-line
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
-
 
 function detectWeb(doc, _url) {
 	if (getSearchResults(doc, true)) {
@@ -481,15 +476,15 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "April 1, 2010",
+				"date": "2010-04-01",
 				"ISBN": "9780810989894",
 				"abstractNote": "Now in paperback! Pass, and have it made. Fail, and suffer the consequences. A master of teen thrillers tests readers’ courage in an edge-of-your-seat novel that echoes the fears of exam-takers everywhere. Ann, a teenage girl living in the security-obsessed, elitist United States of the very near future, is threatened on her way home from school by a mysterious man on a black motorcycle. Soon she and a new friend are caught up in a vast conspiracy of greed involving the mega-wealthy owner of a school testing company. Students who pass his test have it made; those who don’t, disappear . . . or worse. Will Ann be next? For all those who suspect standardized tests are an evil conspiracy, here’s a thriller that really satisfies! Praise for Test “Fast-paced with short chapters that end in cliff-hangers . . . good read for moderately reluctant readers. Teens will be able to draw comparisons to contemporary society’s shift toward standardized testing and ecological concerns, and are sure to appreciate the spoofs on NCLB.” ―School Library Journal “Part mystery, part action thriller, part romance . . . environmental and political overtones . . . fast pace and unique blend of genres holds attraction for younger teen readers.” ―Booklist",
-				"edition": "Reprint Edition",
+				"edition": "Reprint edition",
 				"language": "English",
 				"libraryCatalog": "Amazon",
 				"numPages": 320,
 				"place": "New York",
-				"publisher": "Amulet Paperbacks",
+				"publisher": "Harry N. Abrams",
 				"attachments": [
 					{
 						"title": "Amazon.com Link",
@@ -505,7 +500,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=foot&x=0&y=0",
+		"url": "https://www.amazon.com/s?k=foot&i=stripbooks&x=0&y=0&ref=nb_sb_noss",
 		"items": "multiple"
 	},
 	{
@@ -541,7 +536,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.amazon.com/s?ie=UTF8&keywords=The%20Harvard%20Concise%20Dictionary%20of%20Music%20and%20Musicians&index=blended&Go=o",
+		"url": "https://www.amazon.com/s?k=The+Harvard+Concise+Dictionary+of+Music+and+Musicians&Go=o",
 		"items": "multiple"
 	},
 	{
@@ -599,7 +594,7 @@ var testCases = [
 					}
 				],
 				"date": "May 20, 2003",
-				"language": "English (Dolby Digital 5.1), English (DTS 5.1), French (Dolby Digital 5.1), Unqualified (DTS ES 6.1), English (Dolby Digital 2.0 Surround)",
+				"language": "English (Dolby Digital 2.0 Surround), English (Dolby Digital 5.1), English (DTS 5.1), French (Dolby Digital 5.1), Unqualified (DTS ES 6.1)",
 				"libraryCatalog": "Amazon",
 				"runningTime": "1 hour and 55 minutes",
 				"studio": "Sony Pictures Home Entertainment",
@@ -618,7 +613,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.amazon.com/gp/registry/registry.html?ie=UTF8&id=1Q7ELHV59D7N&type=wishlist",
+		"url": "https://www.amazon.com/gp/registry/registry.html?ie=UTF8&id=1Q7ELHV59D7N&type=wishlist",
 		"items": "multiple"
 	},
 	{
@@ -635,13 +630,13 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "17 août 2011",
+				"date": "2011",
 				"ISBN": "9782035866011",
 				"abstractNote": "Que signifie ce nom \"Candide\" : innocence de celui qui ne connaît pas le mal ou illusion du naïf qui n'a pas fait l'expérience du monde ? Voltaire joue en 1759, après le tremblement de terre de Lisbonne, sur ce double sens. Il nous fait partager les épreuves fictives d'un jeune homme simple, confronté aux leurres de l'optimisme, mais qui n'entend pas désespérer et qui en vient à une sagesse finale, mesurée et mystérieuse. Candide n'en a pas fini de nous inviter au gai savoir et à la réflexion.",
+				"edition": "Larousse édition",
 				"language": "Français",
 				"libraryCatalog": "Amazon",
 				"numPages": 176,
-				"place": "Paris",
 				"publisher": "Larousse",
 				"attachments": [
 					{
@@ -670,7 +665,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "1. Mai 1992",
+				"date": "1992",
 				"ISBN": "9783596105816",
 				"abstractNote": "Gleich bei seinem Erscheinen in den 40er Jahren löste Jorge Luis Borges’ erster Erzählband »Fiktionen« eine literarische Revolution aus. Erfundene Biographien, fiktive Bücher, irreale Zeitläufe und künstliche Realitäten verflocht Borges zu einem geheimnisvollen Labyrinth, das den Leser mit seinen Rätseln stets auf neue herausfordert. Zugleich begründete er mit seinen berühmten Erzählungen wie»›Die Bibliothek zu Babel«, «Die kreisförmigen Ruinen« oder»›Der Süden« den modernen »Magischen Realismus«. »Obwohl sie sich im Stil derart unterscheiden, zeigen zwei Autoren uns ein Bild des nächsten Jahrtausends: Joyce und Borges.« Umberto Eco",
 				"edition": "15",
@@ -707,11 +702,11 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "1 Dec. 2010",
+				"date": "2010-12-01",
 				"abstractNote": "Novel by Charles Dickens, published both serially and in book form in 1859. The story is set in the late 18th century against the background of the French Revolution. Although Dickens borrowed from Thomas Carlyle's history, The French Revolution, for his sprawling tale of London and revolutionary Paris, the novel offers more drama than accuracy. The scenes of large-scale mob violence are especially vivid, if superficial in historical understanding. The complex plot involves Sydney Carton's sacrifice of his own life on behalf of his friends Charles Darnay and Lucie Manette. While political events drive the story, Dickens takes a decidedly antipolitical tone, lambasting both aristocratic tyranny and revolutionary excess--the latter memorably caricatured in Madame Defarge, who knits beside the guillotine. The book is perhaps best known for its opening lines, \"It was the best of times, it was the worst of times,\" and for Carton's last speech, in which he says of his replacing Darnay in a prison cell, \"It is a far, far better thing that I do, than I have ever done; it is a far, far better rest that I go to, than I have ever known.\" -- The Merriam-Webster Encyclopedia of Literature",
 				"language": "English",
 				"libraryCatalog": "Amazon",
-				"numPages": 264,
+				"numPages": 290,
 				"publisher": "Public Domain Books",
 				"attachments": [
 					{
@@ -740,19 +735,20 @@ var testCases = [
 						"creatorType": "author"
 					},
 					{
-						"firstName": "B.",
+						"firstName": "Björn",
 						"lastName": "Berg",
 						"creatorType": "contributor"
 					},
 					{
-						"firstName": "A. Palme Larussa",
+						"firstName": "Annuska Palme Larussa",
 						"lastName": "Sanavio",
 						"creatorType": "translator"
 					}
 				],
-				"date": "26 giugno 2008",
+				"date": "2008",
 				"ISBN": "9788882038670",
 				"abstractNote": "Si pensa che soprattutto in una casa moderna, con prese elettriche, gas, balconi altissimi un bambino possa mettersi in pericolo: Emil vive in una tranquilla casa di campagna, ma riesce a ficcare la testa in una zuppiera e a rimanervi incastrato, a issare la sorellina Ida in cima all'asta di una bandiera, e a fare una tale baldoria alla fiera del paese che i contadini decideranno di organizzare una colletta per spedirlo in America e liberare così la sua povera famiglia. Ma questo succederà nel prossimo libro di Emil, perché ce ne sarà un altro, anzi due, tante sono le sue monellerie. Età di lettura: da 7 anni.",
+				"edition": "3° edizione",
 				"language": "Italiano",
 				"libraryCatalog": "Amazon",
 				"numPages": 72,
@@ -792,16 +788,6 @@ var testCases = [
 					{
 						"firstName": "Jordan",
 						"lastName": "Nagai",
-						"creatorType": "castMember"
-					},
-					{
-						"firstName": "Ed",
-						"lastName": "Asner",
-						"creatorType": "castMember"
-					},
-					{
-						"firstName": "Christopher",
-						"lastName": "Plummer",
 						"creatorType": "castMember"
 					},
 					{
@@ -848,7 +834,7 @@ var testCases = [
 					}
 				],
 				"libraryCatalog": "Amazon",
-				"runningTime": "1:08:58",
+				"runningTime": "1:09:16",
 				"attachments": [
 					{
 						"title": "Amazon.com Link",
@@ -876,10 +862,11 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2012/8/2",
+				"date": "2012-08-02",
 				"ISBN": "9780099578079",
 				"abstractNote": "The year is 1Q84.  This is the real world, there is no doubt about that.   But in this world, there are two moons in the sky.   In this world, the fates of two people, Tengo and Aomame, are closely intertwined. They are each, in their own way, doing something very dangerous. And in this world, there seems no way to save them both.   Something extraordinary is starting.",
-				"language": "英語",
+				"edition": "Combined edition",
+				"language": "English",
 				"libraryCatalog": "Amazon",
 				"numPages": 1328,
 				"publisher": "Vintage",
@@ -899,7 +886,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.amazon.com/Mark-LeBar/e/B00BU8L2DK",
+		"url": "https://www.amazon.com/Mark-LeBar/e/B00BU8L2DK",
 		"items": "multiple"
 	},
 	{
@@ -921,7 +908,7 @@ var testCases = [
 						"creatorType": "editor"
 					}
 				],
-				"date": "April 28, 1998",
+				"date": "1998-04-28",
 				"ISBN": "9780521418195",
 				"abstractNote": "The first printed text of Shakespeare's Hamlet is about half the length of the more familiar second quarto and Folio versions. It reorders and combines key plot elements to present its own workable alternatives. This is the only modernized critical edition of the 1603 quarto in print. Kathleen Irace explains its possible origins, special features and surprisingly rich performance history, and while describing textual differences between it and other versions, offers alternatives that actors or directors might choose for specific productions.",
 				"edition": "First Edition",
@@ -957,10 +944,9 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "1977/9/16",
+				"date": "1977-09-16",
 				"ISBN": "9784003314210",
-				"abstractNote": "帯ありません。若干のスレはありますがほぼ普通です。小口、天辺に少しヤケがあります。中身は少しヤケはありますがきれいです。",
-				"language": "日本語",
+				"language": "Japanese",
 				"libraryCatalog": "Amazon",
 				"publisher": "岩波書店",
 				"attachments": [
@@ -990,7 +976,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "April 24, 2018",
+				"date": "2018-04-24",
 				"ISBN": "9781333821388",
 				"abstractNote": "Excerpt from Studies in Saiva-SiddhantaEuropean Sanskritist, unaware perhaps of the bearings of the expression, rendered the collocation Parama-hamsa' into 'great goose'. The strictly pedagogic purist may endeavour to justify such puerile versions on etymological grounds, but they stand Self-condemned as mal-interpretations reﬂecting anything but the sense and soul of the original. Such lapses into unwitting ignorance, need never be expected in any of the essays contained in the present collection, as our author is not only a sturdy and indefatigable researcher in Tamil philosophic literature illuminative Of the Agamic religion, but has also, in his quest after Truth, freely utilised the services of those Indigenous savam's, who represent the highest water-mark of Hindu traditional learning and spiritual associations at the present-day.About the PublisherForgotten Books publishes hundreds of thousands of rare and classic books. Find more at www.forgottenbooks.comThis book is a reproduction of an important historical work. Forgotten Books uses state-of-the-art technology to digitally reconstruct the work, preserving the original format whilst repairing imperfections present in the aged copy. In rare cases, an imperfection in the original, such as a blemish or missing page, may be replicated in our edition. We do, however, repair the vast majority of imperfections successfully; any imperfections that remain are intentionally left to preserve the state of such historical works.",
 				"language": "English",
@@ -1035,8 +1021,8 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2015年5月1日",
-				"abstractNote": "《中国之翼》是一本书写了一段未被透露的航空编年史的篇章，它讲述了二战时期亚洲战场动荡的背景下的航空冒险的扣人心弦的故事。故事的主体是激动人心的真实的“空中兄弟连”的冒险事迹。正是这些人在二战期间帮助打开了被封锁的中国的天空，并勇敢的在各种冲突中勇敢守卫着它。这是一段值得被更多的中国人和美国人知晓并铭记的航空史和中美关系史。",
+				"date": "2015-05-01",
+				"edition": "第 1st 版",
 				"libraryCatalog": "Amazon",
 				"publisher": "社会科学文献出版社",
 				"attachments": [

--- a/Amazon.js
+++ b/Amazon.js
@@ -353,6 +353,8 @@ function scrape(doc, url) {
 				key = key.replace(/\s*:\s*$/, "");
 				// Extra colon in Language field as of 9/4/2020
 				key = key.replace(/\s*:$/, '');
+				// The colon is surrounded by RTL/LTR marks as of 6/24/2021
+				key = key.replace(/[\s\u200e\u200f]*:[\s\u200e\u200f]*$/, '');
 				info[key.toLowerCase()] = value.trim();
 			}
 		}


### PR DESCRIPTION
The Amazon translator broke because of two puny RTL/LTR control characters. Fixed that, plus some test regressions due to changes in edition strings. Haven't fixed every single one of those - that'll have to wait for localized `cleanEdition`.

Fixes #2489.