### PR TITLE
CI: Don't limit fetch depth at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       # and get more history on the current branch so we can find the branch point
       - run: git fetch origin master:master --depth=1
         if: github.ref != 'refs/heads/master'
-      - run: git fetch --update-shallow --depth=50 origin $(git rev-list HEAD)
+      - run: git fetch --update-shallow origin $(git rev-list HEAD)
       
       - name: Install Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
I'm not so sure that limiting fetch depth is actually gaining us anything, and it makes reviewing old (you know, > 2 weeks) PRs difficult. I'm not entirely sure that this tweak will fix the problem, but it's worth a try.