### PR TITLE
Springer Link: Support for whole books

### DIFF
--- a/Springer Link.js
+++ b/Springer Link.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsbv",
-	"lastUpdated": "2022-01-15 13:09:14"
+	"lastUpdated": "2022-01-23 09:09:07"
 }
 
 /*
@@ -106,7 +106,7 @@ function doWeb(doc, url) {
 			if (isbn) {
 				Z.debug("Found ISBN: " + isbn);
 				// scrape title from the page title
-				var title = ZU.xpathText(doc, '//div[@class="page-title"]/x1');
+				var title = ZU.xpathText(doc, '//div[@class="page-title"]/h1');
 				if (!title) {
 					// if that fails, scrape from <head><title>
 					// (no counterexamples known so far)

--- a/Springer Link.js
+++ b/Springer Link.js
@@ -267,22 +267,21 @@ function scrape(doc, url) {
 	});
 }
 
+/*
+Test several xpaths where the ISBN might show up. At this point, I don't have an
+example where the first xpath does not work. The other two fail if the
+website displays no options to buy the book (e.g. you have access to the pdf
+and physical copies are no longer sold). Example: book/10.1007/BFb0032916
+
+Another option would be to visit an entry of getResultList() and get the
+ISBN from there, either from the html or from the RIS data. This has the
+disadantage	that yet another http request is needed, costing additional
+time.
+
+There are often several different ISBNs for the same book (e.g. eBook,
+Hardcover, Softcover), and we pick the first to appear in the html code.
+*/
 function scrapeISBN(doc, _url) {
-
-	/*
-	Several xpaths where the ISBN might show up. At this point, I don't have an
-	example where the first xpath does not work. The other two fail if the
-	website displays no options to buy the book (e.g. you have access to the pdf
-	and physical copies are no longer sold). Example: book/10.1007/BFb0032916
-
-	Another option would be to visit an entry of getResultList() and get the
-	ISBN from there, either from the html or from the RIS data. This has the
-	disadantage	that yet another http request is needed, costing additional
-	time.
-
-	There are often several different ISBNs for the same book (e.g. eBook,
-	Hardcover, Softcover), and we pick the first to appear in the html code.
-	*/
 	var isbnList = ZU.xpath(doc, '//span[@itemprop="isbn"]');
 	if (isbnList.length) {
 		return isbnList[0].innerText;

--- a/Springer Link.js
+++ b/Springer Link.js
@@ -15,6 +15,7 @@
 /*
    SpringerLink Translator
    Copyright (C) 2020 Aurimas Vinckevicius and Sebastian Karcher
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
@@ -113,7 +114,7 @@ function doWeb(doc, url) {
 		}
 		Zotero.selectItems(items, function (selectedItems) {
 			if (!selectedItems) return;
-			for (var i in selectedItems) {
+			for (let i in selectedItems) {
 				if (i == 0) {
 					searchByISBN(doc, url);
 					// ZU.processDocuments(url, searchByISBN); // does not appear to make a difference

--- a/Springer Link.js
+++ b/Springer Link.js
@@ -30,7 +30,7 @@
  */
 
 function getAction(url) {
-	//eslint-disable-next-line no-useless-escape
+	// eslint-disable-next-line no-useless-escape
 	return url.match(/^https?:\/\/[^\/]+\/([^\/?#]+)/);
 }
 
@@ -268,7 +268,7 @@ function scrape(doc, url) {
 }
 
 function scrapeISBN(doc, _url) {
-	
+
 	/*
 	Several xpaths where the ISBN might show up. At this point, I don't have an
 	example where the first xpath does not work. The other two fail if the


### PR DESCRIPTION
**New features**

In the past, books from Springer Link could only be saved chapter wise (example: https://link.springer.com/book/10.1007/978-3-540-34514-5). The root of the problem is mostly to Springer Link, as they do not provide metadata or RIS data for whole books, only for chapters (see this German [support article](https://support.springer.com/de/support/solutions/articles/6000081276-quellen-exportieren)). In my opinion, their approach makes sense for books that are collections of (mostly independent) articles, but is quite annoying for textbooks which you typically cite as a whole `book` and not as a `bookSection`. This problem was reported by someone else on the [Zotero forum](https://forums.zotero.org/discussion/47168/import-springer-book-as-a-whole) years ago. The DOI translator is not a workaround, because its behaviour is identical to the current Springer Link translator.

I have approached this issue by scraping the ISBN from the website of the whole book and then using the built-in ISBN search translators to find bibliography data. PDF downloads also work (assuming you have access to the file).

Books are still detected as "multiple", and the first entry in the list is now "Full book (by ISBN)" (suggestions for a better caption are very welcome).

**Known issue**

There is one known issue, which I do not know how to fix: If you access Springer Link through a url-rewriting proxy (e.g. the one used by LMU Munich), then the ISBN search translators attempt to proxy their requests as well, which usually fails for me (as my university's proxy does not seem to forward all pages):

```
(3)(+0000001): Translate: resolving URL http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=bath.ISBN=^9783540539513&maximumRecords=1
(3)(+0000000): Translate: resolved to http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=bath.ISBN=^9783540539513&maximumRecords=1
(3)(+0000000): Translate: proxified to http://lx2.loc.gov:210.emedien.ub.uni-muenchen.de/LCDB?operation=searchRetrieve&version=1.1&query=bath.ISBN=%5E9783540539513&maximumRecords=1
[...]
(3)(+0000000): HTTP GET http://lx2.loc.gov:210.emedien.ub.uni-muenchen.de/LCDB?operation=searchRetrieve&version=1.1&query=bath.ISBN=%5E9783540539513&maximumRecords=1 failed with status code undefined
[...]
(3)(+0000000): Translate: resolving URL https://catalogue.bnf.fr/api/SRU?version=1.2&operation=searchRetrieve&query=bib.isbn%20all%20%229783540539513%22
(3)(+0000001): Translate: resolved to https://catalogue.bnf.fr/api/SRU?version=1.2&operation=searchRetrieve&query=bib.isbn%20all%20%229783540539513%22
(3)(+0000000): Translate: proxified to https://catalogue-bnf-fr.emedien.ub.uni-muenchen.de/api/SRU?version=1.2&operation=searchRetrieve&query=bib.isbn%20all%20%229783540539513%22
```
Any suggestions how to approach this problem would be greatly appreciated. Small note for testing: If you want to verify that this translator (including PDF downloads) works fine on proxified webpages as long as the ISBN queries are not proxified, you can temporarily clear the new translator's target regex, which will circumvent Zotero's proxy detection.

**Side note**

I had two problems with ESLint:
- Regular expressions trigger `no-useless-escape` errors in cases where the escape character is needed, e.g. in `url.match(/^https?:\/\/...`. This issue seems to appear [elsewhere](https://stackoverflow.com/questions/47277133/disable-unnecessary-escape-character-no-useless-escape) as well.
- The linter does not allow a block comment directly below a function definition. If you write
    ```
    function (...)
    
    /* ...
    ```
    you get a `padded-blocks` error. If you write instead
    ```
    function (...)
    /* ...
    ```
    you get a `lines-around-comment` error. This could be fixed by setting `"allowBlockStart": true` in the options of `lines-around-comment`.

Thanks in advance for a review and suggestions for improvement.