### PR TITLE
Update HighWire2 importer to correctly set preprint type on biorXiv/medrXiv items

### DIFF
--- a/HighWire 2.0.js
+++ b/HighWire 2.0.js
@@ -409,7 +409,7 @@ function detectWeb(doc, url) {
 			&& !url.includes('/suppl/')
 		) {
 			if (url.includes('medrxiv.org') || url.includes('biorxiv.org')) {
-				return "preprint";
+				return preprintType;
 			}
 			else {
 				return "journalArticle";

--- a/HighWire 2.0.js
+++ b/HighWire 2.0.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-04-04 18:38:42"
+	"lastUpdated": "2022-06-13 22:14:27"
 }
 
 /*
@@ -409,7 +409,7 @@ function detectWeb(doc, url) {
 			&& !url.includes('/suppl/')
 		) {
 			if (url.includes('medrxiv.org') || url.includes('biorxiv.org')) {
-				return "report";
+				return "preprint";
 			}
 			else {
 				return "journalArticle";


### PR DESCRIPTION
Previously, the HighWire2.0 translator was updated in #2808 in commit ba3cec3. However, due to the hard-coded `report` itemtype in `doWeb`, the updated translator code was never called for biorXiv and medrXiv, and thus was failing the biorXiv and medrXiv tests.

This PR updates the hardcoded itemtype in detectWeb for biorXiv and medrXiv to be the "preprint" type, which then passes the biorXiv and medrXiv tests and properly imports these items.