### PR TITLE
WorldCat Discovery: Support v2 site

### DIFF
--- a/WorldCat Discovery Service.js
+++ b/WorldCat Discovery Service.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "fd8dc5f6-a6dd-42b2-948f-600f5da844ea",
 	"label": "WorldCat Discovery Service",
-	"creator": "Sebastian Karcher",
+	"creator": "Sebastian Karcher and Abe Jellinek",
 	"target": "^https?://[^/]+\\.worldcat\\.org/",
 	"minVersion": "3.0.9",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsbv",
-	"lastUpdated": "2019-11-26 22:21:07"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2021-06-28 18:41:34"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 	
-	WorldCat Discovery Service translator; Copyright © 2015 Sebastian Karcher
+	Copyright © 2015-2021 Sebastian Karcher and Abe Jellinek
 	This file is part of Zotero.
 	
 	Zotero is free software: you can redistribute it and/or modify
@@ -34,19 +34,56 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(doc, _url) {
-	var results = getSearchResults(doc);
-	if (results.length) {
+function detectWeb(doc, url) {
+	if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
 
-	// single result
-	// generate item and return type
-	var co = getFirstContextObj(doc);
-	if (ZU.xpathText(doc, '//input[@id="dbList"]/@value') && co) {
-		return generateItem(doc, co).itemType;
+	if (doc.querySelector('div#root')) {
+		if (extractOCLCID(url)) {
+			// we're on a v2 page
+			// we need to get the item type. this selector isn't stable, but the
+			// worst that can happen is an incorrect toolbar button icon.
+			
+			let displayItemType = displayTypeToZotero(
+				text(doc, '[data-testid="publisher-info"] strong')
+			);
+			
+			if (!displayItemType) {
+				Z.monitorDOMChanges(doc.querySelector('div#root'));
+			}
+			
+			return displayItemType;
+		}
+		else if (url.includes('/search')) {
+			Z.monitorDOMChanges(doc.querySelector('div#root'));
+		}
 	}
+	else {
+		var co = getFirstContextObj(doc);
+		if (ZU.xpathText(doc, '//input[@id="dbList"]/@value') && co) {
+			return generateItem(doc, co).itemType;
+		}
+	}
+	
 	return false;
+}
+
+function displayTypeToZotero(displayType) {
+	if (!displayType) return false;
+	
+	if (displayType.includes('©')) {
+		displayType = displayType.substring(displayType.indexOf('©'));
+	}
+
+	displayType = ZU.trimInternal(displayType.replace(/\d/g, ''));
+
+	switch (displayType) {
+		case 'Article':
+			return 'journalArticle';
+		default:
+			return 'book';
+	}
 }
 
 /**
@@ -60,25 +97,41 @@ function generateItem(doc, co) {
 	return item;
 }
 
-function getSearchResults(doc) {
-	var results = ZU.xpath(doc, '//ol[@class="results"]/li[contains(@id, "record")]');
-	return results;
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="/search/detail/"]');
+	if (!rows.length) {
+		rows = doc.querySelectorAll('ol.results li[id*="record"]');
+	}
+	
+	for (let row of rows) {
+		let title = ZU.xpathText(row, './/div[contains(@class, "title") and a[@class="record-title"]]');
+		if (!title) title = ZU.trimInternal(row.textContent); // v2
+		let oclcID = ZU.xpathText(row, './@data-oclcnum');
+		if (!oclcID) oclcID = extractOCLCID(row.href); // v2
+		let databaseID = ZU.xpathText(row, './@data-database-list');
+		let risURL = composeURL(oclcID, databaseID);
+		if (!title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[risURL] = title;
+	}
+	return found ? items : false;
 }
 
 function getFirstContextObj(doc) {
 	return ZU.xpathText(doc, '//span[contains(@class, "Z3988")][1]/@title');
 }
 
-
 /**
  * Given an item URL, extract OCLC ID
  */
 function extractOCLCID(url) {
-	var id = url.match(/\/oclc\/([^?]+)/);
+	var id = url.match(/\/(?:oclc|detail)\/([^?]+)/);
 	if (!id) return false;
 	return id[1];
 }
-
 
 /**
  * Given an item URL, extract database ID
@@ -134,9 +187,11 @@ function scrape(risURL) {
 			// remove space before colon
 			item.title = item.title.replace(/\s+:/, ":");
 
-			// remove trailing colon after place
+			// remove trailing colon and brackets from place
 			if (item.place) {
-				item.place = item.place.replace(/:\s*$/, "");
+				item.place = item.place
+					.replace(/:\s*$/, "")
+					.replace(/\[(.*)\]/, '$1');
 			}
 
 			// remove traling period after publication
@@ -177,6 +232,24 @@ function scrape(risURL) {
 					delete item.url;
 				}
 			}
+			
+			if (item.series) {
+				item.series = item.series.replace(/\.$/, '');
+				if (item.series.split(';').length == 2) {
+					[item.series, item.seriesNumber] = item.series.split(';');
+				}
+			}
+			
+			if (item.edition) {
+				item.edition = item.edition.replace(/\.$/, '');
+			}
+			
+			for (let creator of item.creators) {
+				if (!creator.firstName) continue;
+				creator.firstName = creator.firstName
+					.replace(/\(?[\d-,:\s]+\)?(\.*$)/, '$1')
+					.replace(/(\w{2,})\./, '$1');
+			}
 
 			item.complete();
 		});
@@ -192,30 +265,11 @@ function scrape(risURL) {
 }
 
 function doWeb(doc, url) {
-	var results = getSearchResults(doc);
 	if (detectWeb(doc, url) == "multiple") {
-		var items = {};
-		var articles = [];
-		for (var i = 0, n = results.length; i < n; i++) {
-			let title = ZU.xpathText(results[i], './/div[contains(@class, "title") and a[@class="record-title"]]');
-			// Z.debug(title)
-			if (!title) continue;
-			let oclcID = ZU.xpathText(results[i], './@data-oclcnum');
-			// Z.debug(oclcID)
-			let databaseID = ZU.xpathText(results[i], './@data-database-list');
-			// Z.debug(databaseID)
-			let risURL = composeURL(oclcID, databaseID);
-			Z.debug(risURL);
-			items[risURL] = title.trim();
-		}
-
-		Zotero.selectItems(items, function (items) {
-			if (!items) return;
-
-			for (var i in items) {
-				articles.push(i);
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (items) {
+				scrape(Object.keys(items));
 			}
-			scrape(articles);
 		});
 	}
 	else {
@@ -297,6 +351,237 @@ var testCases = [
 						"snapshot": false
 					}
 				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://goshen.on.worldcat.org/v2/search/detail/62727772?queryString=Human-Computer%20Interaction&clusterResults=true&groupVariantRecords=false",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Encyclopedia of human computer interaction",
+				"creators": [
+					{
+						"lastName": "Ghaoui",
+						"firstName": "Claude",
+						"creatorType": "author"
+					}
+				],
+				"date": "2006",
+				"ISBN": "9781591407980 9781280706820 9786610706822",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"numberOfVolumes": "1 online resource (xviii, 738, [24] pages) : illustrations",
+				"place": "Hershey PA",
+				"publisher": "Idea Group Reference",
+				"series": "Gale virtual reference library",
+				"url": "http://www.books24x7.com/marc.asp?bookid=14703",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://goshen.on.worldcat.org/v2/search/detail/57358293?queryString=harry%20potter&clusterResults=true&groupVariantRecords=false",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Harry Potter and the Half-Blood Prince",
+				"creators": [
+					{
+						"lastName": "Rowling",
+						"firstName": "J. K.",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "GrandPré",
+						"firstName": "Mary",
+						"creatorType": "author"
+					}
+				],
+				"date": "2005",
+				"ISBN": "9780439784542 9780439786775 9780439791328 9780439785969 9780329552510 9780605000230 9781408835012 9780545582995 9781415592946 9780329414382 9780786277452 9781419354342 9780439906296 9781338299199 9780756967659",
+				"edition": "First American edition",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"numPages": "x, 652",
+				"place": "New York, NY",
+				"publisher": "Arthur A. Levine Books, an imprint of Scholastic Inc.",
+				"series": "Harry Potter Series",
+				"seriesNumber": "6",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://goshen.on.worldcat.org/v2/search?queryString=foundation%20asimov&clusterResults=true&groupVariantRecords=false",
+		"defer": true,
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://illinois.on.worldcat.org/v2/oclc/1233323459",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Pride and prejudice",
+				"creators": [
+					{
+						"lastName": "Austen",
+						"firstName": "Jane",
+						"creatorType": "author"
+					}
+				],
+				"date": "2020",
+				"ISBN": "9781513263427 9781513220963",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"numPages": "308",
+				"place": "Portland, Oregon",
+				"publisher": "Mint Editions",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://illinois.on.worldcat.org/v2/oclc/432674",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Quantitative modeling of the physiological factors in radiation lethality,",
+				"creators": [
+					{
+						"lastName": "Iberall",
+						"firstName": "Arthur S.",
+						"creatorType": "author"
+					}
+				],
+				"date": "1967",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"publicationTitle": "Annals of the New York Academy of Sciences",
+				"url": "http://www3.interscience.wiley.com/cgi-bin/fulltext/119756235/PDFSTART",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://illinois.on.worldcat.org/v2/oclc/6995902131",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Jews Working in Agriculture in Poland in the First Years after the Second World War",
+				"creators": [
+					{
+						"lastName": "Rykala A.",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2016",
+				"DOI": "10.1515/esrp-2016-0010",
+				"ISSN": "1231-1952",
+				"issue": "2",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"pages": "49-63",
+				"publicationTitle": "European Spatial Research and Policy",
+				"volume": "23",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://illinois.on.worldcat.org/v2/oclc/1080997809",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "The ego and the id",
+				"creators": [
+					{
+						"lastName": "Freud",
+						"firstName": "Sigmund",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Berasaluce",
+						"firstName": "Andrea Jones",
+						"creatorType": "author"
+					}
+				],
+				"date": "2019",
+				"ISBN": "9781945186790",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"numPages": "66",
+				"place": "New York, NY",
+				"publisher": "Clydesdale Press",
+				"series": "Clydesdale classics",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://illinois.on.worldcat.org/v2/oclc/654235026",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "International financial policy: essays in honor of Jacques J. Polak",
+				"creators": [
+					{
+						"lastName": "Polak",
+						"firstName": "J. J. (Jacques Jacobus)",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Frenkel",
+						"firstName": "Jacob A.",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Goldstein",
+						"firstName": "Morris",
+						"creatorType": "author"
+					}
+				],
+				"date": "1991",
+				"ISBN": "9781455248681 9781283536660 9781455295173",
+				"language": "English",
+				"libraryCatalog": "WorldCat Discovery Service",
+				"numberOfVolumes": "1 online resource (xiv, 508 pages) : illustrations",
+				"place": "Washington, D.C.",
+				"publisher": "International Monetary Fund",
+				"shortTitle": "International financial policy",
+				"url": "https://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=449390",
+				"attachments": [],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []


### PR DESCRIPTION
I pursued two metadata sources for this: RIS, which the original translator uses, and internal WorldCat metadata. WorldCat metadata is promising: it includes correct creator types (everyone is AU in the RIS), cleaner creator names, and an abstract. But it's locked behind a client-generated API key system that requires access to the JS HMAC API. I wrote a hosted lambda function to generate the required values, but after a day of working on a translator, I was still only getting passable data. It was a fragile approach with significant data-cleaning issues.

Although there are downsides to the RIS they give us, users are already used to them. We can stick with it for now.

Fixes #2320.