### PR TITLE
EBSCOhost: fix when user clicks on permalink link

### DIFF
--- a/EBSCOhost.js
+++ b/EBSCOhost.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsib",
-	"lastUpdated": "2021-07-14 17:40:37"
+	"lastUpdated": "2021-08-02 10:36:24"
 }
 
 /*

--- a/EBSCOhost.js
+++ b/EBSCOhost.js
@@ -43,8 +43,7 @@ function detectWeb(doc, url) {
 		return "multiple";
 	}
 
-	var persistentLink = doc.getElementsByClassName("permalink-link");
-	if (persistentLink.length && persistentLink[0].nodeName.toUpperCase() == 'A') {
+	if (doc.querySelector("a.permalink-link")) {
 		return "journalArticle";
 	}
 	else if (ZU.xpathText(doc, '//section[@class="record-header"]/h2')) {


### PR DESCRIPTION
When the user manually clicks on the "permalink" link, this markup appears on the page as part of the popup:

`<span class="icon permalink-link"></span>`

This breaks the detectWeb function, which is expecting the first instance of a `.permalink-link` element to be an anchor tag. It's safer to search for the actual link using querySelector.