### PR TITLE
DOI: Prevent error when no DOIs on page resolve

### DIFF
--- a/DOI.js
+++ b/DOI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-03-13 02:38:54"
+	"lastUpdated": "2021-07-20 16:33:34"
 }
 
 /*
@@ -152,6 +152,12 @@ function retrieveDOIs(dois) {
 						select[doi] = item.title || "[" + item.DOI + "]";
 					}
 				}
+				
+				if (!Object.keys(select).length) {
+					Z.debug('No DOIs resolved correctly; select dialog will not display');
+					return;
+				}
+				
 				Zotero.selectItems(select, function (selectedDOIs) {
 					if (!selectedDOIs) return;
 					


### PR DESCRIPTION
[Example page.](https://lx.berkeley.edu/about/history-berkeley-linguistics)

Without this fix, the connector displays the folder icon but then shows an error when clicked; the single DOI link on the page, http://onlinelibrary.wiley.com/doi/10.1525/aa.1989.91.3.02a00140/epdf, is unresolvable. (Which it probably shouldn't be - it works fine if you strip off the `/epdf`, meaning it's probably a problem with our DOI cleaning routine - but that's a separate issue.)

With this fix, rather than showing an unexplained error, the select dialog simply doesn't show and the translation progress box goes away. Is that better? I think so, although the best solution would be having a way to display custom error text.

@dstillman, any thoughts?