### PR TITLE
nbib - Get page number from LID field when no PG field exists

### DIFF
--- a/MEDLINEnbib.js
+++ b/MEDLINEnbib.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2022-02-14 13:07:48"
+	"lastUpdated": "2022-02-14 13:09:41"
 }
 
 /*
@@ -881,6 +881,81 @@ var testCases = [
 					},
 					{
 						"tag": "Tutoring"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "import",
+		"input": "PMID- 35128459\nOWN - NLM\nSTAT- PubMed-not-MEDLINE\nLR  - 20220208\nIS  - 2641-9157 (Electronic)\nIS  - 2641-9157 (Linking)\nVI  - 4\nIP  - 1\nDP  - 2021\nTI  - Slow Burns: A Qualitative Study of Burn Pit and Toxic Exposures Among Military \n      Veterans Serving in Afghanistan, Iraq and Throughout the Middle East.\nLID - 1042 [pii]\nAB  - During deployment to the Persian Gulf War and Southwest Asia theatre of operations, \n      Veterans often experienced various hazards, foremost being open-air burn pits and \n      oil well fires. While over 23 presumptive conditions (ranging from brain cancer, \n      interstitial lung disease, and lymphomas to sleep/mood disorders, depression, and \n      cognitive impairment) have been studied in connection with their military-related \n      exposures, there is a paucity of qualitative research on this topic. This is \n      especially true in the context of explanatory models and health belief systems, \n      vis-à-vis underlying social and cultural factors. The current paper provides a \n      balanced conceptual framework (summarizing causal virtues and shortcomings) about \n      the challenges that Veterans encounter when seeking medical care, screening \n      assessments and subsequent treatments.\nFAU - Bith-Melander, Pollie\nAU  - Bith-Melander P\nAD  - Department of Social Work, California State University, Stanislaus, Turlock, CA, \n      USA.\nFAU - Ratliff, Jack\nAU  - Ratliff J\nAD  - Department of Medical-Surgical Oncology, James A Haley Veterans Affairs Hospital, \n      Tampa, FL, USA.\nAD  - Military Exposures Team, HunterSeven Foundation, Providence, RI, USA.\nFAU - Poisson, Chelsey\nAU  - Poisson C\nAD  - Military Exposures Team, HunterSeven Foundation, Providence, RI, USA.\nFAU - Jindal, Charulata\nAU  - Jindal C\nAD  - Harvard Medical School, Harvard University, Boston, USA.\nFAU - Ming Choi, Yuk\nAU  - Ming Choi Y\nAD  - Signify Health, Dallas, TX, 75244, USA.\nFAU - Efird, Jimmy T\nAU  - Efird JT\nAD  - Cooperative Studies Program Epidemiology Center, Health Services Research and \n      Development, DVAHCS, Durham, USA.\nLA  - eng\nPT  - Journal Article\nDEP - 20211227\nTA  - Ann Psychiatry Clin Neurosci\nJT  - Annals of psychiatry and clinical neuroscience\nJID - 9918334788106676\nPMC - PMC8816568\nMID - NIHMS1773706\nOTO - NOTNLM\nOT  - Burn pits\nOT  - Deployment anthropology\nOT  - Explanatory models\nOT  - Military exposures\nOT  - Oil well fires\nOT  - Qualitative analysis\nEDAT- 2022/02/08 06:00\nMHDA- 2022/02/08 06:01\nCRDT- 2022/02/07 05:37\nPHST- 2022/02/07 05:37 [entrez]\nPHST- 2022/02/08 06:00 [pubmed]\nPHST- 2022/02/08 06:01 [medline]\nAID - 1042 [pii]\nPST - ppublish\nSO  - Ann Psychiatry Clin Neurosci. 2021;4(1):1042. Epub 2021 Dec 27.\n",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Slow Burns: A Qualitative Study of Burn Pit and Toxic Exposures Among Military Veterans Serving in Afghanistan, Iraq and Throughout the Middle East.",
+				"creators": [
+					{
+						"firstName": "Pollie",
+						"lastName": "Bith-Melander",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Jack",
+						"lastName": "Ratliff",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Chelsey",
+						"lastName": "Poisson",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Charulata",
+						"lastName": "Jindal",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Yuk",
+						"lastName": "Ming Choi",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Jimmy T.",
+						"lastName": "Efird",
+						"creatorType": "author"
+					}
+				],
+				"date": "2021",
+				"ISSN": "2641-9157",
+				"abstractNote": "During deployment to the Persian Gulf War and Southwest Asia theatre of operations, Veterans often experienced various hazards, foremost being open-air burn pits and  oil well fires. While over 23 presumptive conditions (ranging from brain cancer,  interstitial lung disease, and lymphomas to sleep/mood disorders, depression, and  cognitive impairment) have been studied in connection with their military-related  exposures, there is a paucity of qualitative research on this topic. This is  especially true in the context of explanatory models and health belief systems,  vis-à-vis underlying social and cultural factors. The current paper provides a  balanced conceptual framework (summarizing causal virtues and shortcomings) about  the challenges that Veterans encounter when seeking medical care, screening  assessments and subsequent treatments.",
+				"extra": "PMID: 35128459 \nPMCID: PMC8816568",
+				"issue": "1",
+				"journalAbbreviation": "Ann Psychiatry Clin Neurosci",
+				"language": "eng",
+				"pages": "1042",
+				"publicationTitle": "Annals of psychiatry and clinical neuroscience",
+				"volume": "4",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "Burn pits"
+					},
+					{
+						"tag": "Deployment anthropology"
+					},
+					{
+						"tag": "Explanatory models"
+					},
+					{
+						"tag": "Military exposures"
+					},
+					{
+						"tag": "Oil well fires"
+					},
+					{
+						"tag": "Qualitative analysis"
 					}
 				],
 				"notes": [],

--- a/MEDLINEnbib.js
+++ b/MEDLINEnbib.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2021-06-19 00:00:44"
+	"lastUpdated": "2022-02-14 13:07:48"
 }
 
 /*
@@ -151,7 +151,8 @@ function processTag(item, tag, value) {
 		// Pubmed adds all sorts of different IDs in here, so make sure these are URLs
 		if (value.startsWith("http")) {
 			item.attachments.push({ url: value, title: "Catalog Link", snapshot: false });
-		}
+		// If the value is tagged as a PII, we can use this as a page number if we have not previously managed to extract one
+		} else if (value.includes("[pii]")) item.pagesBackup = value.replace(/\s*\[pii\]/, "");
 	}
 	else if (tag == "MH" || tag == "OT") {
 		item.tags.push(value);
@@ -237,7 +238,8 @@ function finalizeItem(item) {
 		if (fullPageRange) {
 			item.pages = fullPageRange;
 		}
-	}
+	// If there is not an explicitly defined page range, try and use the value extracted from the LID field
+	} else if (item.pagesBackup) item.pages = item.pagesBackup;
 	// check for and remove duplicate ISSNs
 	if (item.ISSN && item.ISSN.includes(" ")) {
 		let ISSN = item.ISSN.split(/\s/);

--- a/MEDLINEnbib.js
+++ b/MEDLINEnbib.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2022-02-14 13:09:41"
+	"lastUpdated": "2022-02-21 17:06:30"
 }
 
 /*
@@ -240,6 +240,7 @@ function finalizeItem(item) {
 		}
 	// If there is not an explicitly defined page range, try and use the value extracted from the LID field
 	} else if (item.pagesBackup) item.pages = item.pagesBackup;
+	delete item.pagesBackup;
 	// check for and remove duplicate ISSNs
 	if (item.ISSN && item.ISSN.includes(" ")) {
 		let ISSN = item.ISSN.split(/\s/);


### PR DESCRIPTION
This PR fixes the scenario where an nbib file without a PG field is imported. In this case, the LID (Location Identifier) field is inspected for a PII - if one is found, this is used as the page number in the created item. 

The LID field has been chosen over the AID (Article Identifier) field as this matches the behaviour seen in the PubMed XML translator.

This PR resolves #2783