### PR TITLE
Fix WestLaw case title scraping

### DIFF
--- a/WestLaw UK.js
+++ b/WestLaw UK.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-02-10 22:37:23"
+	"lastUpdated": "2022-02-10 22:42:40"
 }
 
 /*
@@ -77,7 +77,7 @@ function scrapeCase(doc, url) {
 		item.reporter = citationArray[3];
 		item.reporterVolume = citationArray[2];
 		item.firstPage = citationArray[4];
-		item.dateDecided = citationArray[1]
+		item.dateDecided = citationArray[1];
 		item.court = /Court(.+)/.exec(text(doc, "#co_docContentCourt"))[1];
 		item.abstractNote = "";
 		item.complete();

--- a/WestLaw UK.js
+++ b/WestLaw UK.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-06 14:45:19"
+	"lastUpdated": "2022-02-10 22:37:23"
 }
 
 /*
@@ -73,6 +73,7 @@ function scrapeCase(doc, url) {
 	translator.setHandler('itemDone', function (obj, item) {
 		const citationArray = parseCitationList(text(doc, "#co_docContentWhereReported", 0));
 
+		item.title = text(doc, "#co_docHeaderContainer");
 		item.reporter = citationArray[3];
 		item.reporterVolume = citationArray[2];
 		item.firstPage = citationArray[4];
@@ -126,7 +127,7 @@ function scrapeStatuteSection(doc, url) {
 
 
 function parseCitationList(citList) {
-	let citationRe = /[\[|(](\d+)[\]|)] (\d*) ?([A-z. ]+) (\w[^Judgment])+/g;
+	let citationRe = /[[|(](\d+)[\]|)] (\d*) ?([A-z. ]+) (\w[^Judgment])+/g;
 	let citationAsArray;
 	while ((citationAsArray = citationRe.exec(citList))) {
 		if (citationAsArray[3] !== "WLUK") {
@@ -134,8 +135,7 @@ function parseCitationList(citList) {
 		}
 	}
 	return citationAsArray;
-}
-/** BEGIN TEST CASES **/
+}/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/WestLaw UK.js
+++ b/WestLaw UK.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-02-10 22:42:40"
+	"lastUpdated": "2022-02-13 15:15:03"
 }
 
 /*
@@ -73,7 +73,7 @@ function scrapeCase(doc, url) {
 	translator.setHandler('itemDone', function (obj, item) {
 		const citationArray = parseCitationList(text(doc, "#co_docContentWhereReported", 0));
 
-		item.title = text(doc, "#co_docHeaderContainer");
+		item.title = text(doc, "#co_docHeaderContainer") ? text(doc, "#co_docHeaderContainer") : /(.+)\|/.exec(doc.title)[1];
 		item.reporter = citationArray[3];
 		item.reporterVolume = citationArray[2];
 		item.firstPage = citationArray[4];


### PR DESCRIPTION
Annoyingly, WestLaw added " | WestLaw UK" to all the page titles right as my WestLaw translator was merged. This screwed with the case scraping, and this PR gets the case names from somewhere more reliable on the page rather than the page title. 

Statute titles are not affected as their contents was already pulled from the page itself in a much more reliable way. 