### PR TITLE
Linter: Validate lastUpdated and search terms more soundly

### DIFF
--- a/.ci/eslint-plugin-zotero-translator/lib/rules/last-updated.js
+++ b/.ci/eslint-plugin-zotero-translator/lib/rules/last-updated.js
@@ -21,7 +21,7 @@ module.exports = {
 
 				const translator = translators.get(context.getFilename());
 
-				const updated = (new Date)
+				const now = new Date()
 					.toISOString()
 					.replace('T', ' ')
 					.replace(/\..*/, '');
@@ -32,12 +32,21 @@ module.exports = {
 						message: 'Header needs lastUpdated field'
 					});
 				}
+				else if (!/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(header.properties.lastUpdated.value)) {
+					context.report({
+						node: header.properties.lastUpdated,
+						message: `lastUpdated field must be in YYYY-MM-DD HH:MM:SS format`,
+						fix: function (fixer) {
+							return fixer.replaceText(header.properties.lastUpdated, `"${now}"`);
+						},
+					});
+				}
 				else if (translator.lastUpdated && translator.lastUpdated >= header.properties.lastUpdated.value) {
 					context.report({
 						node: header.properties.lastUpdated,
 						message: `lastUpdated field must be updated to be > ${translator.lastUpdated} to push to clients`,
 						fix: function (fixer) {
-							return fixer.replaceText(header.properties.lastUpdated, `"${updated}"`);
+							return fixer.replaceText(header.properties.lastUpdated, `"${now}"`);
 						},
 					});
 				}

--- a/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
+++ b/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
@@ -29,7 +29,7 @@ module.exports = {
 					const sourceCode = context.getSourceCode();
 					if (astUtils.isSemicolonToken(sourceCode.getLastToken(node))) {
 						context.report({
-							message: 'testcases should not have trailing semicolon',
+							message: 'testCases should not have trailing semicolon',
 							loc: declaration.loc.end,
 						});
 					}
@@ -79,11 +79,11 @@ module.exports = {
 					}
 					else if (testCase.type === 'search') {
 						// console.log(JSON.stringify(testCase.input))
-						const term = Object.keys(testCase.input).join('/');
-						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject'];
-						if (!expected.includes(term)) {
+						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject', 'adsBibcode'];
+						if (!Object.keys(testCase.input).every(key => expected.includes(key))) {
+							let invalidKey = Object.keys(testCase.input).find(key => !expected.includes(key));
 							context.report({
-								message: `${prefix} of type "${testCase.type}" has search term '${term}', expected one of ${expected.join(', ')}`,
+								message: `${prefix} of type "${testCase.type}" has invalid search term '${invalidKey}' - expected one of ${expected.join(', ')}`,
 								loc,
 							});
 						}


### PR DESCRIPTION
This adds a basic test for correct `lastUpdated` date formatting, adds `adsBibcode` to the list of supported search terms, and fixes search term validation when a test case runs a search with multiple terms. (I don't think that actually happens in the current translator codebase.)