### PR TITLE
RIS: Fix parsing error when attachment URL is not encoded correctly

### DIFF
--- a/RIS.js
+++ b/RIS.js
@@ -1395,9 +1395,16 @@ function processTag(item, tagValue, risEntry, allowDeprecated) {
 					
 					//get title from file name
 					title = url.match(/([^\/\\]+)(?:\.\w{1,8})$/);
-					if (title) title = decodeURIComponent(title[1]);
-					else title = "Attachment";
-					
+					if (title) {
+						try {
+							title = decodeURIComponent(title[1]);
+						}
+						catch (e) {}
+					}
+					else {
+						title = "Attachment";
+					}
+
 					if (zField[1] == 'HTML') {
 						title = "Full Text (HTML)";
 						mimeType = "text/html";

--- a/RIS.js
+++ b/RIS.js
@@ -1399,7 +1399,9 @@ function processTag(item, tagValue, risEntry, allowDeprecated) {
 						try {
 							title = decodeURIComponent(title[1]);
 						}
-						catch (e) {}
+						catch (e) {
+							title = title[1];
+						}
 					}
 					else {
 						title = "Attachment";

--- a/RIS.js
+++ b/RIS.js
@@ -17,7 +17,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 3,
-	"lastUpdated": "2021-06-09 16:35:41"
+	"lastUpdated": "2021-07-09 05:32:22"
 }
 
 function detectImport() {


### PR DESCRIPTION
See report https://forums.zotero.org/discussion/90606/error-importing-from-paperpile-report-id-506998060

Report log contains
> [JavaScript Error: "URIError: malformed URI sequence" {file: "chrome://zotero/content/xpcom/translation/translate_firefox.js line 425 > eval" line: 1398}]"