### PR TITLE
ScienceDirect: Detect search pages correctly, normalize name spacing

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -9,12 +9,31 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-10-27 06:55:27"
+	"lastUpdated": "2021-07-01 19:17:31"
 }
 
-// attr()/text() v2
-// eslint-disable-next-line
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;} 
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2021 Michael Berkowitz and Aurimas Vinckevicius
+	
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
 
 
 function detectWeb(doc, url) {
@@ -39,8 +58,15 @@ function detectWeb(doc, url) {
 		}
 	}
 
-	if (url.search(/\/search[?/]/) != -1 && getArticleList(doc).length > 0) {
-		return "multiple";
+	if (url.search(/\/search[?/]/) != -1) {
+		if (getArticleList(doc).length > 0) {
+			return "multiple";
+		}
+		else if (doc.querySelector('.LoadingOverlay.show')) {
+			// monitor and update the toolbar icon when results have loaded
+			Z.monitorDOMChanges(doc.querySelector('.results-container'));
+			return false;
+		}
 	}
 	if (!url.includes("pdf")) {
 		// Book sections have the ISBN in the URL

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -303,10 +303,16 @@ function processRIS(doc, text) {
 		for (var i = 0, n = item.creators.length; i < n; i++) {
 			// add spaces after initials
 			if (item.creators[i].firstName) {
-				item.creators[i].firstName = item.creators[i].firstName.replace(/\.\s*(?=\S)/g, '. ');
+				item.creators[i].firstName = item.creators[i].firstName
+					.replace(/\.\s*(?=\S)/g, '. ')
+					.replace(/\s/g, ' '); // NBSP, etc -> space
+			}
+			if (item.creators[i].lastName) {
+				item.creators[i].lastName = item.creators[i].lastName
+					.replace(/\s/g, ' ');
 			}
 			// fix all uppercase lastnames
-			if (item.creators && item.creators[i].lastName.toUpperCase() == item.creators[i].lastName) {
+			if (item.creators[i].lastName.toUpperCase() == item.creators[i].lastName) {
 				item.creators[i].lastName = item.creators[i].lastName.charAt(0) + item.creators[i].lastName.slice(1).toLowerCase();
 			}
 		}

--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -516,12 +516,12 @@ var testCases = [
 				"creators": [
 					{
 						"lastName": "Schaaf",
-						"firstName": "Christian P.",
+						"firstName": "Christian P.",
 						"creatorType": "author"
 					},
 					{
 						"lastName": "Zoghbi",
-						"firstName": "Huda Y.",
+						"firstName": "Huda Y.",
 						"creatorType": "author"
 					}
 				],
@@ -535,11 +535,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "806-808",
 				"publicationTitle": "Neuron",
-				"url": "http://www.sciencedirect.com/science/article/pii/S0896627311004430",
+				"url": "https://www.sciencedirect.com/science/article/pii/S0896627311004430",
 				"volume": "70",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					},
 					{
 						"title": "ScienceDirect Full Text PDF",
@@ -603,16 +604,12 @@ var testCases = [
 				"pages": "1286-1302",
 				"publicationTitle": "Biochimica et Biophysica Acta (BBA) - Molecular Cell Research",
 				"series": "Apoptosis in yeast",
-				"url": "http://www.sciencedirect.com/science/article/pii/S016748890800116X",
+				"url": "https://www.sciencedirect.com/science/article/pii/S016748890800116X",
 				"volume": "1783",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
-					},
-					{
-						"title": "ScienceDirect Full Text PDF",
-						"mimeType": "application/pdf",
-						"proxy": false
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -642,7 +639,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://www.sciencedirect.com/science/book/9780123694683",
+		"url": "https://www.sciencedirect.com/book/9780123694683/computational-materials-engineering",
 		"items": "multiple"
 	},
 	{
@@ -693,10 +690,11 @@ var testCases = [
 				"pages": "267-316",
 				"place": "Burlington",
 				"publisher": "Academic Press",
-				"url": "http://www.sciencedirect.com/science/article/pii/B9780123694683500083",
+				"url": "https://www.sciencedirect.com/science/article/pii/B9780123694683500083",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -734,10 +732,11 @@ var testCases = [
 				"pages": "295-305",
 				"place": "Oxford",
 				"publisher": "Academic Press",
-				"url": "http://www.sciencedirect.com/science/article/pii/B9780123706263000508",
+				"url": "https://www.sciencedirect.com/science/article/pii/B9780123706263000508",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -797,7 +796,7 @@ var testCases = [
 					},
 					{
 						"lastName": "Smith",
-						"firstName": "Jeremy C.",
+						"firstName": "Jeremy C.",
 						"creatorType": "author"
 					},
 					{
@@ -817,11 +816,12 @@ var testCases = [
 				"pages": "849-858",
 				"publicationTitle": "Biophysical Journal",
 				"shortTitle": "Unwrapping of Nucleosomal DNA Ends",
-				"url": "http://www.sciencedirect.com/science/article/pii/S0006349512000835",
+				"url": "https://www.sciencedirect.com/science/article/pii/S0006349512000835",
 				"volume": "102",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					},
 					{
 						"title": "ScienceDirect Full Text PDF",
@@ -899,15 +899,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "267-276",
 				"publicationTitle": "The Lancet",
-				"url": "http://www.sciencedirect.com/science/article/pii/S014067361362228X",
+				"url": "https://www.sciencedirect.com/science/article/pii/S014067361362228X",
 				"volume": "383",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
-					},
-					{
-						"title": "ScienceDirect Full Text PDF",
-						"mimeType": "application/pdf"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -918,7 +915,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.sciencedirect.com/science/article/abs/pii/0584853976801316",
+		"url": "https://www.sciencedirect.com/science/article/pii/0584853976801316",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -955,15 +952,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "663-672",
 				"publicationTitle": "Spectrochimica Acta Part A: Molecular Spectroscopy",
-				"url": "http://www.sciencedirect.com/science/article/pii/0584853976801316",
+				"url": "https://www.sciencedirect.com/science/article/pii/0584853976801316",
 				"volume": "32",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
-					},
-					{
-						"title": "ScienceDirect Full Text PDF",
-						"mimeType": "application/pdf"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -996,15 +990,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "255-261",
 				"publicationTitle": "Journal of Sound and Vibration",
-				"url": "http://www.sciencedirect.com/science/article/pii/0022460X72904348",
+				"url": "https://www.sciencedirect.com/science/article/pii/0022460X72904348",
 				"volume": "25",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
-					},
-					{
-						"title": "ScienceDirect Full Text PDF",
-						"mimeType": "application/pdf"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -1042,11 +1033,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "2775-2785",
 				"publicationTitle": "Journal of Integrative Agriculture",
-				"url": "http://www.sciencedirect.com/science/article/pii/S2095311916614284",
+				"url": "https://www.sciencedirect.com/science/article/pii/S2095311916614284",
 				"volume": "15",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					},
 					{
 						"title": "ScienceDirect Full Text PDF",
@@ -1079,6 +1071,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "http://www.sciencedirect.com/search?qs=zotero&show=25&sortBy=relevance",
+		"defer": true,
 		"items": "multiple"
 	},
 	{
@@ -1135,16 +1128,12 @@ var testCases = [
 				"libraryCatalog": "ScienceDirect",
 				"pages": "2766-2774",
 				"publicationTitle": "Acta de Investigación Psicológica",
-				"url": "http://www.sciencedirect.com/science/article/pii/S2007471917300571",
+				"url": "https://www.sciencedirect.com/science/article/pii/S2007471917300571",
 				"volume": "7",
 				"attachments": [
 					{
-						"title": "ScienceDirect Snapshot"
-					},
-					{
-						"title": "ScienceDirect Full Text PDF",
-						"mimeType": "application/pdf",
-						"proxy": false
+						"title": "ScienceDirect Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -1187,6 +1176,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://www.sciencedirect.com/search/advanced?qs=testing",
+		"defer": true,
 		"items": "multiple"
 	}
 ]


### PR DESCRIPTION
`detectWeb` uses `journalArticle` as a fallback type after tests for all other types have failed (the opposite of the way most translators do it, but it makes sense for this site). That was causing empty/not-yet-loaded search pages to show as `journalArticle`s, and the toolbar icon wouldn't update once loading completed.

Also added some code to normalize spacing in names (a lot of author names contain non-breaking spaces, which is unusual), removed `attr`/`text`, and added a license block.