### PR TITLE
New translator for swisslex.ch

### DIFF
--- a/swisslex.js
+++ b/swisslex.js
@@ -346,8 +346,8 @@ function patchupMetaCommon(docData, metas) {
 	if (metas._editor !== undefined) {
 		let editors = metas._editor.split(',');
 		metas.creators = metas.creators || [];
-		for (let i = 0; i < editors.length; i++) {
-			metas.creators.push(ZU.cleanAuthor(editors[i], "editor", false));
+		for (let editor of editors) {
+			metas.creators.push(ZU.cleanAuthor(editor, "editor", false));
 		}
 	}
 	if (metas._author !== undefined) {
@@ -355,10 +355,10 @@ function patchupMetaCommon(docData, metas) {
 		// (which doesn't split names but authors)
 		let authors = metas._author.split(',');
 		metas.creators = metas.creators || [];
-		for (let i = 0; i < authors.length; i++) {
-			let oneAuthor = ZU.cleanAuthor(authors[i], "author", false);
-			[oneAuthor.firstName, oneAuthor.lastName] = [oneAuthor.lastName, oneAuthor.firstName];
-			metas.creators.push(oneAuthor);
+		for (let author of authors) {
+			let cleanAuthor = ZU.cleanAuthor(author, "author", false);
+			[cleanAuthor.firstName, cleanAuthor.lastName] = [cleanAuthor.lastName, cleanAuthor.firstName];
+			metas.creators.push(cleanAuthor);
 		}
 	}
 }

--- a/swisslex.js
+++ b/swisslex.js
@@ -90,8 +90,8 @@ function extractDocumentData(doc, url) {
 	};
 	const url_regexp = "^https://www.swisslex.ch/(de|fr|it|en)/doc/([a-z]+)/([-0-9a-f]+)";
 
-	var parts;
-	var result = new DocumentData();
+	let parts;
+	let result = new DocumentData();
 
 	url = decodeURI(url);
 	parts = url.match(url_regexp);
@@ -145,8 +145,8 @@ function extractRawItemData(doc_data) {
 		"rechtsgebiete": "_tags"
 	};
 
-	var dom_metas = ZU.xpath(doc_data.dom, '//div[@id="' + doc_data.id + '"]//li[contains(@class,"meta-entry")]');
-	var result = new Metas();
+	const dom_metas = ZU.xpath(doc_data.dom, '//div[@id="' + doc_data.id + '"]//li[contains(@class,"meta-entry")]');
+	let result = new Metas();
 
 	result.url = doc_data.url;
 	for (let i=0, l=dom_metas.length; i<l; i++) {
@@ -168,7 +168,7 @@ function extractRawItemData(doc_data) {
  * Common metadata fiels that have to be patched are:
  *   * date     convert to ISO
  *   * edition  extract numerical value
- *   * tags     split string by comma
+ *   * _tags    split string by comma
  *   * _author  add to creators array - format: lastname firstname
  *   * _editor  add to creators array - format: firstname lastname
  *

--- a/swisslex.js
+++ b/swisslex.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-11-15 20:49:43"
+	"lastUpdated": "2021-11-22 18:57:40"
 }
 
 /*
@@ -64,6 +64,8 @@ const translationMetaLabel = {
 	// "collection": "series",
 	"collection": "series",
 	"urteilsdatum": "date",
+	"urteilsbesprechung": "number",
+	"commentaire du jugement": "number",
 	"date du jugement": "date",
 	"jahr": "date",
 	"année": "date",
@@ -382,8 +384,12 @@ function patchupMetaMagic(docData, metas) {
 		// the magic field should compare to "abbreviation (volume/)year page"
 		let value = magic.split(' ');
 		metas.journalAbbreviation = value[0];
-		if (value[1].includes("/")) {
-			metas.issue = value[1].split("/")[0];
+		value[1] = value[1].split('/');
+		if (value[1].length > 1) {
+			metas.issue = value[1].shift();
+		}
+		if (metas.date === undefined) { // sometime year is not set in its own field
+			metas.date = value[1].shift();
 		}
 	}
 	else if (docData.type === "case") {
@@ -397,7 +403,9 @@ function patchupMetaMagic(docData, metas) {
 			metas.reporter = value[0];
 			metas.reporterVolume = value[1];
 			// @TODO verify with other publications on site
-			magic = text(docData.dom, "p.documenttitle").split(" – ").splice(-1)[0];
+			let docketRegex = /[-;]\s*([^-;)]+)\)?\.?$/;
+			let parts = text(docData.dom, "p.documenttitle").match(docketRegex);
+			magic = parts[1];
 		}
 		else {
 			delete metas.publicationTitle;

--- a/swisslex.js
+++ b/swisslex.js
@@ -35,10 +35,24 @@
 	***** END LICENSE BLOCK *****
 */
 
+/*
+	Translator for Swiss legal research site swisslex.ch
+
+	The site is accessible by paid accounts (and university access) only. The UI is
+	available in German and French - metadata is partly localized to language.
+
+	As each document access is billed, search and batch import is not supported by choice.
+
+	As a paid option, EU case law and legal documents are available on the site.
+	It is, however, only a half-reasonable import of EUR-lex/Celex.
+	I therefore do not support the EU documents in swisslex.
+ */
+
 /* eslint quote-props: ["error", "consistent"] */
 
 /**
  * translation table from human readable metadata labels to fields
+ *
  * @type {{}}
  */
 const translationMetaLabel = {
@@ -91,6 +105,7 @@ const translationMetaLabel = {
 
 /**
  * translation table from canton to its abbreviation
+ *
  * @type {{}}
  */
 const translationCanton = {
@@ -150,6 +165,11 @@ const translationCanton = {
 	"Luxembourg": "",
 };
 
+/**
+ * institutional editors that should not be included in metadata
+ *
+ * @type {string[]}
+ */
 const institutionalEditors = [
 	"Neue Zürcher Zeitung",
 	"Europa Institut an der Universität Zürich",
@@ -158,6 +178,7 @@ const institutionalEditors = [
 
 /**
  * translation table from court names to abbreviations
+ *
  * @type {{}}
  */
 const translationCourt = {
@@ -201,6 +222,11 @@ const translationCourt = {
 	"Cour de justice de l'Union européenne": "ECJ"
 };
 
+/**
+ * federal case compilations
+ *
+ * @type {string[]}
+ */
 const topLevelCaseCompilations = [
 	"BGE ",
 	"ATF ",
@@ -213,6 +239,7 @@ const topLevelCaseCompilations = [
 
 /**
  * data class holding web document information
+ *
  * @typedef DocumentData
  * @type {Object}
  * @property {Element}           dom
@@ -327,7 +354,7 @@ function extractRawItemData(docData) {
 		else if (label.length > 0) {
 			Z.debug("Unknown swisslex metadata label: '" + label + "'");
 		}
-		// else empty label -e happens with two line values we ignor
+		// else empty label - happens with two line values we ignore
 	}
 
 	return result;
@@ -379,7 +406,7 @@ function patchupMetaCommon(docData, metas) {
 		}
 	}
 	if (metas._author !== undefined) {
-		// authors are presented in "lastname firstname" but without a comma
+		// authors are presented in "lastname firstname" format but without a comma
 		// (which doesn't split names but authors)
 		let authors = metas._author.split(',');
 		metas.creators = metas.creators || [];
@@ -649,7 +676,7 @@ function doWeb(doc, url) {
 	}
 
 	// as long as we cannot get the PDF, save the website
-	// even as the website contains hidden documents and not-working app elements
+	// even as the snapshot will contain whole hidden documents and not-working app elements
 	item.attachments.push({
 		title: "Snapshot",
 		document: doc

--- a/swisslex.js
+++ b/swisslex.js
@@ -585,6 +585,7 @@ function doWeb(doc, url) {
 	delete metas._editor;
 
 	let item = new Zotero.Item(docData.type);
+	item.abstractNote = text(docData.dom, "div.abstract", 0);
 	for (let one in metas) {
 		if (one.substring(0, 1) !== "_") {
 			item[one] = metas[one];

--- a/swisslex.js
+++ b/swisslex.js
@@ -84,7 +84,7 @@ class Metas {}
  * @returns {DocumentData}
  */
 function extractDocumentData(doc, url) {
-	const types = {
+	const document_types = {
 		"bookdoc": "bookSection",
 		"essay": "journalArticle",
 		"clawrev": "journalArticle",
@@ -105,7 +105,7 @@ function extractDocumentData(doc, url) {
 			url: parts[0],
 			lang: parts[1],
 			id: parts[3],
-			type: types[parts[2]]
+			type: document_types[parts[2]]
 		}
 	}
 
@@ -191,7 +191,11 @@ function patchupMetaCommon(doc_data, metas) {
 		delete metas._tags;
 		metas.tags = [];
 		for (let i = 0; i < tags.length; i++) {
-			metas.tags.push( ZU.trimInternal( tags[i] ) );
+			let tag_parts = tags[i].split("/");
+			metas.tags.push( ZU.trimInternal( tag_parts[0] ) );
+			if ( tag_parts.length > 1 ) {
+				metas.tags.push( ZU.trimInternal( tags[i] ) );
+			}
 		}
 	}
 	if (metas._editor !== undefined) {

--- a/swisslex.js
+++ b/swisslex.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-11-09 20:53:10"
+	"lastUpdated": "2021-11-15 20:49:43"
 }
 
 /*
@@ -523,6 +523,14 @@ function doWeb(doc, url) {
 			Z.debug("ignoring still existing internal metadata field + " + one);
 		}
 	}
+
+	// as long as we cannot get the PDF, save the website
+	// even as the website contains hidden documents and contains not-working app elements
+	item.attachments.push({
+		title: "Snapshot",
+		document: doc
+	});
+
 	item.complete();
 }
 /** BEGIN TEST CASES **/

--- a/swisslex.js
+++ b/swisslex.js
@@ -2,14 +2,14 @@
 	"translatorID": "0fc8deb5-fba2-4471-8d99-97698e2e4060",
 	"label": "swisslex",
 	"creator": "Hans-Peter Oeri",
-	"target": "^https://www\\.swisslex\\.ch/de/doc/",
+	"target": "^https://www\\.swisslex\\.ch/(de|fr)/doc/",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-11-06 13:03:06"
+	"lastUpdated": "2021-11-06 17:53:27"
 }
 
 /*
@@ -41,26 +41,46 @@
  */
 const metadata_label_translation = {
 	"artikelkommentar": "_article",
+	"commentaire d'article": "_article",
 	"dokument": "_magic",
+	"document": "_magic",
 	"dokumenttitel": "_subtitle",
+	"titre du document": "_subtitle",
 	"auflage": "edition",
+	"édition": "edition",
 	"autor": "_author",
+	"auteur": "_author",
 	"autoren": "_author",
+	"auteurs": "_author",
 	"titel": "title",
+	"titre": "title",
 	"buchtitel": "publicationTitle",
+	"titre du livre": "publicationTitle",
 	"serie/reihe": "series",
+	"série / collection": "series",
 	"reihe": "series",
+	// "collection": "series",
+	"collection": "series",
 	"urteilsdatum": "date",
+	"date du jugement": "date",
 	"jahr": "date",
+	"année": "date",
 	"seiten": "pages",
+	"pages": "pages",
 	"herausgeber": "_editor",
+	"éditeur(s)": "_editor",
 	"isbn": "ISBN",
 	"verlag": "publisher",
+	"maison d’édition": "publisher",
 	"publikation": "publicationTitle",
+	"publication": "publicationTitle",
 	"issn": "ISSN",
 	"gericht": "court",
+	"tribunal": "court",
 	"betreff": "abstractNote",
-	"rechtsgebiete": "_tags"
+	"objet": "abstractNote",
+	"rechtsgebiete": "_tags",
+	"domaines du droit": "_tags"
 };
 
 /**
@@ -69,16 +89,57 @@ const metadata_label_translation = {
  */
 const canton_translation = {
 	"Schweiz": "",
+	"Suisse": "",
 	"Zürich": "ZH",
+	"Zurich": "ZH",
 	"Bern": "BE",
-	"Basel-Stadt": "BS",
-	"Basel-Land": "BL",
+	"Berne": "BE",
+	"Luzern": "LU",
+	"Lucerne": "LU",
+	"Uri": "UR",
+	"Schwyz": "SZ",
+	"Obwalden": "OW",  // FR
+	"Nidwalden": "NW",  // FR
+	"Glarus": "GL",
+	"Glaris": "GL",
+	"Zug": "ZG",
+	"Zoug": "ZG",
 	"Freiburg": "FR",
-	"Graubünden": "GR",
-	"Genf": "GE",
+	"Fribourg": "FR",
+	"Solothurn": "SO",
+	"Soleure": "SO",
+	"Basel-Stadt": "BS",
+	"Bâle-Ville": "BS",
+	"Basel-Land": "BL",
+	"Bâle-Campagne": "BL",
+	"Schaffhausen": "SH",
+	"Schaffhouse": "SH",
+	"Appenzell Ausserrhoden": "AR",
+	"Appenzell Rhodes-Extérieures": "AR",
+	"Appenzell Innerrhoden": "AR",
+	"Appenzell Rhodes-Intérieures": "AR",
 	"St. Gallen": "SG",
+	"St-Gall": "SG",
+	"Graubünden": "GR",
+	"Grisons": "GR",
+	"Aargau": "AG",
+	"Argovie": "AG",
+	"Thurgau": "TG",
+	"Thurgovie": "TG",
 	"Tessin": "TI",
-	"Luzern": "LU"
+	"Waadt": "VD",
+	"Vaud": "VD",
+	"Wallis": "VS",
+	"Valais": "VS",
+	"Neuenburg": "NE",
+	"Neuchâtel": "NE",
+	"Genf": "GE",
+	"Genève": "GE",
+	"Jura": "JU",
+	"Strassburg": "",
+	"Strasbourg": "",
+	"Luxemburg": "",
+	"Luxembourg": "",
 };
 
 /**
@@ -87,23 +148,47 @@ const canton_translation = {
  */
 const court_translation = {
 	"Bundesstrafgericht": "BStrG",
+	"Tribunal pénal fédéral": "TPF",
 	"Bundesverwaltungsgericht": "BVerwG",
+	"Tribunal administratif fédéral": "TAF",
 	"Bundesgericht": "BGer",
+	"Tribunal fédéral": "TF",
 	"Eidgenössisches Versicherungsgericht": "EVGer",
+	"Tribunal fédéral des assurances": "TFA",
 	"Eidgenössische Bankenkommission": "EBK",
+	"Commission fédérale des banques": "CFB",
 	"Bundesamt": "BJ",
+	// "Division de la justice": ""
 	"Bundesstaatsanwaltschaft": "BA",
+	// FR
 	"Steuerekurskommission": "StRK",
+	// "Commission de recours en matière fiscale": ""
 	"Obergericht": "OGer",
+	"Cour suprème": "CS",
 	"Handelsgericht": "HGer",
 	"Kantonsgericht": "KGer",
+	"Tribunal cantonal": "TC",
+	"Cour de justice": "CJ",
 	"Appellationsgericht": "AppG",
+	"Appellationshof": "AppH",
+	"Cour d'appel": "CA",
 	"Kassationsgericht": "KassG",
 	"Kreisgericht": "KrG",
+	// "Tribunal d'arrondissement": ""
 	"Bezirksgericht": "BezG",
+	"Tribunal de district": "TD",
+	"Tribunal régional": "TR",
 	"Zivilgericht": "ZG",
+	"Cour Civile": "CC",
 	"Versicherungsgericht": "VG",
 	"Sozialversicherungsgericht": "SozVG",
+	"Verwaltungsgericht": "VwG",
+	"Verwaltungsrekurskommission": "VRK",
+	"Tribunal administratif": "TA",
+	"Cour européenne des droits de l'homme": "CEDH",
+	"Europäischer Gerichtshof für Menschenrechte": "EGMR",
+	"Europäischer Gerichtshof": "ECJ",
+	// FR
 };
 
 /**
@@ -205,9 +290,10 @@ function extractRawItemData(doc_data) {
 		if (metadata_label_translation[label] !== undefined) {
 			result[metadata_label_translation[label]] = dom_metas[i].children[1].innerText;
 		}
-		else {
-			Z.debug( "Unknown swisslex metadata label: " + label );
+		else if (label.length > 0) {
+			Z.debug( "Unknown swisslex metadata label: '" + label + "'" );
 		}
+		// else empty label
 	}
 
 	return result;
@@ -219,7 +305,7 @@ function extractRawItemData(doc_data) {
  * Common metadata fiels that have to be patched are:
  *   * date     convert to ISO
  *   * edition  extract numerical value
- *   * _tags    split string by comma
+ *   * _tags    split string by comma for tags, by slash for subtags
  *   * _author  add to creators array - format: lastname firstname
  *   * _editor  add to creators array - format: firstname lastname
  *

--- a/swisslex.js
+++ b/swisslex.js
@@ -256,6 +256,17 @@ const topLevelCaseCompilations = [
  */
 
 /**
+ * convert swiss date to ISO date (numerical only version)
+ *
+ * @param {string} date
+ */
+function swissStrToISO(date) {
+	let parts = date.split(/\.\s*|\s+/);
+	parts = parts.map( value => parseInt(value).toString().padStart(2, '0'));
+	return parts.reverse().join('-');
+}
+
+/**
  * interpret a document URL and extract web document information
  *
  * @param   {Document} doc   Document as received from Zotero
@@ -338,7 +349,7 @@ function extractRawItemData(docData) {
 function patchupMetaCommon(docData, metas) {
 	if (metas.date !== undefined) {
 		// all dates are presented in both languages as "dd.mm.yyyy"
-		metas.date = metas.date.split('.').reverse().join('-');
+		metas.date = swissStrToISO(metas.date);
 	}
 	if (metas.edition !== undefined) {
 		// all editions start with the numeric - parseInt ignores everything thereafter ;)
@@ -392,7 +403,7 @@ function interpretJournalMagic(docData, metas) {
 
 	if (tokens[1] === "Nr." || tokens[1] === "n°") { // newspaper format
 		metas.issue = tokens[2];
-		metas.date = tokens[3].split('.').reverse().join('-');
+		metas.date = swissStrToISO(tokens[3]);
 	}
 	else if (tokens.length > 1) { // journal format
 		tokens[1] = tokens[1].match(/^(?:(\d+)\/)?(\d{2,4})$/);
@@ -451,9 +462,9 @@ function patchupMetaMagic(docData, metas) {
 		}
 		else {
 			delete metas.publicationTitle;
+			metas.number = magic;
+			metas.title = magic;
 		}
-		metas.number = magic;
-		metas.title = magic;
 	}
 	else if (docData.type === "bookSection") {
 		// at least one bookSection I found did not give the book's edition in
@@ -637,5 +648,5 @@ function doWeb(doc, url) {
 	item.complete();
 }
 /** BEGIN TEST CASES **/
-var testCases = [];
+var testCases = []
 /** END TEST CASES **/

--- a/swisslex.js
+++ b/swisslex.js
@@ -264,7 +264,7 @@ function extractDocumentData(doc, url) {
 
 	if (parts !== null) {
 		result = {
-			dom: doc.documentElement,
+			dom: doc.querySelector("div[id='" + parts[3] + "']"),
 			url: parts[0],
 			lang: parts[1],
 			id: parts[3],
@@ -288,8 +288,8 @@ function extractDocumentData(doc, url) {
  * @returns {Metas}
  */
 function extractRawItemData(docData) {
-	const domMetas = ZU.xpath(docData.dom, '//div[@id="' + docData.id + '"]//li[contains(@class,"meta-entry")]');
-	let result = new Metas();
+	const domMetas = docData.dom.querySelectorAll("li.meta-entry");
+	let result = {};
 
 	result.url = docData.url;
 	for (let i = 0, l = domMetas.length; i < l; i++) {
@@ -321,7 +321,8 @@ function extractRawItemData(docData) {
  */
 function patchupMetaCommon(docData, metas) {
 	if (metas.date !== undefined) {
-		metas.date = ZU.strToISO(metas.date);
+		// all dates are presented in both languages as "dd.mm.yyyy"
+		metas.date = metas.date.split('.').reverse().join('-');
 	}
 	if (metas.edition !== undefined) {
 		// all editions start with the numeric - parseInt ignores everything thereafter ;)

--- a/swisslex.js
+++ b/swisslex.js
@@ -197,6 +197,16 @@ const translationCourt = {
 	// FR
 };
 
+const topLevelCaseCompilations = [
+	"BGE ",
+	"ATF ",
+	"BVGE ",
+	"ATAF ",
+	"EVGE ",
+	"ATFA ",
+	"TPF "
+];
+
 /**
  * data class holding web document information
  * @typedef DocumentData
@@ -472,9 +482,13 @@ function patchupForCase(docData, metas) {
 	let court = metas.court.split(",");
 	let title = metas.title;
 
+	for (let compilation of topLevelCaseCompilations) {
+		if (title.startsWith(compilation)) {
+			return;
+		}
+	}
+
 	// cases are uniformly referenced by "court-abbreviation (canton) docket"
-	// except for federal and international courts that leave out the canton part
-	// @TODO BVGE, BSTGE
 	if (title.substring(0, 4) !== "BGE ") {
 		let temp = court[0].trim();
 		if (translationCanton[temp] !== undefined) {

--- a/swisslex.js
+++ b/swisslex.js
@@ -148,6 +148,10 @@ const translationCanton = {
 	"Luxembourg": "",
 };
 
+const institutionalEditors = [
+	"Neue Zürcher Zeitung"
+];
+
 /**
  * translation table from court names to abbreviations
  * @type {{}}
@@ -357,7 +361,9 @@ function patchupMetaCommon(docData, metas) {
 		let editors = metas._editor.split(',');
 		metas.creators = metas.creators || [];
 		for (let editor of editors) {
-			metas.creators.push(ZU.cleanAuthor(editor, "editor", false));
+			if (!institutionalEditors.includes(editor)) {
+				metas.creators.push(ZU.cleanAuthor(editor, "editor", false));
+			}
 		}
 	}
 	if (metas._author !== undefined) {

--- a/swisslex.js
+++ b/swisslex.js
@@ -1,0 +1,250 @@
+{
+	"translatorID": "0fc8deb5-fba2-4471-8d99-97698e2e4060",
+	"label": "swisslex",
+	"creator": "Hans-Peter Oeri",
+	"target": "^https://www\\.swisslex\\.ch/de/doc/",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2021-10-23 10:32:29"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2021 Hans-Peter Oeri
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+base_url = "^https://www.swisslex.ch/(de|fr|it|en)/doc/([a-z]+)/([-0-9a-f]+)/";
+base_index = {
+	"type": 2,
+	"id": 3
+};
+
+detecttypes = {
+	"bookdoc": "bookSection",
+	"essay": "journalArticle",
+	"clawrev": "journalArticle",
+	"commentarydoc": "encyclopediaArticle",
+	"claw": "case"
+};
+
+doparams = {
+	"artikelkommentar": "_magic",
+	// "dokumenttitel": "_magic",
+	"dokument": "_magic",
+	"auflage": "edition",
+	"autor": "author",
+	"autoren": "author",
+	"titel": "title",
+	"buchtitel": "publicationTitle",
+	"serie/reihe": "series",
+	"reihe": "series",
+	"urteilsdatum": "date",
+	"jahr": "date",
+	"seiten": "pages",
+	"herausgeber": "editor",
+	"isbn": "ISBN",
+	"verlag": "publisher",
+	"publikation": "publicationTitle",
+	"issn": "ISSN",
+	"gericht": "court",
+	"betreff": "abstractNote",
+	"rechtsgebiete": "tags"
+};
+
+docantons = {
+	"Schweiz": "",
+	"Zürich": "ZH",
+	"Bern": "BE",
+	"Basel-Stadt": "BS",
+	"Basel-Land": "BL",
+	"Freiburg": "FR",
+	"Graubünden": "GR",
+	"Genf": "GE",
+	"St. Gallen": "SG",
+	"Tessin": "TI",
+	"Luzern": "LU"
+	
+};
+
+docourts = {
+	"Bundesstrafgericht": "BStrG",
+	"Bundesverwaltungsgericht": "BVerwG",
+	"Bundesgericht": "BGer",
+	"Eidgenössisches Versicherungsgericht": "EVGer",
+	"Eidgenössische Bankenkommission": "EBK",
+	"Bundesamt": "BJ",
+	"Bundesstaatsanwaltschaft": "BA",
+	"Steuerekurskommission": "StRK",
+	"Obergericht": "OGer",
+	"Handelsgericht": "HGer",
+	"Kantonsgericht": "KGer",
+	"Appellationsgericht": "AppG",
+	"Kassationsgericht": "KassG",
+	"Kreisgericht": "KrG",
+	"Bezirksgericht": "BezG",
+	"Zivilgericht": "ZG",
+	"Versicherungsgericht": "VG",
+	"Sozialversicherungsgericht": "SozVG",
+};
+
+function interpretURI(url) {
+	url = decodeURI(url);
+
+	var base_url = "^https://www.swisslex.ch/(de|fr|it|en)/doc/([a-z]+)/([-0-9a-f]+)";
+	var parts = url.match(base_url);
+	var res = {};
+
+	if (parts !== null) {
+		res.url = parts[0];
+		res.lang = parts[1];
+		res.id = parts[3];
+		res.type = detecttypes[parts[2]];
+	}
+	return res;
+}
+
+function detectWeb(doc, url) {
+	return interpretURI(url).type;
+}
+
+function doWeb(doc, url) {
+	var urlparts = interpretURI(url);
+	var docmetas = ZU.xpath(doc, '//div[@id="' + urlparts.id + '"]//li[contains(@class,"meta-entry")]');
+	var metas = {};
+	var i, one, value, temp;
+	
+	metas.url = urlparts.url;
+	for (i=0, l=docmetas.length; i<l; i++) {
+		one = docmetas[i].children[0].innerText.toLowerCase();
+		if (doparams[one] != undefined) {
+			metas[doparams[one]] = docmetas[i].children[1].innerText;
+		}
+	}
+
+	var item = new Zotero.Item(urlparts.type);
+	for (one in metas) {
+		value = metas[one];
+		switch (one) {
+			case "_magic":
+				if (urlparts.type == "journalArticle") {
+					value = value.split(' ');
+					item.journalAbbreviation = value[0];
+					if (value[1].includes("/")) {
+						item.issue = value[1].split("/")[0];
+					}
+				}
+				else if (urlparts.type == "bookSection") {
+					value = value.match( '([0-9]+)\.A.,' );
+					if (value) {
+						item.edition = value[1];
+					}
+				}
+				else if (urlparts.type == "encyclopediaArticle") {
+					item.title = value;
+				}
+				else if (urlparts.type == "case") {
+					item.number = value;
+					item.title = value;
+				}
+				break;
+			case "court":
+				item.court = value;
+				if (item.title.substring(0,3) != "BGE") {
+					value = value.split(",");
+					
+					temp = value[0].trim();
+					if (docantons[temp] != undefined) {
+						if (docantons[temp]) {
+							temp = docantons[temp] + " ";
+						}
+						else {
+							temp = "";
+						}
+					} 
+					else {
+						Z.debug( "unknown canton: " + temp );
+						temp = temp + " ";
+					}
+					item.title = temp + item.title;
+					
+					temp = value[1].trim();
+					if (docourts[temp] != undefined ) {
+						temp = docourts[temp];
+					}
+					else {
+						Z.debug( "unknown court: " + temp );
+					}
+					item.title = temp + " " + item.title;
+				}
+				break;
+			case "edition":
+				item.edition = value.split('.')[0];
+				break;
+			case "title":
+				if (urlparts.type == "encyclopediaArticle") {
+					item.publicationTitle = value;
+				}
+				else {
+					item.title = value;
+				}
+				break;
+			case "date":
+				item.date = ZU.strToISO(value);
+				break;
+			case "tags":
+				value = value.split(',');
+				for (i=0; i<value.length; i++) {
+					item.tags.push( ZU.trimInternal( value[i] ) );
+				}
+				break;
+			case "editor":
+				value = value.split(',');
+				for (i=0; i<value.length; i++) {
+					item.creators.push( ZU.cleanAuthor( value[i], one, false) );
+				}
+				break;
+			case "author":
+				value = value.split(',');
+				for (i=0; i<value.length; i++) {
+					value[i] = ZU.cleanAuthor( value[i], one, false);
+					temp = value[i].firstName;
+					value[i].firstName = value[i].lastName;
+					value[i].lastName = temp;
+					item.creators.push( value[i] );
+				}
+				break;
+			default:
+				if (one[0] != '_') {
+					item[one] = value;
+				}
+		}
+	}
+
+	item.complete();
+}
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/swisslex.js
+++ b/swisslex.js
@@ -262,7 +262,7 @@ const topLevelCaseCompilations = [
  */
 function swissStrToISO(date) {
 	let parts = date.split(/\.\s*|\s+/);
-	parts = parts.map( value => parseInt(value).toString().padStart(2, '0'));
+	parts = parts.map(value => parseInt(value).toString().padStart(2, '0'));
 	return parts.reverse().join('-');
 }
 
@@ -413,7 +413,7 @@ function patchupMetaMagicJournal(docData, metas) {
 		}
 
 		if (tokens.length > 2 && metas.pages === undefined) {
-			if (tokens[2] === "S." || tokens === "p.") {
+			if (tokens[2] === "S." || tokens[2] === "p.") {
 				metas.pages = tokens[3];
 			}
 			else {
@@ -430,7 +430,7 @@ function patchupMetaMagicCaseInJournal(docData, metas) {
 	patchupMetaMagicJournal(docData, metas);
 	metas.reporter = metas.journalAbbreviation;
 	delete metas.journalAbbreviation;
-	metas.reporterVolume = (metas.issue ? metas.issue + "/": "") + metas.date.substring(0, 4);
+	metas.reporterVolume = (metas.issue ? metas.issue + "/" : "") + metas.date.substring(0, 4);
 	delete metas.issue;
 
 	// looking for decision date and docket in prose text
@@ -462,7 +462,7 @@ function patchupMetaMagic(docData, metas) {
 	}
 
 	if (docData.type === "journalArticle") {
-		patchupMetaMagicJournal(docData, metas)
+		patchupMetaMagicJournal(docData, metas);
 	}
 	else if (docData.type === "case") {
 		// court case compilations and journal case listings are both tagged with "publication"
@@ -600,7 +600,7 @@ function patchupForLegalCommentary(docData, metas) {
 
 	// if its a commentary to a specific articles
 	// swisslex designates it as '[statute-abbreviation] [article number]'
-	if (metas._article !== undefined) {x
+	if (metas._article !== undefined) {
 		let commentary = metas.series || metas.publisher.split(" ")[0];
 		let articleParts = metas._article.split(" ");
 		metas.title = metas._article + " (" + commentary + ")";

--- a/swisslex.js
+++ b/swisslex.js
@@ -9,8 +9,9 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-11-06 17:53:27"
+	"lastUpdated": "2021-11-09 20:53:10"
 }
+
 /*
 	***** BEGIN LICENSE BLOCK *****
 
@@ -215,6 +216,7 @@ class DocumentData {}
  * @property {String} _editor
  * @property {Array}  creators
  * @property {String} title
+ * @property {String} shortTitle
  * @property {String} _subtitle
  * @property {String} publicationTitle
  * @property {String} series
@@ -444,23 +446,32 @@ function patchupForCase(docData, metas) {
 }
 
 /**
- * patchup metas for document type 'legalCommentary' - mapped to 'ecyclopediaArtice'
+ * patchup metas for document type 'legalCommentary' - mapped to 'encyclopediaArticle'
  * @param {DocumentData}  docData
  * @param {Metas}         metas
  */
 function patchupForLegalCommentary(docData, metas) {
+	// set series to abbreviation ("BK - Berner Kommentar" => "BK")
+	if (metas.series !== undefined && metas.series.match("^[A-Z]{2,5} - ")) {
+		metas.series = ZU.trimInternal(metas.series.split("-")[0]);
+	}
+
+	// if its a commentary to a specific articles
 	if (metas._article !== undefined) {
+		let commentary = metas.series || metas.publisher.split(" ")[0];
+		let articleParts = metas._article.split(" ");
 		metas.encyclopediaTitle = metas.title;
-		metas.title = metas._article;
+		metas.title = metas._article + " (" + commentary + ")";
+		metas.shortTitle = (docData.lang === "fr" ? "art. " : "Art. ") + articleParts[1] + " " + articleParts[0];
 		delete metas._article;
 		delete metas._subtitle;
+		delete metas.pages;
 	}
+
+	// if its a non-article commentary, handle like a bookSection
 	if (metas._subtitle) {
 		metas.title = metas.title + " - " + metas._subtitle;
 		delete metas._subtitle;
-	}
-	if (metas.series !== undefined && metas.series.match("^[A-Z]{2,5} - ")) {
-		metas.series = metas.series.split("-")[0];
 	}
 }
 


### PR DESCRIPTION
swisslex.ch is one of the main recherche tools in Switzerland. Unfortunately, they only offer paid accounts (apart from universities).

They do not (yet) put metadata in their DOM, but have preliminarily offered support in the future. This translator wholly relies on interpretation of human-readable data.

NB: Tests do not work as the testing framework does not keep the browser's session (and they do not allow anonymous access).