### PR TITLE
Update NLA Catalogue translator to save urls for digitised items

### DIFF
--- a/National Library of Australia (new catalog).js
+++ b/National Library of Australia (new catalog).js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-08-01 05:49:00"
+	"lastUpdated": "2022-08-02 21:35:50"
 }
 
 /*
@@ -115,9 +115,9 @@ function scrapeMarc(text) {
 		record.importBinary(text);
 		var item = new Zotero.Item();
 		// If there is a url for the digitised item add it
-		var url = record.getFieldSubfields("856");
-		if (url && url.length > 0 && url[0].u && url[0].z && url[0].z.startsWith("National Library of Australia digitised item")) {
-			item.url = url[0].u;
+		var [url] = record.getFieldSubfields("856");
+		if (url && url.u && url.z && url.z.startsWith("National Library of Australia digitised item")) {
+			item.url = url.u;
 		}
 		record.translate(item);
 		item.complete();

--- a/National Library of Australia (new catalog).js
+++ b/National Library of Australia (new catalog).js
@@ -1,15 +1,15 @@
 {
 	"translatorID": "54ac4ec1-9d07-45d3-9d96-48bed3411fb6",
 	"label": "National Library of Australia (new catalog)",
-	"creator": "Philipp Zumstein",
+	"creator": "Philipp Zumstein and Tim Sherratt",
 	"target": "^https?://catalogue\\.nla\\.gov\\.au",
-	"minVersion": "3.0",
+	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-01-30 09:40:11"
+	"lastUpdated": "2022-08-01 05:49:00"
 }
 
 /*
@@ -35,24 +35,20 @@
 	***** END LICENSE BLOCK *****
 */
 
-
-// attr()/text() v2
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
-
-
 function detectWeb(doc, url) {
 	if (url.match("/Record/[0-9]+")) {
 		var format = doc.getElementById("myformat").textContent;
 		return computeFormat(format);
-		
-	} else if (url.includes("/Search/Home") && doc.getElementById("resultItemLine1")) {
+	}
+	else if (url.includes("/Search/Home") && doc.getElementById("resultItemLine1")) {
 		return "multiple";
 	}
+	return "book";
 }
 
 
 // map the nla formats to zotero formats
-function computeFormat(format){
+function computeFormat(format) {
 	// clean up whitespace and remove commas from items with multiple formats
 	format = Zotero.Utilities.trimInternal(format.replace(',', ''));
 	if (format == "Audio") return "audioRecording";
@@ -73,7 +69,7 @@ function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll('.resultitem a.title');
-	for (let i=0; i<rows.length; i++) {
+	for (let i = 0; i < rows.length; i++) {
 		let href = rows[i].href;
 		if (!/\/Record\/\d+/.test(href)) continue;
 		let title = ZU.trimInternal(rows[i].textContent);
@@ -89,19 +85,18 @@ function getSearchResults(doc, checkOnly) {
 function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) {
-				return true;
-			}
+			if (!items) return;
 			processUrls(Object.keys(items));
 		});
-	} else {
+	}
+	else {
 		processUrls([url]);
 	}
 }
 
 
 function processUrls(urls) {
-	for (let i=0; i<urls.length; i++) {
+	for (let i = 0; i < urls.length; i++) {
 		var bibid = urls[i].match(/\/Record\/(\d+)\b/);
 		if (bibid) {
 			var marcUrl = "/Record/" + bibid[1] + "/Export?style=marc";
@@ -114,7 +109,19 @@ function scrapeMarc(text) {
 	var translator = Zotero.loadTranslator("import");
 	translator.setTranslator("a6ee60df-1ddc-4aae-bb25-45e0537be973");
 	translator.setString(text);
-	translator.translate();
+	translator.getTranslatorObject(function (obj) {
+		var record = new obj.record();
+		// Populate the record from the MARC
+		record.importBinary(text);
+		var item = new Zotero.Item();
+		// If there is a url for the digitised item add it
+		var url = record.getFieldSubfields("856");
+		if (url && url.length > 0 && url[0].u && url[0].z && url[0].z.startsWith("National Library of Australia digitised item")) {
+			item.url = url[0].u;
+		}
+		record.translate(item);
+		item.complete();
+	});
 }
 
 /** BEGIN TEST CASES **/
@@ -163,6 +170,54 @@ var testCases = [
 		"type": "web",
 		"url": "http://catalogue.nla.gov.au/Search/Home?lookfor=labor&type=all&limit%5B%5D=&submit=Find&filter[]=language:%22eng%22",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://catalogue.nla.gov.au/Record/296911",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Australian almanack and general directory: for the year of Our Lord",
+				"creators": [
+					{
+						"firstName": "E. W.",
+						"lastName": "O'Shaughnessey",
+						"creatorType": "editor"
+					}
+				],
+				"date": "1835",
+				"libraryCatalog": "National Library of Australia (new catalog)",
+				"numPages": "1",
+				"place": "Sydney",
+				"publisher": "Printed at the Gazette Office by Anne Howe; published and sold by John Innes",
+				"shortTitle": "Australian almanack and general directory",
+				"url": "https://nla.gov.au/nla.obj-2976853543",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "Almanacs, Australian"
+					},
+					{
+						"tag": "Directories"
+					},
+					{
+						"tag": "Directories"
+					},
+					{
+						"tag": "New South Wales"
+					},
+					{
+						"tag": "Sydney (N.S.W.)"
+					}
+				],
+				"notes": [
+					{
+						"note": "National Library of Australia's FRM F1878 (N1) copy is bound in black leather with much decorative gilt embossing, including the inner edged of the covers, marbled endpapers and has the name of the owner highlighted onthe front cover: Rev Dr Fletcher. This copy contains the dedication: \"To Eliza Coster from Wm. Fletcher, September 21st, 1843\""
+					}
+				],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
The NLA catalogue includes links to digitised versions of items where available in the 856 MARC field. This PR saves this url to the Zotero item if the z subfield of 856 starts with 'National Library of Australia digitised item'. 

I also fixed up a few linting errors and added a new test.