### PR TITLE
zotero.org: Don't try to scrape multiples when empty

### DIFF
--- a/zotero.org.js
+++ b/zotero.org.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsv",
-	"lastUpdated": "2020-02-21 14:40:54"
+	"lastUpdated": "2021-07-18 22:33:42"
 }
 
 /*
@@ -138,7 +138,8 @@ function detectWeb(doc, url) {
 
 	const multipleItemsDataEl = doc.querySelector('script#translator-items-list');
 
-	if (multipleItemsDataEl) {
+	if (multipleItemsDataEl
+		&& Object.keys(JSON.parse(multipleItemsDataEl.textContent)).length) {
 		return 'multiple';
 	}
 
@@ -306,6 +307,5 @@ var testCases = [
 		"defer": true,
 		"items": "multiple"
 	}
-
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
Previously, opening an empty collection would display the folder icon in the connector. When clicked, the translator would try to call `selectItems` with empty input and the connector would display an error. This fixes detection so that we no longer detect anything if we're in an empty collection.