### PR TITLE
Twitter: Don't detect untitled tweet views, fix link attachment regressions

### DIFF
--- a/Twitter.js
+++ b/Twitter.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-07-20 02:25:24"
+	"lastUpdated": "2021-07-22 20:11:59"
 }
 
 /*
@@ -61,7 +61,7 @@ function unshortenURLs(doc, str) {
 
 function unshortenURL(doc, tCoURL) {
 	var a = doc.querySelector('a[href*="' + tCoURL + '"]');
-	return (a ? a.title : false) || tCoURL;
+	return (a ? a.textContent.replace(/…$/, '') : false) || tCoURL;
 }
 
 function extractURLs(doc, str) {
@@ -270,7 +270,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "blogPost",
-				"title": "Zotero 3.0 beta is now available with duplicate detection and tons more. Runs outside Firefox with Chrome or Safari! http://t.co/bRvJgRy",
+				"title": "Zotero 3.0 beta is now available with duplicate detection and tons more. Runs outside Firefox with Chrome or Safari! http://zotero.org/blog/announcing-zotero-3-0-beta-release/",
 				"creators": [
 					{
 						"lastName": "Zotero",
@@ -289,7 +289,7 @@ var testCases = [
 						"mimeType": "text/html"
 					},
 					{
-						"title": "Link",
+						"title": "Link (zotero.org)",
 						"mimeType": "text/html",
 						"snapshot": false
 					}
@@ -344,7 +344,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "blogPost",
-				"title": "You don’t have to send students to a site that will spam them with ads or try to charge them money just to build a bibliography. Instead, tell them about ZoteroBib, the free, open-source, privacy-protecting bibliography generator from Zotero. https://t.co/iPP102WB1D",
+				"title": "You don’t have to send students to a site that will spam them with ads or try to charge them money just to build a bibliography. Instead, tell them about ZoteroBib, the free, open-source, privacy-protecting bibliography generator from Zotero. https://zbib.org",
 				"creators": [
 					{
 						"lastName": "Zotero",
@@ -363,7 +363,7 @@ var testCases = [
 						"mimeType": "text/html"
 					},
 					{
-						"title": "Link",
+						"title": "Link (zbib.org)",
 						"mimeType": "text/html",
 						"snapshot": false
 					}

--- a/Twitter.js
+++ b/Twitter.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-05-10 04:35:01"
+	"lastUpdated": "2021-07-20 02:25:24"
 }
 
 /*
@@ -36,12 +36,11 @@
    	***** END LICENSE BLOCK *****
 */
 
-// attr()/text() v2
-// eslint-disable-next-line
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
+
+let titleRe = /^(?:\(\d+\) )?(.+) .* Twitter: .([\S\s]+). \/ Twitter/;
 
 function detectWeb(doc, _url) {
-	if (_url.includes('/status/')) {
+	if (_url.includes('/status/') && titleRe.test(doc.title)) {
 		return "blogPost";
 	}
 	return false;
@@ -96,10 +95,10 @@ function scrape(doc, url) {
 	if (!/[A-Z]/.test(canonicalURL)) {
 		canonicalURL = url.match(/^([^?#]+)/)[1];
 	}
-	var originalTitle = text(doc, 'title');
+	var originalTitle = doc.title;
 	var unshortenedTitle = ZU.unescapeHTML(unshortenURLs(doc, originalTitle));
 	// Extract tweet from "[optional count] [Display Name] on Twitter: “[tweet]”"
-	var matches = unshortenedTitle.match(/^(?:\(\d+\) )?(.+) .* Twitter: .([\S\s]+). \/ Twitter/);
+	var matches = unshortenedTitle.match(titleRe);
 	var [, author, tweet] = matches;
 	
 	// Title is tweet with newlines removed
@@ -271,7 +270,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "blogPost",
-				"title": "Zotero 3.0 beta is now available with duplicate detection and tons more. Runs outside Firefox with Chrome or Safari! http://www.zotero.org/blog/announcing-zotero-3-0-beta-release/",
+				"title": "Zotero 3.0 beta is now available with duplicate detection and tons more. Runs outside Firefox with Chrome or Safari! http://t.co/bRvJgRy",
 				"creators": [
 					{
 						"lastName": "Zotero",
@@ -290,17 +289,13 @@ var testCases = [
 						"mimeType": "text/html"
 					},
 					{
-						"title": "Link (zotero.org)",
+						"title": "Link",
 						"mimeType": "text/html",
 						"snapshot": false
 					}
 				],
 				"tags": [],
-				"notes": [
-					{
-						"note": "<p>“Zotero 3.0 beta is now available with duplicate detection and tons more. Runs outside Firefox with Chrome or Safari!&nbsp; http://www.zotero.org/blog/announcing-zotero-3-0-beta-release/”</p>"
-					}
-				],
+				"notes": [],
 				"seeAlso": []
 			}
 		]
@@ -349,7 +344,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "blogPost",
-				"title": "You don’t have to send students to a site that will spam them with ads or try to charge them money just to build a bibliography. Instead, tell them about ZoteroBib, the free, open-source, privacy-protecting bibliography generator from Zotero. https://zbib.org",
+				"title": "You don’t have to send students to a site that will spam them with ads or try to charge them money just to build a bibliography. Instead, tell them about ZoteroBib, the free, open-source, privacy-protecting bibliography generator from Zotero. https://t.co/iPP102WB1D",
 				"creators": [
 					{
 						"lastName": "Zotero",
@@ -368,7 +363,7 @@ var testCases = [
 						"mimeType": "text/html"
 					},
 					{
-						"title": "Link (zbib.org)",
+						"title": "Link",
 						"mimeType": "text/html",
 						"snapshot": false
 					}


### PR DESCRIPTION
This primarily affects when a user opens a tweet by clicking on the image, not the text, to get the full-screen lightbox view. Twitter doesn't update the page title in that case, so it's very difficult for us to scrape anything useful. Previously the translator would detect 'blogPost' but error out in `doWeb`; now we'll just not detect anything at all. Better than a confusing error.