### PR TITLE
conference_proceeding->book

### DIFF
--- a/Primo Normalized XML.js
+++ b/Primo Normalized XML.js
@@ -64,6 +64,7 @@ function doImport() {
 		case 'pbook':
 		case 'print_book':
 		case 'books':
+		case 'conference_proceeding':
 		case 'score':
 		case 'journal':		// as long as we don't have a periodical item type;
 			item.itemType = "book";
@@ -111,9 +112,6 @@ function doImport() {
 			break;
 		case 'newspaper_article':
 			item.itemType = "newspaperArticle";
-			break;
-		case 'conference_proceeding':
-			item.itemType = "conferencePaper";
 			break;
 		default:
 			item.itemType = "document";


### PR DESCRIPTION
This adjusts the behavior for conference proceedings so they get imported as item type `book`. The current behavior (import as item type `conference paper`) doesn't seem to be a good fit IMO. 