### PR TITLE
The Guardian: update translator

### DIFF
--- a/The Guardian.js
+++ b/The Guardian.js
@@ -2,14 +2,14 @@
 	"translatorID": "8e11559d-60f0-4a7f-bb91-99ac0c5a2d63",
 	"label": "The Guardian",
 	"creator": "Philipp Zumstein, Bao Trinh",
-	"target": "^https?://(www\\.)?(guardian\\.co\\.uk|theguardian\\.com)",
+	"target": "^https?://(www\\.)?(guardian\\.co\\.uk|theguardian\\.com)/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-15 03:37:32"
+	"lastUpdated": "2021-09-13 21:32:27"
 }
 
 /*
@@ -42,7 +42,6 @@ function detectWeb(doc) {
 		case "article":
 			return "newspaperArticle";
 		case "website":
-		case null:
 		default:
 			if (getSearchResults(doc, true)) {
 				return "multiple";
@@ -118,7 +117,7 @@ function scrape(doc, url) {
 		}
 
 		let linkedData = JSON.parse(text(doc, 'script[type="application/ld+json"]'));
-		if (linkedData instanceof Array) linkedData = linkedData.find(x => x["@type"] == "NewsArticle");
+		if (Array.isArray(linkedData)) linkedData = linkedData.find(x => x["@type"] == "NewsArticle");
 		if (linkedData) {
 			if (linkedData.publisher) item.libraryCatalog = linkedData.publisher.name;
 			if (linkedData.publisher) item.publicationTitle = linkedData.publisher.name;

--- a/The Guardian.js
+++ b/The Guardian.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "8e11559d-60f0-4a7f-bb91-99ac0c5a2d63",
 	"label": "The Guardian",
-	"creator": "Philipp Zumstein",
+	"creator": "Philipp Zumstein, Bao Trinh",
 	"target": "^https?://(www\\.)?(guardian\\.co\\.uk|theguardian\\.com)",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-08-11 14:15:22"
+	"lastUpdated": "2021-08-15 03:37:32"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017 Philipp Zumstein
+	Copyright © 2017-2021 Philipp Zumstein, Bao Trinh
 	
 	This file is part of Zotero.
 
@@ -36,21 +36,29 @@
 */
 
 
-function detectWeb(doc, url) {
-	if (ZU.xpathText(doc, '//div[contains(@class, "content__main-column")]//h1')) {
-		return "newspaperArticle";
-	} else if (getSearchResults(doc, true)) {
-		return "multiple";
+function detectWeb(doc) {
+	let contentType = attr(doc, 'meta[property="og:type"]', 'content');
+	switch (contentType) {
+		case "article":
+			return "newspaperArticle";
+		case "website":
+		case null:
+		default:
+			if (getSearchResults(doc, true)) {
+				return "multiple";
+			}
+			break;
 	}
+	return false;
 }
 
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//a[@data-link-name="article"]');
-	for (var i=0; i<rows.length; i++) {
-		var href = rows[i].href;
-		var title = ZU.trimInternal(rows[i].textContent);
+	var rows = doc.querySelectorAll('.fc-slice__item h3 a');
+	for (let row of rows) {
+		let href = row.href;
+		let title = row.textContent;
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -62,17 +70,19 @@ function getSearchResults(doc, checkOnly) {
 
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+		Zotero.selectItems(getSearchResults(doc, false), (items) => {
 			if (!items) {
 				return true;
 			}
-			var articles = [];
-			for (var i in items) {
+			const articles = [];
+			for (const i in items) {
 				articles.push(i);
 			}
 			ZU.processDocuments(articles, scrape);
+			return true;
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
@@ -82,39 +92,67 @@ function scrape(doc, url) {
 	var translator = Zotero.loadTranslator('web');
 	// Embedded Metadata
 	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
-	//translator.setDocument(doc);
-	
+	translator.setDocument(doc);
+
 	translator.setHandler('itemDone', function (obj, item) {
-		//The authors in the metadata are incomplete and are not cleaned,
-		//but contain unneccessary data about location etc.
-		//Thus we try to take them directly from the byline.
-		var byline = ZU.xpathText(doc, '//p[contains(@class, "byline")]');
+		let authors = new Set();
+
+		for (let author of doc.querySelectorAll('a[rel="author"]')) {
+			authors.add(author.textContent);
+		}
+
+		// The authors in the metadata are incomplete and are not cleaned,
+		// but contain unneccessary data about location etc.
+		// Thus we try to take them directly from the byline.
+		let byline = text(doc, 'address[data-link-name="byline"] *');
 		if (byline) {
-			item.creators = [];
-			var authors = byline.replace(/\s(in|for)\s.+/, '').split(/\s+and\s+|\s*,\s*/);
-			for (var i=0; i<authors.length; i++) {
-				item.creators.push(ZU.cleanAuthor(authors[i], "author"));
+			// parse out linked publications
+			byline = byline.split(/ for /)[0];
+			// parse out location
+			byline = byline.split(/\s*\b(?:in|at)\b\s*/)[0];
+
+			// parse authors from rest of byline
+			for (let author of byline.split(/\s*(?:\band\b|,)\s*/)) {
+				authors.add(author);
 			}
 		}
-		item.language = "en-GB";
-		// og:url does not preserve https prefixes, so use canonical link until fixed
-		var canonical = doc.querySelector('link[rel="canonical"]');
-		if (canonical) {
-			item.url = canonical.href;
+
+		let linkedData = JSON.parse(text(doc, 'script[type="application/ld+json"]'));
+		if (linkedData instanceof Array) linkedData = linkedData.find(x => x["@type"] == "NewsArticle");
+		if (linkedData) {
+			if (linkedData.publisher) item.libraryCatalog = linkedData.publisher.name;
+			if (linkedData.publisher) item.publicationTitle = linkedData.publisher.name;
+			if (linkedData.author) {
+				for (let author of linkedData.author) {
+					authors.add(author.name);
+				}
+			}
+			if (linkedData.datePublished) item.date = linkedData.datePublished;
+			if (linkedData.headline) item.title = linkedData.headline;
+			if (linkedData.mainEntityOfPage) item.url = linkedData.mainEntityOfPage;
 		}
-		var serie = ZU.xpathText(doc, '(//a[contains(@class, "content__label__link")])[1]');
-		if (serie=="The Observer") {
+
+		item.creators.length = 0;
+		for (let author of authors) {
+			if (author.match(/^(guardian staff|agenc(y|ies))/i)) continue;
+			item.creators.push(ZU.cleanAuthor(author, 'author'));
+		}
+
+		item.language = "en-GB";
+
+		if (text(doc, '[data-component="series"]') == "The Observer") {
 			item.publicationTitle = "The Observer";
 			item.ISSN = "0029-7712";
-		} else {
-			item.publicationTitle = "The Guardian";
+		}
+		else {
 			item.ISSN = "0261-3077";
 		}
+
 		item.complete();
 	});
 
-	translator.getTranslatorObject(function(trans) {
-		trans.itemType = "newspaperArticle";
+	translator.getTranslatorObject(function (trans) {
+		trans.itemType = detectWeb(doc, url);
 		trans.doWeb(doc, url);
 	});
 }
@@ -127,7 +165,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "newspaperArticle",
-				"title": "Venezuela begins seven days of mourning following death of Hugo Chávez",
+				"title": "Venezuela begins seven days of mourning after death of Hugo Chávez",
 				"creators": [
 					{
 						"firstName": "Jonathan",
@@ -144,13 +182,14 @@ var testCases = [
 				"ISSN": "0261-3077",
 				"abstractNote": "Death comes 21 months after it was revealed he had a tumour, and he will be given a state funeral in the capital",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Guardian",
 				"section": "World news",
 				"url": "https://www.theguardian.com/world/2013/mar/05/hugo-chavez-dies-cuba",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -205,14 +244,15 @@ var testCases = [
 				"ISSN": "0261-3077",
 				"abstractNote": "Exclusive: General David Petraeus and 'dirty wars' veteran behind commando units implicated in detainee abuse See the full-length documentary film of the 15-month investigation",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Guardian",
 				"section": "World news",
 				"shortTitle": "Revealed",
 				"url": "https://www.theguardian.com/world/2013/mar/06/pentagon-iraqi-torture-centres-link",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -273,13 +313,14 @@ var testCases = [
 				"ISSN": "0261-3077",
 				"abstractNote": "If there is, does God himself play? And if he does, what position, asks Percy Zvomuya?",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Guardian",
 				"section": "World news",
 				"url": "https://www.theguardian.com/world/2013/feb/26/football-heaven-god-play",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -328,19 +369,20 @@ var testCases = [
 				"ISSN": "0261-3077",
 				"abstractNote": "The political commentator talks about the response to his attack on the Daily Telegraph, his hopes for the future of the paper – and why the distinction between deer hunting and deer stalking matters",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Guardian",
 				"section": "Media",
 				"shortTitle": "Peter Oborne",
 				"url": "https://www.theguardian.com/media/2015/feb/18/peter-oborne-daily-telegraph-newspaper-unprecedented",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
 					{
-						"tag": "Barclay Brothers"
+						"tag": "Barclay brothers"
 					},
 					{
 						"tag": "Daily Telegraph"
@@ -378,14 +420,15 @@ var testCases = [
 				"ISSN": "0029-7712",
 				"abstractNote": "Our critics choose the books they intend to give this Christmas, and the ones they hope to receive",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Observer",
 				"section": "Books",
 				"shortTitle": "Christmas gifts 2011",
 				"url": "https://www.theguardian.com/books/2011/nov/27/christmas-gifts-2011-books-tree",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -488,14 +531,15 @@ var testCases = [
 				"ISSN": "0029-7712",
 				"abstractNote": "David Graeber’s snarky study of the meaningless nature of modern employment adds little to our understanding of it",
 				"language": "en-GB",
-				"libraryCatalog": "www.theguardian.com",
+				"libraryCatalog": "The Guardian",
 				"publicationTitle": "The Observer",
 				"section": "Books",
 				"shortTitle": "Bullshit Jobs",
 				"url": "https://www.theguardian.com/books/2018/may/27/bullshit-jobs-a-theory-david-graeber-review-laboured-rant",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
@@ -507,6 +551,162 @@ var testCases = [
 					},
 					{
 						"tag": "Economics"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.theguardian.com/sport/blog/2021/aug/14/joe-root-forgets-englands-toils-and-refinds-secret-to-batting-immortality",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Joe Root forgets England’s toils and refinds secret to batting immortality",
+				"creators": [
+					{
+						"firstName": "Jonathan",
+						"lastName": "Liew",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-08-14T20:08:27.000Z",
+				"ISSN": "0261-3077",
+				"abstractNote": "The put-upon captain might have faded away in his fifth year in the job but instead he has played some of his greatest innings",
+				"language": "en-GB",
+				"libraryCatalog": "The Guardian",
+				"publicationTitle": "The Guardian",
+				"section": "Sport",
+				"url": "https://www.theguardian.com/sport/blog/2021/aug/14/joe-root-forgets-englands-toils-and-refinds-secret-to-batting-immortality",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Cricket"
+					},
+					{
+						"tag": "England cricket team"
+					},
+					{
+						"tag": "England v India 2021"
+					},
+					{
+						"tag": "India cricket team"
+					},
+					{
+						"tag": "Joe Root"
+					},
+					{
+						"tag": "Sport"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.theguardian.com/football/2021/aug/13/mikel-artetas-arsenal-already-on-back-foot-after-first-night-failure",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Arteta’s Arsenal already on back foot after bruising first night failure",
+				"creators": [
+					{
+						"firstName": "Nick",
+						"lastName": "Ames",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-08-13T22:36:53.000Z",
+				"ISSN": "0261-3077",
+				"abstractNote": "A comprehensive defeat by Premier League newcomers Brentford laid the Gunners’ problems starkly bare",
+				"language": "en-GB",
+				"libraryCatalog": "The Guardian",
+				"publicationTitle": "The Guardian",
+				"section": "Football",
+				"url": "https://www.theguardian.com/football/2021/aug/13/mikel-artetas-arsenal-already-on-back-foot-after-first-night-failure",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Arsenal"
+					},
+					{
+						"tag": "Brentford"
+					},
+					{
+						"tag": "Football"
+					},
+					{
+						"tag": "Mikel Arteta"
+					},
+					{
+						"tag": "Sport"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.theguardian.com/us-news/2021/aug/14/republican-leaders-fiddle-while-covid-burns-through-their-own-supporters",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Republican leaders fiddle while Covid burns through their own supporters",
+				"creators": [
+					{
+						"firstName": "David",
+						"lastName": "Smith",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-08-14T06:00:32.000Z",
+				"ISSN": "0261-3077",
+				"abstractNote": "Governors of states such as Florida and Texas, where the Delta variant is surging, have made masks and vaccines a partisan issue, in a lethal mix of ignorance, irrationality and nihilism",
+				"language": "en-GB",
+				"libraryCatalog": "The Guardian",
+				"publicationTitle": "The Guardian",
+				"section": "US news",
+				"url": "https://www.theguardian.com/us-news/2021/aug/14/republican-leaders-fiddle-while-covid-burns-through-their-own-supporters",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Coronavirus"
+					},
+					{
+						"tag": "Florida"
+					},
+					{
+						"tag": "Republicans"
+					},
+					{
+						"tag": "Texas"
+					},
+					{
+						"tag": "US news"
+					},
+					{
+						"tag": "US politics"
 					}
 				],
 				"notes": [],


### PR DESCRIPTION
The translator's selectors were no longer applicable, updated to use the JSON-LD for article data (particularly the authors). 

I kept the old byline-parsing code (though refactored) because of [this test-case](https://www.theguardian.com/world/2013/mar/05/hugo-chavez-dies-cuba) where one of the authors is not officially linked. This complicates the code and it also means there are likely to be false-positives when there are more complicated bylines.