### PR TITLE
Rewrite translator for Toronto Star

### DIFF
--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -55,10 +55,10 @@ function detectWeb(doc) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = doc.querySelectorAll('a[data-test-id="mediacard"]');
+	var rows = doc.querySelectorAll('a[class*="-mediacard"]');
 	for (let row of rows) {
 		let href = row.href;
-		let title = text(row, '*[data-test-id="mediacard-headline"]');
+		let title = text(row, 'h3');
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -267,6 +267,16 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://www.thestar.com/news/canada.html",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.thestar.com/authors.sarrouh_maria.html",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.thestar.com/topic.ottawa.html",
 		"items": "multiple"
 	}
 ]

--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -105,10 +105,10 @@ function scrape(doc, url) {
 				if (articleData.author) {
 					if (Array.isArray(articleData.author)) {
 						for (let author of articleData.author) {
-							item.creators.push(ZU.cleanAuthor(author.name, 'author'));
+							if (author.name) item.creators.push(ZU.cleanAuthor(author.name, 'author'));
 						}
 					}
-					else {
+					else if (articleData.author.name) {
 						item.creators.push(ZU.cleanAuthor(articleData.author.name, 'author'));
 					}
 				}
@@ -278,6 +278,68 @@ var testCases = [
 		"type": "web",
 		"url": "https://www.thestar.com/topic.ottawa.html",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.thestar.com/news/canada/2021/08/12/yukon-reports-nine-new-cases-of-covid-19-territory-has-45-active-infections.html",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Yukon reports nine new cases of COVID-19; territory has 45 active infections",
+				"creators": [],
+				"date": "2021-08-12",
+				"ISSN": "0319-0781",
+				"abstractNote": "WHITEHORSE - Yukon health officials are reporting nine new cases of COVID-19.",
+				"language": "en-CA",
+				"libraryCatalog": "Toronto Star",
+				"publicationTitle": "The Toronto Star",
+				"section": "Canada",
+				"url": "https://www.thestar.com/news/canada/2021/08/12/yukon-reports-nine-new-cases-of-covid-19-territory-has-45-active-infections.html",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "CP_URGENCY_2"
+					},
+					{
+						"tag": "CP_health"
+					},
+					{
+						"tag": "Canada"
+					},
+					{
+						"tag": "FEEDPROVIDER_CP"
+					},
+					{
+						"tag": "FEED_automated"
+					},
+					{
+						"tag": "Health"
+					},
+					{
+						"tag": "Whitehorse"
+					},
+					{
+						"tag": "bc"
+					},
+					{
+						"tag": "smg_canada"
+					},
+					{
+						"tag": "social"
+					},
+					{
+						"tag": "yukon territory"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-06-10 23:04:25"
+	"lastUpdated": "2021-08-12 21:47:17"
 }
 
 /*
@@ -36,18 +36,17 @@
 */
 
 
-function detectWeb(doc, url) {
-	if (url.includes("search") && !url.includes("classifieds") && getSearchResults(doc, true)) {
-		return "multiple";
-	}
-	else if (ZU.xpathText(doc, '//meta[@property="og:type"]/@content') == "article") {
-		var urlFolder = url.split('/').slice(0, -1).join('/');
-		if (urlFolder.includes('blog')) {
-			return "blogPost";
-		}
-		else {
+function detectWeb(doc) {
+	let contentType = attr(doc, 'meta[property="og:type"]', 'content');
+	switch (contentType) {
+		case "article":
 			return "newspaperArticle";
-		}
+		case "website":
+		default:
+			if (getSearchResults(doc, true)) {
+				return "multiple";
+			}
+			break;
 	}
 	return false;
 }
@@ -56,10 +55,10 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//a[span[contains(@class, "story__headline")]]');
-	for (var i = 0; i < rows.length; i++) {
-		var href = rows[i].href;
-		var title = ZU.trimInternal(rows[i].textContent);
+	var rows = doc.querySelectorAll('a[data-test-id="mediacard"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = text(row, '*[data-test-id="mediacard-headline"]');
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -73,12 +72,7 @@ function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
 			if (!items) return;
-
-			var articles = [];
-			for (var i in items) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
+			ZU.processDocuments(Object.keys(items), scrape);
 		});
 	}
 	else {
@@ -88,33 +82,52 @@ function doWeb(doc, url) {
 
 
 function scrape(doc, url) {
-	var item = new Zotero.Item(detectWeb(doc, url));
-	item.title = ZU.xpathText(doc, '//h1[@itemprop="headline"]');
-	item.date = ZU.xpathText(doc, '//meta[@property="article:published"]/@content');
-	item.section = ZU.xpathText(doc, '//meta[@property="article:section"]/@content');
-	item.abstractNote = ZU.xpathText(doc, '//meta[@name="description"]/@content');
-	var authors = ZU.xpath(doc, '//span[@itemprop="author"]//span[@itemprop="name"]');
-	for (let i = 0; i < authors.length; i++) {
-		item.creators.push(ZU.cleanAuthor(authors[i].textContent, "author"));
-	}
-	var tags = ZU.xpath(doc, '//div[contains(@class, "tags")]//a');
-	for (let i = 0; i < tags.length; i++) {
-		item.tags.push(tags[i].textContent);
-	}
-	if (item.itemType == "newspaperArticle") {
-		item.publicationTitle = "The Toronto Star";
-		item.ISSN = "0319-0781";
-	}
-	item.language = "en-CA";
-	item.url = url;
-	item.attachments.push({
-		document: doc,
-		title: 'Toronto Star Snapshot',
-		mimeType: 'text/html'
+	var trans = Zotero.loadTranslator('web');
+	trans.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48'); // Embedded Metadata
+	trans.setDocument(doc);
+
+	trans.setHandler('itemDone', function (obj, item) {
+		if (item.itemType == "newspaperArticle") {
+			item.publicationTitle = "The Toronto Star";
+			item.libraryCatalog = "Toronto Star";
+			item.ISSN = "0319-0781";
+		}
+		item.language = "en-CA";
+
+		let linkedData = JSON.parse(text(doc, 'script[type="application/ld+json"]'))["@graph"];
+		if (linkedData.length > 0) {
+			let articleData = linkedData.find(x => x["@type"] == "ReportageNewsArticle");
+			if (articleData) {
+				item.title = articleData.headline;
+				item.date = articleData.datePublished;
+				item.abstractNote = articleData.description;
+
+				if (articleData.author) {
+					if (Array.isArray(articleData.author)) {
+						for (let author of articleData.author) {
+							item.creators.push(ZU.cleanAuthor(author.name, 'author'));
+						}
+					}
+					else {
+						item.creators.push(ZU.cleanAuthor(articleData.author.name, 'author'));
+					}
+				}
+			}
+		}
+
+		for (let tag of doc.querySelectorAll('div.tags a')) {
+			item.tags.push(tag.textContent);
+		}
+
+		item.complete();
 	});
-	item.complete();
+
+	trans.getTranslatorObject(function (trans) {
+		trans.itemType = detectWeb(doc, url);
+		trans.doWeb(doc, url);
+	});
 }
-	
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
@@ -135,12 +148,14 @@ var testCases = [
 				"url": "https://www.thestar.com/news/world/2010/01/26/france_should_ban_muslim_veils_commission_says.html",
 				"attachments": [
 					{
-						"title": "Toronto Star Snapshot",
+						"title": "Snapshot",
 						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"France"
+					{
+						"tag": "France"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -172,13 +187,14 @@ var testCases = [
 				"url": "https://www.thestar.com/business/tech_news/2011/07/29/hamilton_ontario_should_reconsider_offshore_wind.html",
 				"attachments": [
 					{
-						"title": "Toronto Star Snapshot",
+						"title": "Snapshot",
 						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"Great Lakes",
-					"United States"
+					{
+						"tag": "Great Lakes"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -214,12 +230,29 @@ var testCases = [
 				"url": "https://www.thestar.com/news/canada/2012/07/03/bev_oda_resigns_as_international_cooperation_minister_conservative_mp_for_durham.html",
 				"attachments": [
 					{
-						"title": "Toronto Star Snapshot",
+						"title": "Snapshot",
 						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"Stephen Harper"
+					{
+						"tag": "Bev Oda"
+					},
+					{
+						"tag": "Conservatives"
+					},
+					{
+						"tag": "Durham"
+					},
+					{
+						"tag": "Stephen Harper"
+					},
+					{
+						"tag": "orange juice"
+					},
+					{
+						"tag": "savoy hotel"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -233,32 +266,8 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://www.thestar.com/yourtoronto/education_blog/2014/03/toronto_tustee_misbehaviour_isn_t_anything_new.html",
-		"items": [
-			{
-				"itemType": "blogPost",
-				"title": "Toronto trustee misbehaviour isn't anything new",
-				"creators": [
-					{
-						"firstName": "Kristin",
-						"lastName": "Rushowy",
-						"creatorType": "author"
-					}
-				],
-				"date": "2014-03-18",
-				"language": "en-CA",
-				"url": "https://www.thestar.com/yourtoronto/education_blog/2014/03/toronto_tustee_misbehaviour_isn_t_anything_new.html",
-				"attachments": [
-					{
-						"title": "Toronto Star Snapshot",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
+		"url": "https://www.thestar.com/news/canada.html",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/

--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "6b0b11a6-9b77-4b49-b768-6b715792aa37",
 	"label": "Toronto Star",
-	"creator": "Philipp Zumstein",
-	"target": "^https?://www\\.thestar\\.com",
+	"creator": "Philipp Zumstein, Bao Trinh",
+	"target": "^https?://www\\.thestar\\.com/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-12 21:47:17"
+	"lastUpdated": "2021-08-13 04:02:22"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017 Philipp Zumstein
+	Copyright © 2017 Philipp Zumstein, Bao Trinh
 	
 	This file is part of Zotero.
 

--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -15,7 +15,7 @@
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017 Philipp Zumstein, Bao Trinh
+	Copyright © 2017-2021 Philipp Zumstein, Bao Trinh
 	
 	This file is part of Zotero.
 

--- a/Toronto Star.js
+++ b/Toronto Star.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-13 04:02:22"
+	"lastUpdated": "2021-08-13 15:59:47"
 }
 
 /*
@@ -118,6 +118,7 @@ function scrape(doc, url) {
 		for (let tag of doc.querySelectorAll('div.tags a')) {
 			item.tags.push(tag.textContent);
 		}
+		item.tags = item.tags.filter(tag => !tag.includes('_'));
 
 		item.complete();
 	});
@@ -303,19 +304,7 @@ var testCases = [
 				],
 				"tags": [
 					{
-						"tag": "CP_URGENCY_2"
-					},
-					{
-						"tag": "CP_health"
-					},
-					{
 						"tag": "Canada"
-					},
-					{
-						"tag": "FEEDPROVIDER_CP"
-					},
-					{
-						"tag": "FEED_automated"
 					},
 					{
 						"tag": "Health"
@@ -325,9 +314,6 @@ var testCases = [
 					},
 					{
 						"tag": "bc"
-					},
-					{
-						"tag": "smg_canada"
 					},
 					{
 						"tag": "social"


### PR DESCRIPTION
Not sure of the last time this translator was working, but it seems to be nonfunctional for the Toronto Star website as of time of writing. I rewrote the translator. Mostly uses the JSON-LD data because it seems to be the most consistent and accurate (e.g. doesn't truncate the description).

Some issues/assumptions:

* the hardcoded `.language = "en-CA"` was kept from the original translator, as were `.publicationTitle` and `.ISSN`. 
* `.libraryCatalog` was added to match the values from the original tests (not sure where this came from originally)
* based the translator off of the Embedded Metadata translator. This seems to be common but most of the data is hand-pulled so it might be more straightforward to skip this
* The tags don't match the original tests. Partially due to the embedded metadata translator and because the tags listed seem to have been removed from the pages

It passes the linter and the existing tests have been validated