### PR TITLE
PKP Catalog Systems: Support issue TOC on home page

### DIFF
--- a/PKP Catalog Systems.js
+++ b/PKP Catalog Systems.js
@@ -2,14 +2,14 @@
 	"translatorID": "99b62ba4-065c-4e83-a5c0-d8cc0c75d388",
 	"label": "PKP Catalog Systems",
 	"creator": "Aurimas Vinckevicius and Abe Jellinek",
-	"target": "/(article|preprint|issue)/view/|/catalog/book/|/search/search",
+	"target": "/(article|preprint|issue)/view/|/catalog/book/|/search/search|/index\\.php/default",
 	"minVersion": "2.1.9",
 	"maxVersion": "",
 	"priority": 200,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-16 15:24:50"
+	"lastUpdated": "2021-08-17 03:01:34"
 }
 
 /*
@@ -43,7 +43,8 @@ function detectWeb(doc, url) {
 	}
 	
 	if (generator.startsWith('Open ')
-		&& (url.includes('/search/search') || url.includes('/issue/view'))) {
+		&& (url.includes('/search/search')
+			|| doc.querySelector('.obj_issue_toc .cmp_article_list'))) {
 		if (getSearchResults(doc, true)) {
 			return "multiple";
 		}
@@ -1485,6 +1486,11 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://kurdishstudies.net/journal/ks/issue/view/59",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://jnp.journals.yorku.ca/index.php/default",
 		"items": "multiple"
 	}
 ]


### PR DESCRIPTION
See added test. Some journals show the latest issue on their home page, so we should detect it as a multiple.

One might say that we have a few too many tests for this translator.