### PR TITLE
Fix Straits Times

### DIFF
--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-23 22:06:21"
+	"lastUpdated": "2022-01-23 22:08:18"
 }
 
 /*
@@ -73,7 +73,7 @@ function scrape(doc, url) {
 	if (authors !== null && authors.length) {
 		authors = authors.trim();
 		insertCreator(authors, newItem);
-	} 
+	}
 	else {
 		authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); // multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
 		if (authors !== null && authors.length) {
@@ -258,8 +258,7 @@ function insertCreator(authorName, newItem) {
 	else {
 		newItem.creators.push(ZU.cleanAuthor(authorName, "author"));
 	}
-}
-/** BEGIN TEST CASES **/
+}/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -74,7 +74,7 @@ function scrape(doc, url) {
 		authors = authors.trim();
 		insertCreator(authors, newItem);	
 	} else {
-		authors = Zotero.Utilities.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); //multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
+		authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); //multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
 		if (authors !== null && authors.length) {
 			var authorsArr = authors.split(',');
 			for (var i = 0; i < authorsArr.length; i++) {

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-23 21:59:07"
+	"lastUpdated": "2022-01-23 22:06:21"
 }
 
 /*
@@ -72,9 +72,10 @@ function scrape(doc, url) {
 	var authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//div[contains(@itemprop, "author")]'); // single author article. https://www.straitstimes.com/singapore/more-employees-eligible-for-covid-19-support-grant-application-start-date-pushed-back-msf
 	if (authors !== null && authors.length) {
 		authors = authors.trim();
-		insertCreator(authors, newItem);	
-	} else {
-		authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); //multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
+		insertCreator(authors, newItem);
+	} 
+	else {
+		authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); // multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
 		if (authors !== null && authors.length) {
 			var authorsArr = authors.split(',');
 			for (var i = 0; i < authorsArr.length; i++) {
@@ -87,7 +88,7 @@ function scrape(doc, url) {
 	if (authors === null || !authors.length) {
 		var author = ZU.xpathText(doc, '//div[contains(@class, "group-byline-info")]//div[contains(@class, "field-byline")]');
 		if (author !== null && author.length) {
-			var authorArr = author.trim().replace(' For The Straits Times', '').split(' and '); //https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health
+			var authorArr = author.trim().replace(' For The Straits Times', '').split(' and '); // https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health
 			for (var i2 = 0; i2 < authorArr.length; i2++) {
 				insertCreator(authorArr[i2], newItem);
 			}
@@ -150,16 +151,16 @@ function insertCreator(authorName, newItem) {
 		'Benjamin Lim Kang': { first: 'Benjamin, Kang', last: 'Lim' },
 		'Chang Ai-Lien': { first: 'Ai-Lien', last: 'Chang' },
 		'Chang May Choon': { first: 'May Choon', last: 'Chang' },
-		'Chang Tou Liang': { first: 'Tou Liang', last: 'Chang'},
+		'Chang Tou Liang': { first: 'Tou Liang', last: 'Chang' },
 		'Cheong Suk-Wai': { first: 'Suk-Wai', last: 'Cheong' },
-		'Cheow Sue-Ann' : { first: 'Sue-Ann', last: 'Cheow' },
-		'Cheryl Teh TL' : { first: 'Cheryl, TL', last: 'Teh' },
+		'Cheow Sue-Ann': { first: 'Sue-Ann', last: 'Cheow' },
+		'Cheryl Teh TL': { first: 'Cheryl, TL', last: 'Teh' },
 		'Chew Hui Min': { first: 'Hui Min', last: 'Chew' },
 		'Chin Hui Shan': { first: 'Hui Shan', last: 'Chin' },
 		'Chng Choon Hiong': { first: 'Choon Hion', last: 'Chng' },
 		'Chong Jun Liang': { first: 'Jun Liang', last: 'Chong' },
 		'Choo Yun Ting': { first: 'Yun Ting', last: 'Choo' },
-		'Christian de Boisredon' : { first: 'Christian', last: 'de Boisredon' },
+		'Christian de Boisredon': { first: 'Christian', last: 'de Boisredon' },
 		'Chua Mui Hoong': { first: 'Mui Hoong', last: 'Chua' },
 		'Chua Siang Yee': { first: 'Siang Yee', last: 'Chua' },
 		'Feng Zengkun': { first: 'Zengkun', last: 'Feng' },
@@ -173,20 +174,20 @@ function insertCreator(authorName, newItem) {
 		'Joy Pang Minle': { first: 'Joy, Minle', last: 'Pang' },
 		'Kang Wan Chern': { first: 'Wan Chern', last: 'Kang' },
 		'Khoe Wei Jun': { first: 'Wei Jun', last: 'Khoe' },
-		'Kok Xing Hui' : { first: 'Xing Hui', last: 'Kok' },
+		'Kok Xing Hui': { first: 'Xing Hui', last: 'Kok' },
 		'Kua Chee Siong': { first: 'Chee Siong', last: 'Kua' },
 		'Lai Shueh Yuan': { first: 'Shueh Yuan', last: 'Lai' },
 		'Lee Chee Chew': { first: 'Chee Chew', last: 'Lee' },
 		'Lee Choo Kiong': { first: 'Choo Kiong', last: 'Lee' },
 		'Lee Jian Xuan': { first: 'Jian Xuan', last: 'Lee' },
 		'Lee Min Kok': { first: 'Min Kok', last: 'Lee' },
-		'Lee Nian Tjoe': { first: 'Nian Tjoe', last: 'Lee'},
+		'Lee Nian Tjoe': { first: 'Nian Tjoe', last: 'Lee' },
 		'Lee Qing Ping': { first: 'Qing Ping', last: 'Lee' },
 		'Lee Seok Hwai': { first: 'Seok Hwai', last: 'Lee' },
 		'Lee Si Xuan': { first: 'Si Xuan', last: 'Lee' },
 		'Lee Siew Hua': { first: 'Siew Hua', last: 'Lee' },
-		'Lee Xin En' : { first: 'Xin En', last: 'Lee' },
 		'Lee Wei Ling': { first: 'Wei Ling', last: 'Lee' },
+		'Lee Xin En': { first: 'Xin En', last: 'Lee' },
 		'Li Xueying': { first: 'Xueying', last: 'Li' },
 		'Lian Szu Jin': { first: 'Szu Jin', last: 'Lian' },
 		'Liew Ai Xin': { first: 'Ai Xin', last: 'Liew' },
@@ -207,7 +208,7 @@ function insertCreator(authorName, newItem) {
 		'Nicholas De Silva': { first: 'Nicholas', last: 'De Silva' },
 		'Ng Kane Gene': { first: 'Kane Gene', last: 'Ng' },
 		'Ng Huiwen': { first: 'Huiwen', last: 'Ng' },
-		'Ng Wei Kai': {first: 'Wei Kai', last: 'Ng'},
+		'Ng Wei Kai': { first: 'Wei Kai', last: 'Ng' },
 		'Nur Asyiqin Mohamad Salleh': { first: 'Nur Asyiqin', last: 'Mohamad Salleh' },
 		'Ong Sor Fern': { first: 'Sor Fern', last: 'Ong' },
 		'Poon Chian Hui': { first: 'Chain Hui', last: 'Poon' },
@@ -237,7 +238,7 @@ function insertCreator(authorName, newItem) {
 		'Toh Ting Wei': { first: 'Ting Wei', last: 'Toh' },
 		'Toh Yong Chuan': { first: 'Yong Chuan', last: 'Toh' },
 		'Tong Ming Chien': { first: 'Ming Chien', last: 'Tong' },
-		'Wang Gungwu': { first: 'Gungwu', last: 'Wang'},
+		'Wang Gungwu': { first: 'Gungwu', last: 'Wang' },
 		'Wong Ah Yoke': { first: 'Ah Yoke', last: 'Wong' },
 		'Wong Kim Hoh': { first: 'Kim Hoh', last: 'Wong' },
 		'Wong Shiying': { first: 'Shiying', last: 'Wong' },

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -258,7 +258,9 @@ function insertCreator(authorName, newItem) {
 	else {
 		newItem.creators.push(ZU.cleanAuthor(authorName, "author"));
 	}
-}/** BEGIN TEST CASES **/
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-08-03 06:47:27"
+	"lastUpdated": "2022-01-23 21:42:11"
 }
 
 /*
@@ -36,14 +36,14 @@
 */
 
 function detectWeb(doc, url) {
-	var pageClass = ZU.xpathText(doc, '//meta[@name="cXenseParse:pageclass"]/@content');
+	var pageClass = ZU.xpathText(doc, '//meta[@property="og:type"]/@content');
 	if (pageClass === 'article') {
 		var testPath = url.replace(/^https?:\/\/(www.)?straitstimes.com\//, '');
 		if (testPath.split('/').length > 1) {
 			return 'newspaperArticle';
 		}
 	}
-	if (pageClass === 'frontpage') {
+	if (pageClass === 'Website') {
 		return 'multiple';
 	}
 	
@@ -64,20 +64,31 @@ function scrape(doc, url) {
 	newItem.ISSN = '0585-3923';
 	newItem.url = url;
 	newItem.publicationTitle = 'The Straits Times';
-	newItem.title = ZU.xpathText(doc, '//meta[@name="dcterms.title"]/@content');
-	newItem.abstractNote = (ZU.xpathText(doc, '//meta[@name="dcterms.description"]/@content') || '').replace('Read more at straitstimes.com.', '').trim();
-	newItem.date = ZU.xpathText(doc, '//meta[@name="dcterms.date"]/@content');
+	newItem.title = ZU.xpathText(doc, '//meta[@property="og:title"]/@content');
+	newItem.abstractNote = (ZU.xpathText(doc, '//meta[@property="og:description"]/@content') || '').replace('\n. Read more at straitstimes.com.', '').trim();
+	newItem.date = ZU.xpathText(doc, '//meta[@property="article:published_time"]/@content');
 	newItem.place = 'Singapore';
 	newItem.language = 'en';
-	var authors = ZU.xpath(doc, '//meta[@property="article:author"]');
-	for (var i = 0; i < authors.length; i++) {
-		insertCreator(authors[i].getAttribute('content'), newItem);
+	var authors = ZU.xpathText(doc, '//div[contains(@class, "field-byline")]//div[contains(@itemprop, "author")]'); // single author article. https://www.straitstimes.com/singapore/more-employees-eligible-for-covid-19-support-grant-application-start-date-pushed-back-msf
+	if (authors !== null && authors.length) {
+		authors = authors.trim();
+		insertCreator(authors, newItem);	
+	} else {
+		authors = Zotero.Utilities.xpathText(doc, '//div[contains(@class, "field-byline")]//span[contains(@itemprop, "author")]'); //multiple authors article. https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales
+		if (authors !== null && authors.length) {
+			var authorsArr = authors.split(',');
+			for (var i = 0; i < authorsArr.length; i++) {
+				insertCreator(authorsArr[i], newItem);
+			}
+		}
 	}
-	// for opinion/forum contributors
-	if (!authors.length) {
-		var author = ZU.xpath(doc, '//div[contains(@class, "field-byline-custom")]');
-		if (author.length) {
-			insertCreator(ZU.xpathText(doc, '//div[contains(@class, "field-byline-custom")]'), newItem);
+
+	// for opinion/forum contributors. https://www.straitstimes.com/opinion/facebooks-next-frontier-the-metaverse-what-does-that-mean
+	if (authors === null || !authors.length) {
+		var author = ZU.xpathText(doc, '//div[contains(@class, "group-byline-info")]//div[contains(@class, "field-byline")]');
+		if (author !== null && author.length) {
+			var authorArr = author.trim().replace(' For The Straits Times', '').split(' and '); //https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health
+			insertCreator(author, newItem);
 		}
 	}
 	
@@ -130,37 +141,49 @@ function insertCreator(authorName, newItem) {
 	var authorList = {
 		'Alison de Souza': { first: 'Alison', last: 'de Souza' },
 		'Arnoud de Meyer': { first: 'Arnoud', last: 'de Meyer' },
+		'Ang Yiying': { first: 'Yiying', last: 'Ang' },
+		'Ang Qing': { first: 'Qing', last: 'Ang' },
 		'Aw Cheng Wei': { first: 'Cheng Wei', last: 'Aw' },
 		'Baey Zo-Er': { first: 'Zo-Er', last: 'Baey' },
-		'Benjamin Kang Lim': { first: 'Benjamin Kang', last: 'Lim' },
+		'Benjamin Lim Kang': { first: 'Benjamin, Kang', last: 'Lim' },
 		'Chang Ai-Lien': { first: 'Ai-Lien', last: 'Chang' },
 		'Chang May Choon': { first: 'May Choon', last: 'Chang' },
+		'Chang Tou Liang': { first: 'Tou Liang', last: 'Chang'},
 		'Cheong Suk-Wai': { first: 'Suk-Wai', last: 'Cheong' },
+		'Cheow Sue-Ann' : { first: 'Sue-Ann', last: 'Cheow' },
+		'Cheryl Teh TL' : { first: 'Cheryl, TL', last: 'Teh' },
+		'Chew Hui Min': { first: 'Hui Min', last: 'Chew' },
 		'Chin Hui Shan': { first: 'Hui Shan', last: 'Chin' },
 		'Chng Choon Hiong': { first: 'Choon Hion', last: 'Chng' },
 		'Chong Jun Liang': { first: 'Jun Liang', last: 'Chong' },
 		'Choo Yun Ting': { first: 'Yun Ting', last: 'Choo' },
+		'Christian de Boisredon' : { first: 'Christian', last: 'de Boisredon' },
 		'Chua Mui Hoong': { first: 'Mui Hoong', last: 'Chua' },
 		'Chua Siang Yee': { first: 'Siang Yee', last: 'Chua' },
 		'Feng Zengkun': { first: 'Zengkun', last: 'Feng' },
 		'Goh Ruoxue': { first: 'Ruoxue', last: 'Goh' },
 		'Goh Sui Noi': { first: 'Sui Noi', last: 'Goh' },
 		'Goh Yan Han': { first: 'Yan Han', last: 'Goh' },
+		'Han Fook Kwang': { first: 'Fook Kwang', last: 'Han' },
 		'Ho Ai Li': { first: 'Ai Li', last: 'Ho' },
 		'Ho Cai Jun': { first: 'Cai Jun', last: 'Ho' },
 		'Jeremy Au Yong': { first: 'Jeremy', last: 'Au Yong' },
 		'Joy Pang Minle': { first: 'Joy, Minle', last: 'Pang' },
+		'Kang Wan Chern': { first: 'Wan Chern', last: 'Kang' },
 		'Khoe Wei Jun': { first: 'Wei Jun', last: 'Khoe' },
+		'Kok Xing Hui' : { first: 'Xing Hui', last: 'Kok' },
 		'Kua Chee Siong': { first: 'Chee Siong', last: 'Kua' },
 		'Lai Shueh Yuan': { first: 'Shueh Yuan', last: 'Lai' },
 		'Lee Chee Chew': { first: 'Chee Chew', last: 'Lee' },
 		'Lee Choo Kiong': { first: 'Choo Kiong', last: 'Lee' },
 		'Lee Jian Xuan': { first: 'Jian Xuan', last: 'Lee' },
 		'Lee Min Kok': { first: 'Min Kok', last: 'Lee' },
+		'Lee Nian Tjoe': { first: 'Nian Tjoe', last: 'Lee'},
 		'Lee Qing Ping': { first: 'Qing Ping', last: 'Lee' },
 		'Lee Seok Hwai': { first: 'Seok Hwai', last: 'Lee' },
 		'Lee Si Xuan': { first: 'Si Xuan', last: 'Lee' },
 		'Lee Siew Hua': { first: 'Siew Hua', last: 'Lee' },
+		'Lee Xin En' : { first: 'Xin En', last: 'Lee' },
 		'Lee Wei Ling': { first: 'Wei Ling', last: 'Lee' },
 		'Li Xueying': { first: 'Xueying', last: 'Li' },
 		'Lian Szu Jin': { first: 'Szu Jin', last: 'Lian' },
@@ -172,16 +195,20 @@ function insertCreator(authorName, newItem) {
 		'Lim Yan Liang': { first: 'Yan Liang', last: 'Lim' },
 		'Lim Yaohui': { first: 'Yaohui', last: 'Lim' },
 		'Lim Yi Han': { first: 'Yi Han', last: 'Lim' },
-		'Lin Yangchen': { first: 'Yanchen', last: 'Lin' },
+		'Lin Yangchen': { first: 'Yangchen', last: 'Lin' },
+		'Ling Chang Hong': { first: 'Chang Hong', last: 'Ling' },
 		'Loh Guo Pei': { first: 'Guo Pei', last: 'Loh' },
+		'Loh Keng Fatt': { first: 'Keng Fatt', last: 'Loh' },
 		'Low Lin Fhoong': { first: 'Lin Fhoong', last: 'Low' },
 		'Mok Qiu Lin': { first: 'Qiu Lin', last: 'Mok' },
 		'Moon Jae-in': { first: 'Jae-in', last: 'Moon' },
 		'Nicholas De Silva': { first: 'Nicholas', last: 'De Silva' },
 		'Ng Kane Gene': { first: 'Kane Gene', last: 'Ng' },
 		'Ng Huiwen': { first: 'Huiwen', last: 'Ng' },
+		'Ng Wei Kai': {first: 'Wei Kai', last: 'Ng'},
 		'Nur Asyiqin Mohamad Salleh': { first: 'Nur Asyiqin', last: 'Mohamad Salleh' },
 		'Ong Sor Fern': { first: 'Sor Fern', last: 'Ong' },
+		'Poon Chian Hui': { first: 'Chain Hui', last: 'Poon' },
 		'Quah Ting Wen': { first: 'Ting Wen', last: 'Quah' },
 		'Raynold Toh YK': { first: 'Raynold, YK', last: 'Toh' },
 		'Rebecca Tan Hui Qing': { first: 'Rebecca, Hui Qing', last: 'Tan' },
@@ -206,12 +233,15 @@ function insertCreator(authorName, newItem) {
 		'Thong Yong Jun': { first: 'Yong Jun', last: 'Thong' },
 		'Toh Wen Li': { first: 'Wen Li', last: 'Toh' },
 		'Toh Ting Wei': { first: 'Ting Wei', last: 'Toh' },
+		'Toh Yong Chuan': { first: 'Yong Chuan', last: 'Toh' },
 		'Tong Ming Chien': { first: 'Ming Chien', last: 'Tong' },
+		'Wang Gungwu': { first: 'Gungwu', last: 'Wang'},
 		'Wong Ah Yoke': { first: 'Ah Yoke', last: 'Wong' },
 		'Wong Kim Hoh': { first: 'Kim Hoh', last: 'Wong' },
 		'Wong Shiying': { first: 'Shiying', last: 'Wong' },
 		'Wong Yang': { first: 'Yang', last: 'Wong' },
 		'Yeo Shu Hui': { first: 'Shu Hui', last: 'Yeo' },
+		'Yip Wai Yee': { first: 'Wai Yee', last: 'Yip' },
 		'Yuen Sin': { first: 'Sin', last: 'Yuen' },
 		'Zhao Jiayi': { first: 'Jiayi', last: 'Zhao' }
 	};
@@ -226,6 +256,8 @@ function insertCreator(authorName, newItem) {
 		newItem.creators.push(ZU.cleanAuthor(authorName, "author"));
 	}
 }
+
+
 
 
 /** BEGIN TEST CASES **/
@@ -244,7 +276,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2020-12-28T05:00+08:00",
+				"date": "2020-12-28T05:00:00+08:00",
 				"ISSN": "0585-3923",
 				"abstractNote": "For life to become more normal, and for businesses to get back on their feet, more people need to become immune to the virus.",
 				"language": "en",
@@ -278,7 +310,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2020-04-30T22:49+08:00",
+				"date": "2020-04-30T22:49:30+08:00",
 				"ISSN": "0585-3923",
 				"abstractNote": "The grant application has been pushed back from May 1 to May 4 or 11, depending on the employee's situation.",
 				"language": "en",
@@ -313,7 +345,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2021-08-02T21:04+08:00",
+				"date": "2021-08-02T21:04:19+08:00",
 				"ISSN": "0585-3923",
 				"abstractNote": "Under the tweaked rules, non-residents from high-risk areas can also enter Hong Kong if they are fully vaccinated.",
 				"language": "en",
@@ -347,7 +379,7 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2021-08-03T05:00+08:00",
+				"date": "2021-08-03T05:00:00+08:00",
 				"ISSN": "0585-3923",
 				"abstractNote": "Advertising dominates Facebook's social-networking business model. Zuckerberg's move to create a virtual world raises the possibility of new revenue sources.",
 				"extra": "Straits Times Access: Subscription only",
@@ -372,6 +404,45 @@ var testCases = [
 		"type": "web",
 		"url": "https://www.straitstimes.com/",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "S'poreans going ahead with CNY plans despite Covid-19 surge, Chinatown businesses see boost in sales",
+				"creators": [
+					{
+						"lastName": "Yeo",
+						"firstName": "Shu Hui",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Dominic",
+						"lastName": "Low",
+						"creatorType": "author"
+					}
+				],
+				"date": "2022-01-23T18:32:31+08:00",
+				"ISSN": "0585-3923",
+				"abstractNote": "But they are taking precautions, such as taking turns for visits and doing regular tests.",
+				"language": "en",
+				"libraryCatalog": "The Straits Times",
+				"place": "Singapore",
+				"publicationTitle": "The Straits Times",
+				"url": "https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-23 21:42:11"
+	"lastUpdated": "2022-01-23 21:55:40"
 }
 
 /*
@@ -88,7 +88,9 @@ function scrape(doc, url) {
 		var author = ZU.xpathText(doc, '//div[contains(@class, "group-byline-info")]//div[contains(@class, "field-byline")]');
 		if (author !== null && author.length) {
 			var authorArr = author.trim().replace(' For The Straits Times', '').split(' and '); //https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health
-			insertCreator(author, newItem);
+			for (var i2 = 0; i2 < authorArr.length; i2++) {
+				insertCreator(authorArr[i2], newItem);
+			}
 		}
 	}
 	
@@ -256,6 +258,7 @@ function insertCreator(authorName, newItem) {
 		newItem.creators.push(ZU.cleanAuthor(authorName, "author"));
 	}
 }
+
 
 
 
@@ -432,6 +435,86 @@ var testCases = [
 				"place": "Singapore",
 				"publicationTitle": "The Straits Times",
 				"url": "https://www.straitstimes.com/singapore/community/sporeans-going-ahead-with-cny-plans-amid-surge-in-covid-19-cases-as-businesses-see-boost-in-sales",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.straitstimes.com/world/science-talk-hope-and-concern-for-two-novel-covid-19-antivirals",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Science Talk: Hope and concern for two novel Covid-19 antivirals",
+				"creators": [
+					{
+						"firstName": "William A.",
+						"lastName": "Haseltine",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Roberto",
+						"lastName": "Patarca",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-11-22T05:00:00+08:00",
+				"ISSN": "0585-3923",
+				"abstractNote": "Public health measures, vaccines and antimicrobials – which kill micro-organisms or stop their growth – are the hallmarks to keeping plague-causing microbes at bay and, in exceedingly rare instances, even to eradicating them.",
+				"language": "en",
+				"libraryCatalog": "The Straits Times",
+				"place": "Singapore",
+				"publicationTitle": "The Straits Times",
+				"shortTitle": "Science Talk",
+				"url": "https://www.straitstimes.com/world/science-talk-hope-and-concern-for-two-novel-covid-19-antivirals",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Science Talk: When climate change impacts human health",
+				"creators": [
+					{
+						"firstName": "Ching Ann",
+						"lastName": "Hui",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Woo",
+						"lastName": "Qiyun",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021-11-08T20:22:34+08:00",
+				"ISSN": "0585-3923",
+				"abstractNote": "SINGAPORE - The climate crisis is often treated as an environmental problem, but the planetary heating could also have severe repercussions on human health.",
+				"language": "en",
+				"libraryCatalog": "The Straits Times",
+				"place": "Singapore",
+				"publicationTitle": "The Straits Times",
+				"shortTitle": "Science Talk",
+				"url": "https://www.straitstimes.com/singapore/environment/science-talk-when-climate-change-impacts-human-health",
 				"attachments": [
 					{
 						"title": "Snapshot",

--- a/The Straits Times.js
+++ b/The Straits Times.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-23 21:55:40"
+	"lastUpdated": "2022-01-23 21:59:07"
 }
 
 /*
@@ -258,11 +258,6 @@ function insertCreator(authorName, newItem) {
 		newItem.creators.push(ZU.cleanAuthor(authorName, "author"));
 	}
 }
-
-
-
-
-
 /** BEGIN TEST CASES **/
 var testCases = [
 	{


### PR DESCRIPTION
major changes in the meta elements, and some changes to their byline section rendered the current version of the translator non-functional. this update retargets at the remaining available meta elements and byline section.