### PR TITLE
Repair ProQuest detection on non-Abstract pages

### DIFF
--- a/ProQuest.js
+++ b/ProQuest.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-12-31 09:03:40"
+	"lastUpdated": "2021-12-31 09:11:56"
 }
 
 /*
@@ -168,7 +168,7 @@ function detectWeb(doc, url) {
 
 	// there is not much information about the item type in the pdf/fulltext page
 	let titleRow = text(doc, '.open-access');
-	if (titleRow) {
+	if (titleRow && doc.getElementById('docview-nav-stick')) { // do not continue if there is no nav to the Abstract, as the translation will fail
 		if (getItemType([titleRow])) {
 			return getItemType([titleRow]);
 		}

--- a/ProQuest.js
+++ b/ProQuest.js
@@ -243,15 +243,17 @@ function doWeb(doc, url, noFollow) {
 
 function scrape(doc, url, type) {
 	var item = new Zotero.Item(type);
+	
 	// get all rows
 	var rows = doc.getElementsByClassName('display_record_indexing_row');
+	
 	let label, value, enLabel;
 	var dates = [], place = {}, altKeywords = [];
 
 	for (let i = 0, n = rows.length; i < n; i++) {
 		label = rows[i].childNodes[0];
 		value = rows[i].childNodes[1];
-		Z.debug(label+": "+value);
+		
 		if (!label || !value) continue;
 
 		label = label.textContent.trim();

--- a/ProQuest.js
+++ b/ProQuest.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-12-31 09:11:56"
+	"lastUpdated": "2022-01-04 09:11:57"
 }
 
 /*
@@ -224,7 +224,7 @@ function doWeb(doc, url, noFollow) {
 			Zotero.debug("On Abstract tab and scraping");
 			scrape(doc, url, type);
 		}
-		else if (noFollow) { // when is this used? wouldn't it be better to throw an error instead of brute forcing?
+		else if (noFollow) {
 			Z.debug('Not following link again. Attempting to scrape');
 			scrape(doc, url, type);
 		}

--- a/ProQuest.js
+++ b/ProQuest.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-10-10 02:27:10"
+	"lastUpdated": "2021-12-31 09:03:40"
 }
 
 /*
@@ -219,23 +219,22 @@ function doWeb(doc, url, noFollow) {
 		});
 	}
 	else {
-		var abstractTab = doc.getElementById('tab-AbstractRecord-null') // Seems like that null is a bug and it might change at some point
-			|| doc.getElementById('tab-Record-null'); // Shown as Details
-		if (!(abstractTab && !abstractTab.classList.contains('active'))) {
-			Zotero.debug("On Abstract page, scraping");
+		var abstractTab = doc.getElementById('addFlashPageParameterformat_abstract');
+		if (abstractTab && abstractTab.classList.contains('active')) {
+			Zotero.debug("On Abstract tab and scraping");
 			scrape(doc, url, type);
 		}
-		else if (noFollow) {
+		else if (noFollow) { // when is this used? wouldn't it be better to throw an error instead of brute forcing?
 			Z.debug('Not following link again. Attempting to scrape');
 			scrape(doc, url, type);
 		}
 		else {
-			var link = abstractTab.getElementsByTagName('a')[0];
+			var link = abstractTab.href;
 			if (!link) {
 				throw new Error("Could not find the abstract/metadata link");
 			}
 			Zotero.debug("Going to the Abstract tab");
-			ZU.processDocuments(link.href, function (doc, url) {
+			ZU.processDocuments(link, function (doc, url) {
 				doWeb(doc, url, true);
 			});
 		}
@@ -244,17 +243,15 @@ function doWeb(doc, url, noFollow) {
 
 function scrape(doc, url, type) {
 	var item = new Zotero.Item(type);
-
 	// get all rows
 	var rows = doc.getElementsByClassName('display_record_indexing_row');
-
 	let label, value, enLabel;
 	var dates = [], place = {}, altKeywords = [];
 
 	for (let i = 0, n = rows.length; i < n; i++) {
 		label = rows[i].childNodes[0];
 		value = rows[i].childNodes[1];
-
+		Z.debug(label+": "+value);
 		if (!label || !value) continue;
 
 		label = label.textContent.trim();

--- a/ProQuest.js
+++ b/ProQuest.js
@@ -219,7 +219,7 @@ function doWeb(doc, url, noFollow) {
 		});
 	}
 	else {
-		var abstractTab = doc.getElementById('addFlashPageParameterformat_abstract');
+		var abstractTab = doc.getElementById('addFlashPageParameterformat_abstract') || doc.getElementById('addFlashPageParameterformat_citation');
 		if (abstractTab && abstractTab.classList.contains('active')) {
 			Zotero.debug("On Abstract tab and scraping");
 			scrape(doc, url, type);

--- a/ProQuest.js
+++ b/ProQuest.js
@@ -168,7 +168,7 @@ function detectWeb(doc, url) {
 
 	// there is not much information about the item type in the pdf/fulltext page
 	let titleRow = text(doc, '.open-access');
-	if (titleRow && !text(doc, '.ol-login-link')) {
+	if (titleRow) {
 		if (getItemType([titleRow])) {
 			return getItemType([titleRow]);
 		}


### PR DESCRIPTION
Fixes
* `detectWeb` no longer matches PQ pages without an Abstract tab (#2760)
  * This saves the translator from erroring out when it cannot find the Abstract tab; prevents user confusion
* Restored auto-navigation to the Abstract tab when starting the translator on the Full text tab

cc @avram @adam3smith 