### PR TITLE
index.d.ts: fix HTTPRequestParameters for Zotero.Utilities.request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,7 +154,7 @@ declare namespace Zotero {
 
 		type HTTPRequestParameters<T extends HTTPResponseType> = {
 			method?: string = "GET",
-			requestHeaders?: Record<string, string>,
+			headers?: Record<string, string>,
 			body?: string,
 			responseCharset?: string,
 			responseType?: T = "text"


### PR DESCRIPTION
requestHeaders should be headers, see https://github.com/zotero/zotero-connectors/blob/master/src/common/http.js#L68