### PR TITLE
beck-online: Allow detection of proxied URLs

### DIFF
--- a/beck-online.js
+++ b/beck-online.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-10 17:39:39"
+	"lastUpdated": "2021-08-11 15:41:33"
 }
 
 /*
@@ -590,6 +590,21 @@ function finalize(doc, url, item) {
 	
 	var perma = ZU.xpathText(doc, '//div[@class="doc-link"]/a/@href');
 	if (perma) {
+		// not clear that this case ever comes up - permalinks appear always
+		// to be relative now. but just in case it's absolute, we want to strip
+		// the domain off and add the known beck-online domain back manually to
+		// avoid dot-dash proxy-to-proper confusion
+		// (beck-online-beck-de.proxy.university.edu being converted to
+		// beck.online.beck.de instead of beck-online.beck.de)
+		let pathRe = /^https?:\/\/[^/]+(\/.*)$/;
+		if (pathRe.test(perma)) {
+			perma = perma.match(pathRe)[1];
+		}
+		
+		if (perma.startsWith('/')) {
+			perma = 'https://beck-online.beck.de' + perma;
+		}
+		
 		item.url = perma;
 	}
 	

--- a/beck-online.js
+++ b/beck-online.js
@@ -2,14 +2,14 @@
 	"translatorID": "e8544423-1515-4daf-bb5d-3202bf422b58",
 	"label": "beck-online",
 	"creator": "Philipp Zumstein",
-	"target": "^https?://beck-online\\.beck\\.de/",
+	"target": "^https?://beck[-.]online\\.beck\\.de/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcs",
-	"lastUpdated": "2021-06-07 11:59:55"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2021-08-10 17:39:39"
 }
 
 /*


### PR DESCRIPTION
This is a hack. EZproxy replaces dots with dashes in proxied HTTPS URLs, so the connector undoes that by replacing dashes with dots. Unfortunately, that means that `beck-online.beck.de` will be proxied to `beck-online-beck-de` and then de-proxied by the connector to `beck.online.beck.de`. Accepting a dot in addition to a dash sidesteps the issue.

Fixes #2598.