### PR TITLE
Improve Citavi 5/6 translator improvements

### DIFF
--- a/Citavi 5 XML.js
+++ b/Citavi 5 XML.js
@@ -1,39 +1,40 @@
 {
 	"translatorID": "e7243cef-a709-4a46-ba46-1b1318051bec",
 	"label": "Citavi 5 XML",
-	"creator": "Philipp Zumstein",
+	"creator": "Philipp Zumstein, Tomasz Najdek",
 	"target": "xml",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"configOptions": {
-		"dataMode": "xml/dom"
+		"dataMode": "xml/dom",
+		"async": true
 	},
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2020-06-11 13:27:10"
+	"lastUpdated": "2022-08-16 21:47:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
-	
+
 	Copyright © 2016 Philipp Zumstein
-	
+
 	This file is part of Zotero.
-	
+
 	Zotero is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Zotero is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
-	
+
 	***** END LICENSE BLOCK *****
 */
 
@@ -46,92 +47,67 @@ TEST DATA can be found here:
  - Citavi 6 project (935 KB): https://gist.github.com/zuphilip/00a4ec6df58ac24b68366e32531bae4b
 */
 
-
 function detectImport() {
 	var text = Zotero.read(1000);
 	return text.indexOf("<CitaviExchangeData") != -1;
 }
 
-//This maps the Citavi types to the Zotero types.
-//https://www.citavi.com/sub/manual5/en/referencetypeselectiondialog.html
+// This maps the Citavi types to the Zotero types.
+// https://www.citavi.com/sub/manual5/en/referencetypeselectiondialog.html
 var typeMapping = {
-	"ArchiveMaterial" : "manuscript", //Archivgut
-	"AudioBook" : "book", //Hörbuch
-	"AudioOrVideoDocument" : "document", //Ton- oder Filmdokument
-	"Book" : "book", //Buch (Monographie)
-	"BookEdited" : "book", //Buch (Sammelwerk)
-	"Broadcast" : "tvBroadcast", //Radio- oder Fernsehsendung
-	"CollectedWorks" : "book", //Schriften eines Autors
-	"ComputerProgram" : "computerProgram", //Software
-	"ConferenceProceedings" : "book", //Tagungsband
-	"Contribution" : "bookSection", //Beitrag in ...
-	"ContributionInLegalCommentary" : "bookSection", //Beitrag in Gesetzeskommentar
-	"CourtDecision" : "case", //Gerichtsentscheid
-	"File" : "manuscript", //Akte
-	"InternetDocument" : "webpage", //Internetdokument
-	"InterviewMaterial" : "interview", //Interviewmaterial
-	"JournalArticle" : "journalArticle", //Zeitschriftenaufsatz
-	"Lecture" : "presentation", //Vortrag
-	"LegalCommentary" : "book", //Gesetzeskommentar
-	"Manuscript" : "manuscript", //Manuskript
-	"Map" : "map", //Geographische Karte
-	"Movie" : "videoRecording", //Spielfilm
-	"MusicTrack" : "audioRecording", //Musiktitel in ...
-	"MusicAlbum" : "audioRecording", //Musikwerk / Musikalbum
-	"NewsAgencyReport" : "report", //Agenturmeldung
-	"NewspaperArticle" : "newspaperArticle", //Zeitungsartikel
-	"Patent" : "patent", //Patentschrift
-	"PersonalCommunication" : "email", //Persönliche Mitteilung
-	"PressRelease" : "report", //Pressemitteilung
-	"RadioPlay" : "podcast", //Hörspiel
-	"SpecialIssue" : "book", //Sonderheft, Beiheft
-	"Standard" : "report", //Norm
-	"StatuteOrRegulation" : "statute", //Gesetz / Verordnung
-	"Thesis" : "thesis", //Hochschulschrift
-	"Unknown" : "document", //Unklarer Dokumententyp
-	"UnpublishedWork" : "report" //Graue Literatur / Bericht / Report
+	ArchiveMaterial : "manuscript", //Archivgut
+	AudioBook : "book", //Hörbuch
+	AudioOrVideoDocument : "document", //Ton- oder Filmdokument
+	Book : "book", //Buch (Monographie)
+	BookEdited : "book", //Buch (Sammelwerk)
+	Broadcast : "tvBroadcast", //Radio- oder Fernsehsendung
+	CollectedWorks : "book", //Schriften eines Autors
+	ComputerProgram : "computerProgram", //Software
+	ConferenceProceedings : "book", //Tagungsband
+	Contribution : "bookSection", //Beitrag in ...
+	ContributionInLegalCommentary : "bookSection", //Beitrag in Gesetzeskommentar
+	CourtDecision : "case", //Gerichtsentscheid
+	File : "manuscript", //Akte
+	InternetDocument : "webpage", //Internetdokument
+	InterviewMaterial : "interview", //Interviewmaterial
+	JournalArticle : "journalArticle", //Zeitschriftenaufsatz
+	Lecture : "presentation", //Vortrag
+	LegalCommentary : "book", //Gesetzeskommentar
+	Manuscript : "manuscript", //Manuskript
+	Map : "map", //Geographische Karte
+	Movie : "videoRecording", //Spielfilm
+	MusicTrack : "audioRecording", //Musiktitel in ...
+	MusicAlbum : "audioRecording", //Musikwerk / Musikalbum
+	NewsAgencyReport : "report", //Agenturmeldung
+	NewspaperArticle : "newspaperArticle", //Zeitungsartikel
+	Patent : "patent", //Patentschrift
+	PersonalCommunication : "email", //Persönliche Mitteilung
+	PressRelease : "report", //Pressemitteilung
+	RadioPlay : "podcast", //Hörspiel
+	SpecialIssue : "book", //Sonderheft, Beiheft
+	Standard : "report", //Norm
+	StatuteOrRegulation : "statute", //Gesetz / Verordnung
+	Thesis : "thesis", //Hochschulschrift
+	Unknown : "document", //Unklarer Dokumententyp
+	UnpublishedWork : "report" //Graue Literatur / Bericht / Report
 };
 
-
-function doImport() {
-	var doc = Zotero.getXML();
-	var citaviVersion = ZU.xpathText(doc, '//CitaviExchangeData/@Version');
-	
-	//Groups will also be mapped to tags which can be assigned to
-	//items or notes.
-	var groups = ZU.xpath(doc, '//Groups/Group');
-	var rememberTags = {};
-	for (var i=0; i<groups.length; i++) {
-		var id = ZU.xpathText(groups[i], './@id');
-		var name = ZU.xpathText(groups[i], './Name');
-		var referenceGroups = ZU.xpath(doc, '//ReferenceGroups/OnetoN[contains(text(), "'+id+'")]|//KnowledgeItemGroups/OnetoN[contains(text(), "'+id+'")]');
-		for (var j=0; j<referenceGroups.length; j++) {
-			var refid = referenceGroups[j].textContent.split(';')[0];
-			if (rememberTags[refid]) {
-				rememberTags[refid].push(name);
-			} else {
-				rememberTags[refid] = [name];
-			}
-		}
-	}
-	
-	//Main information for each reference.
-	var item;
-	var references = ZU.xpath(doc, '//References/Reference');
-	var unfinishedReferences = [];
-	var itemIdList = {};
-	for (var i=0, n=references.length; i<n; i++) {
+async function importItem(data) {
+	const { references, doc, citaviVersion, rememberTags, itemIdList, unfinishedReferences } = data;
+	for (var i = 0, n = references.length; i < n; i++) {
 		var type = ZU.xpathText(references[i], 'ReferenceType');
+		let item;
 		if (type && typeMapping[type]) {
 			item = new Zotero.Item(typeMapping[type]);
-		} else {
+		}
+		else {
 			Z.debug("Not yet supported type: " + type);
 			Z.debug("Therefore use default type 'journalArticle'");
 			item = new Zotero.Item("journalArticle");
 		}
 		item.itemID = ZU.xpathText(references[i], './@id');
-		//Z.debug(item.itemID);
-		
+		// Z.debug(item.itemID);
+
 		item.title = ZU.xpathText(references[i], './Title');
 		var subtitle = ZU.xpathText(references[i], './Subtitle');
 		if (subtitle) {
@@ -146,67 +122,67 @@ function doImport() {
 		item.edition = ZU.xpathText(references[i], './Edition');
 		item.place = ZU.xpathText(references[i], './PlaceOfPublication');
 		item.numberOfVolumes = ZU.xpathText(references[i], './NumberOfVolumes');
-		
+
 		addExtraLine(item, "PMID", ZU.xpathText(references[i], './PubMedID'));
-		
+
 		item.pages = extractPages(ZU.xpathText(references[i], './PageRange'));
 		item.numPages = extractPages(ZU.xpathText(references[i], './PageCount'));
-		
-		item.date = ZU.xpathText(references[i], './DateForSorting') ||
-			ZU.xpathText(references[i], './Date') ||
-			ZU.xpathText(references[i], './Year');
+
+		item.date = ZU.xpathText(references[i], './DateForSorting')
+			|| ZU.xpathText(references[i], './Date')
+			|| ZU.xpathText(references[i], './Year');
 		item.accessDate = ZU.xpathText(references[i], './AccessDate');
-		
+
 		for (var field of ['Notes', 'TableOfContents', 'Evaluation']) {
-			var note = ZU.xpathText(references[i], './'+field);
+			var note = ZU.xpathText(references[i], './' + field);
 			if (note) {
-				item.notes.push({ note : note , tags : ["#" + field] });
+				item.notes.push({ note: note, tags: ["#" + field] });
 			}
 		}
-		
+
 		var seriesID = ZU.xpathText(references[i], './SeriesTitleID');
 		if (seriesID) {
 			item.series = ZU.xpathText(doc.getElementById(seriesID), './Name');
 		}
-		
+
 		var periodicalID = ZU.xpathText(references[i], './PeriodicalID');
 		if (periodicalID) {
 			var periodical = doc.getElementById(periodicalID);
 			item.publicationTitle = ZU.xpathText(periodical, './Name');
 			item.ISSN = ZU.xpathText(periodical, './ISSN');
-			item.journalAbbreviation = ZU.xpathText(periodical, './StandardAbbreviation') ||
-				ZU.xpathText(periodical, './UserAbbreviation1') ||
-				ZU.xpathText(periodical, './UserAbbreviation2');
+			item.journalAbbreviation = ZU.xpathText(periodical, './StandardAbbreviation')
+				|| ZU.xpathText(periodical, './UserAbbreviation1')
+				|| ZU.xpathText(periodical, './UserAbbreviation2');
 		}
-		
-		var authors = ZU.xpathText(doc, '//ReferenceAuthors/OnetoN[starts-with(text(), "'+item.itemID+'")]');
+
+		var authors = ZU.xpathText(doc, '//ReferenceAuthors/OnetoN[starts-with(text(), "' + item.itemID + '")]');
 		attachPersons(doc, item, authors, "author");
-		var editors = ZU.xpathText(doc, '//ReferenceEditors/OnetoN[starts-with(text(), "'+item.itemID+'")]');
+		var editors = ZU.xpathText(doc, '//ReferenceEditors/OnetoN[starts-with(text(), "' + item.itemID + '")]');
 		attachPersons(doc, item, editors, "editor");
-		var collaborators = ZU.xpathText(doc, '//ReferenceCollaborators/OnetoN[starts-with(text(), "'+item.itemID+'")]');
+		var collaborators = ZU.xpathText(doc, '//ReferenceCollaborators/OnetoN[starts-with(text(), "' + item.itemID + '")]');
 		attachPersons(doc, item, collaborators, "contributor");
-		var organizations = ZU.xpathText(doc, '//ReferenceOrganizations/OnetoN[starts-with(text(), "'+item.itemID+'")]');
+		var organizations = ZU.xpathText(doc, '//ReferenceOrganizations/OnetoN[starts-with(text(), "' + item.itemID + '")]');
 		attachPersons(doc, item, organizations, "contributor");
-		
-		var publishers = ZU.xpathText(doc, '//ReferencePublishers/OnetoN[starts-with(text(), "'+item.itemID+'")]');
-		if (publishers && publishers.length>0) {
+
+		var publishers = ZU.xpathText(doc, '//ReferencePublishers/OnetoN[starts-with(text(), "' + item.itemID + '")]');
+		if (publishers && publishers.length > 0) {
 			item.publisher = attachName(doc, publishers).join('; ');
 		}
-		
-		var keywords = ZU.xpathText(doc, '//ReferenceKeywords/OnetoN[starts-with(text(), "'+item.itemID+'")]');
-		if (keywords && keywords.length>0) {
+
+		var keywords = ZU.xpathText(doc, '//ReferenceKeywords/OnetoN[starts-with(text(), "' + item.itemID + '")]');
+		if (keywords && keywords.length > 0) {
 			item.tags = attachName(doc, keywords);
 		}
 		if (rememberTags[item.itemID]) {
-			for (var j=0; j<rememberTags[item.itemID].length; j++) {
+			for (var j = 0; j < rememberTags[item.itemID].length; j++) {
 				item.tags.push(rememberTags[item.itemID][j]);
 			}
 		}
-		
-		//For all corresponding knowledge items attach a note containing
-		//the information of it.
-		var citations = ZU.xpath(doc, '//KnowledgeItem[ReferenceID="'+item.itemID+'"]');
-		for (var j=0; j<citations.length; j++) {
+
+		// For all corresponding knowledge items attach a note containing
+		// the information of it.
+		var citations = ZU.xpath(doc, '//KnowledgeItem[ReferenceID="' + item.itemID + '"]');
+		for (let j = 0; j < citations.length; j++) {
 			var noteObject = {};
 			noteObject.id = ZU.xpathText(citations[j], '@id');
 			var title = ZU.xpathText(citations[j], 'CoreStatement');
@@ -216,7 +192,7 @@ function doImport() {
 			if (title) {
 				noteObject.note += '<h1>' + title + "</h1>\n";
 			}
-			if (text) { 
+			if (text) {
 				noteObject.note += "<p>" + ZU.xpathText(citations[j], 'Text') + "</p>\n";
 			}
 			if (pages) {
@@ -229,42 +205,36 @@ function doImport() {
 				item.notes.push(noteObject);
 			}
 		}
-		
-		//Locations will be saved as URIs in attachments, DOI, extra etc.
-		var locations = ZU.xpath(doc, '//Locations/Location[ReferenceID="'+item.itemID+'"]');
-		//If we only have partial information about the callnumber or
-		//library location, then we save this info in these two arrays
-		//which will then processed after the for loop if no other info
-		//was found.
+
+		// Locations will be saved as URIs in attachments, DOI, extra etc.
+		var locations = ZU.xpath(doc, '//Locations/Location[ReferenceID="' + item.itemID + '"]');
+		// If we only have partial information about the callnumber or
+		// library location, then we save this info in these two arrays
+		// which will then processed after the for loop if no other info
+		// was found.
 		var onlyLibraryInfo = [];
 		var onlyCallNumber = [];
-		for (var j=0; j<locations.length; j++) {
+		for (let j = 0; j < locations.length; j++) {
 			var address = ZU.xpathText(locations[j], 'Address');
 			if (address && citaviVersion[0] !== "5") {
 				var jsonAddress = JSON.parse(address);
 				// Z.debug(jsonAddress);
-				address = jsonAddress["UriString"];
+				address = jsonAddress.UriString;
 			}
 			var addressType = ZU.xpathText(locations[j], 'MirrorsReferencePropertyId');
 			if (address) {
 				if (addressType == "Doi" && !item.DOI) {
 					item.DOI = address;
-				} else if (addressType == "PubMedId" && ((item.extra && !item.extra.includes("PMID"))|| !item.extra)) {
+				} else if (addressType == "PubMedId" && ((item.extra && !item.extra.includes("PMID")) || !item.extra)) {
 					addExtraLine(item, "PMID", address);
 				} else {
 					// distinguish between local paths and internet addresses
 					// (maybe also encoded in AddressInfo subfield?)
-					if (address.indexOf('http://')==0 || address.indexOf('https://')==0) {
-						item.attachments.push({
-							url: address,
-							title: "Online"
-						});
-					} else {
-						item.attachments.push({
-							path: address,
-							title: "Full Text"
-						});
-					}
+					item.attachments.push(
+						(address.indexOf('http://') == 0 || address.indexOf('https://') == 0)
+							? { url: address, title: "Online" }
+							: { path: address, title: "Full Text" }
+					);
 				}
 			}
 			var callNumber = ZU.xpathText(locations[j], 'CallNumber');
@@ -272,44 +242,51 @@ function doImport() {
 			if (callNumber && libraryId) {
 				item.callNumber = callNumber;
 				item.libraryCatalog = ZU.xpathText(doc.getElementById(libraryId), "Name");
-			} else if (callNumber) {
+			}
+			else if (callNumber) {
 				onlyCallNumber.push(callNumber);
-			} else if (libraryId) {
+			}
+			else if (libraryId) {
 				onlyLibraryInfo.push(ZU.xpathText(doc.getElementById(libraryId), "Name"));
 			}
 		}
 		if (!item.callNumber) {
-			if (onlyCallNumber.length>0) {
+			if (onlyCallNumber.length > 0) {
 				item.callNumber = onlyCallNumber[0];
-			} else if (onlyLibraryInfo.length>0) {
+			}
+			else if (onlyLibraryInfo.length > 0) {
 				item.libraryCatalog = onlyLibraryInfo[0];
 			}
 		}
-		
-		//Only for journalArticle and conferencePaper the DOI field is
-		//currently established and therefore we need to add the info for
-		//all other itemTypes in the extra field.
+
+		// Only for journalArticle and conferencePaper the DOI field is
+		// currently established and therefore we need to add the info for
+		// all other itemTypes in the extra field.
 		if (item.DOI && item.itemType != "journalArticle" && item.itemType != "conferencePaper") {
 			addExtraLine(item, "DOI", item.DOI);
 		}
-		
-		//The items of type contribution need more data from their container
-		//element and are therefore not yet finished. The other items can
-		//be completed here.
+
+		// The items of type contribution need more data from their container
+		// element and are therefore not yet finished. The other items can
+		// be completed here.
 		itemIdList[item.itemID] = item;
+
 		if (type == "Contribution") {
 			unfinishedReferences.push(item);
-		} else {
-			item.complete();
+		}
+		else {
+			await item.complete(); // eslint-disable-line no-await-in-loop
 		}
 	}
-	
-	
-	//For unfinished references we add additional data from the
-	//container item and save the relation between them as well.
-	for (var i=0; i< unfinishedReferences.length; i++) {
+}
+
+// For unfinished references we add additional data from the
+// container item and save the relation between them as well.
+async function importUnfinished(data) {
+	const { doc, itemIdList, unfinishedReferences } = data;
+	for (var i = 0; i < unfinishedReferences.length; i++) {
 		var item = unfinishedReferences[i];
-		var containerString = ZU.xpathText(doc, '//ReferenceReferences/OnetoN[contains(text(), "'+item.itemID+'")]');
+		var containerString = ZU.xpathText(doc, `//ReferenceReferences/OnetoN[contains(text(), "${item.itemID}")]`);
 		if (containerString) {
 			var containerId = containerString.split(';')[0];
 			var containerItem = itemIdList[containerId];
@@ -324,7 +301,7 @@ function doImport() {
 			item.edition = containerItem.edition;
 			item.series = containerItem.series;
 
-			for (var j=0; j<containerItem.creators.length; j++) {
+			for (var j = 0; j < containerItem.creators.length; j++) {
 				var creatorObject = containerItem.creators[j];
 				var role = creatorObject.creatorType;
 				if (role == "author") {
@@ -332,105 +309,141 @@ function doImport() {
 				}
 				item.creators.push(creatorObject);
 			}
-			
+
 			item.seeAlso.push(containerItem.itemID);
-			
 		}
-		item.complete();
+		await item.complete(); // eslint-disable-line no-await-in-loop
 	}
-	
-	//Categories will be mapped to collections where the name contains
-	//also the hierarchy number which we first calculate from the
-	//CategoryCategories list.
-	var categories = ZU.xpath(doc, '//Categories/Category');
-	//typo CategoryCatgories was fixed in Citavi 6
-	var hierarchy = ZU.xpath(doc, '//CategoryCatgories/OnetoN|//CategoryCategories/OnetoN');
-	var numbering = { "00000000-0000-0000-0000-000000000000" : "$" };
-	//we will have fixed prefix "$." for all collections (see below),
-	//such that only the substring starting form index 2 is relevant.
-	for (var i=0, n=hierarchy.length; i<n; i++) {
-		var categoryLists = hierarchy[i].textContent.split(";");
-		var referencePoint = categoryLists[0];
-		if (!numbering[referencePoint]) {
-			//in some cases the ordering of these relations is different
-			Z.debug("Warning: Reference point for categorization hierarchy not yet found");
-			Z.debug(categoryLists);
-			continue;
-		}
-		for (var j=1; j<categoryLists.length; j++) {
-			numbering[categoryLists[j]] = numbering[referencePoint] + "." + j;
-		}
-	}
-	var collectionList = [];
-	for (var i=0, n=categories.length; i<n; i++) {
-		var collection = new Zotero.Collection();
-		collection.id = ZU.xpathText(categories[i], './@id');
-		collection.name = ZU.xpathText(categories[i], './Name');
-		if (numbering[collection.id]) {
-			//add the hierarchy number whenever possible
-			collection.name = numbering[collection.id].substr(2) + ' ' + collection.name;
-		}
-		collection.type = 'collection';
-		collection.children = [];
-		var referenceCategories = ZU.xpath(doc, '//ReferenceCategories/OnetoN[contains(text(), "'+collection.id+'")]');
-		for (var j=0; j<referenceCategories.length; j++) {
-			var refid = referenceCategories[j].textContent.split(';')[0];
-			collection.children.push({ type: 'item', id: refid });
-		}
-		collectionList.push(collection);
-		collection.complete();
-	}
-	
-	
-	//Task items will be mapped to new standalone note
-	var tasks = ZU.xpath(doc, '//TaskItems/TaskItem');
-	for (var i=0, n=tasks.length; i<n; i++) {
-		item = new Zotero.Item("note");
-		
+}
+
+// Task items will be mapped to new standalone note
+async function importTasks(tasks) {
+	for (var i = 0, n = tasks.length; i < n; i++) {
+		let item = new Zotero.Item("note");
 		var dueDate = ZU.xpathText(tasks[i], './DueDate');
 		if (dueDate) {
 			item.note = "<h1>" + ZU.xpathText(tasks[i], './Name') + " until " + dueDate + "</h1>";
-		} else {
+		}
+		else {
 			item.note = "<h1>" + ZU.xpathText(tasks[i], './Name') + "</h1>";
 		}
 		var noteText = ZU.xpathText(tasks[i], './Notes');
 		if (noteText) {
 			item.note += "\n" + noteText;
 		}
-		
+
 		item.seeAlso.push(ZU.xpathText(tasks[i], './ReferenceID'));
-		
+
 		item.tags.push("#todo");
-		item.complete();
+		await item.complete(); // eslint-disable-line no-await-in-loop
 	}
-	
-	
+}
+
+function importCategories(doc) {
+	// Categories will be mapped to collections where the name contains
+	// also the hierarchy number which we first calculate from the
+	// CategoryCategories list.
+	var categories = ZU.xpath(doc, '//Categories/Category');
+	// typo CategoryCatgories was fixed in Citavi 6
+	var hierarchy = ZU.xpath(doc, '//CategoryCatgories/OnetoN|//CategoryCategories/OnetoN');
+	var numbering = { "00000000-0000-0000-0000-000000000000": "$" };
+	// we will have fixed prefix "$." for all collections (see below),
+	// such that only the substring starting form index 2 is relevant.
+	for (let i = 0, n = hierarchy.length; i < n; i++) {
+		var categoryLists = hierarchy[i].textContent.split(";");
+		var referencePoint = categoryLists[0];
+		if (!numbering[referencePoint]) {
+			// in some cases the ordering of these relations is different
+			Z.debug("Warning: Reference point for categorization hierarchy not yet found");
+			Z.debug(categoryLists.toString());
+			continue;
+		}
+		for (let j = 1; j < categoryLists.length; j++) {
+			numbering[categoryLists[j]] = numbering[referencePoint] + "." + j;
+		}
+	}
+	var collectionList = [];
+	for (let i = 0, n = categories.length; i < n; i++) {
+		var collection = new Zotero.Collection();
+		collection.id = ZU.xpathText(categories[i], './@id');
+		collection.name = ZU.xpathText(categories[i], './Name');
+		if (numbering[collection.id]) {
+			// add the hierarchy number whenever possible
+			collection.name = numbering[collection.id].substr(2) + ' ' + collection.name;
+		}
+		collection.type = 'collection';
+		collection.children = [];
+		var referenceCategories = ZU.xpath(doc, '//ReferenceCategories/OnetoN[contains(text(), "' + collection.id + '")]');
+		for (let j = 0; j < referenceCategories.length; j++) {
+			var refid = referenceCategories[j].textContent.split(';')[0];
+			collection.children.push({ type: 'item', id: refid });
+		}
+		collectionList.push(collection);
+		collection.complete();
+	}
+}
+
+async function doImport() {
+	var doc = Zotero.getXML();
+	var citaviVersion = ZU.xpathText(doc, '//CitaviExchangeData/@Version');
+
+	// Groups will also be mapped to tags which can be assigned to
+	// items or notes.
+	var groups = ZU.xpath(doc, '//Groups/Group');
+	var rememberTags = {};
+	for (var i = 0; i < groups.length; i++) {
+		var id = ZU.xpathText(groups[i], './@id');
+		var name = ZU.xpathText(groups[i], './Name');
+		var referenceGroups = ZU.xpath(doc, `//ReferenceGroups/OnetoN[contains(text(), "${id}")]|//KnowledgeItemGroups/OnetoN[contains(text(), "${id}")]`);
+		for (var j = 0; j<referenceGroups.length; j++) {
+			var refid = referenceGroups[j].textContent.split(';')[0];
+			if (rememberTags[refid]) {
+				rememberTags[refid].push(name);
+			}
+			else {
+				rememberTags[refid] = [name];
+			}
+		}
+	}
+	var tasks = ZU.xpath(doc, '//TaskItems/TaskItem');
+
+	// Main information for each reference.
+	var references = ZU.xpath(doc, '//References/Reference');
+	var unfinishedReferences = [];
+	var itemIdList = {};
+
+	await importItem({ references, doc, citaviVersion, rememberTags, itemIdList, unfinishedReferences });
+	await importUnfinished({ doc, itemIdList, unfinishedReferences });
+	await importTasks(tasks);
+	importCategories(doc);
 }
 
 function attachName(doc, ids) {
-	if (!ids || !ids.length || ids.length<=0) {
-		return ;
-	}
 	var valueList = [];
+
+	if (!ids || !ids.length || ids.length <= 0) {
+		return valueList;
+	}
+
 	var idList = ids.split(';');
-	//skip the first element which is the id of reference
-	for (var j=1; j<idList.length; j++) {
+	// skip the first element which is the id of reference
+	for (var j = 1; j < idList.length; j++) {
 		var author = doc.getElementById(idList[j]);
 		valueList.push(ZU.xpathText(author, 'Name'));
 	}
 	return valueList;
 }
 
-//For each id in the list of ids, find the 
-//corresponding node in the document and 
-//attach the data to the creators array.
+// For each id in the list of ids, find the
+// corresponding node in the document and
+// attach the data to the creators array.
 function attachPersons(doc, item, ids, type) {
-	if (!ids || !ids.length || ids.length<=0) {
-		return ;
+	if (!ids || !ids.length || ids.length <= 0) {
+		return;
 	}
 	var authorIds = ids.split(';');
-	//skip the first element which is the id of reference
-	for (var j=1; j<authorIds.length; j++) {
+	// skip the first element which is the id of reference
+	for (var j = 1; j < authorIds.length; j++) {
 		var author = doc.getElementById(authorIds[j]);
 		var lastName = ZU.xpathText(author, 'LastName');
 		var firstName = ZU.xpathText(author, 'FirstName');
@@ -439,13 +452,12 @@ function attachPersons(doc, item, ids, type) {
 			if (middleName) {
 				firstName += ' ' + middleName;
 			}
-			item.creators.push({ lastName : lastName, firstName : firstName, creatorType : type });
+			item.creators.push({ lastName, firstName, creatorType: type });
 		}
 		if (!firstName && lastName) {
-			item.creators.push({ lastName : lastName, creatorType : type , fieldMode : true});
+			item.creators.push({ lastName, creatorType: type, fieldMode: true });
 		}
 	}
-	
 }
 
 function addExtraLine(item, prefix, text) {
@@ -453,15 +465,18 @@ function addExtraLine(item, prefix, text) {
 		if (!item.extra) {
 			item.extra = '';
 		}
-		item.extra += prefix + ': ' + text + "\n"; 
+		item.extra += prefix + ': ' + text + "\n";
 	}
 }
 
 function extractPages(multilineText) {
 	if (multilineText) {
 		var parts = multilineText.split("\n");
-		return parts[parts.length-1].replace(/[^0-9\-–]/g, '');
+		return parts[parts.length - 1].replace(/[^0-9\-–]/g, '');
 	}
-}/** BEGIN TEST CASES **/
-var testCases = []
+	return '';
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [];
 /** END TEST CASES **/

--- a/Citavi 5 XML.js
+++ b/Citavi 5 XML.js
@@ -50,47 +50,47 @@ TEST DATA can be found here:
 
 function detectImport() {
 	var text = Zotero.read(1000);
-	return text.indexOf("<CitaviExchangeData") != -1;
+	return text.includes("<CitaviExchangeData");
 }
 
 // This maps the Citavi types to the Zotero types.
 // https://www.citavi.com/sub/manual5/en/referencetypeselectiondialog.html
 var typeMapping = {
-	ArchiveMaterial : "manuscript", //Archivgut
-	AudioBook : "book", //Hörbuch
-	AudioOrVideoDocument : "document", //Ton- oder Filmdokument
-	Book : "book", //Buch (Monographie)
-	BookEdited : "book", //Buch (Sammelwerk)
-	Broadcast : "tvBroadcast", //Radio- oder Fernsehsendung
-	CollectedWorks : "book", //Schriften eines Autors
-	ComputerProgram : "computerProgram", //Software
-	ConferenceProceedings : "book", //Tagungsband
-	Contribution : "bookSection", //Beitrag in ...
-	ContributionInLegalCommentary : "bookSection", //Beitrag in Gesetzeskommentar
-	CourtDecision : "case", //Gerichtsentscheid
-	File : "manuscript", //Akte
-	InternetDocument : "webpage", //Internetdokument
-	InterviewMaterial : "interview", //Interviewmaterial
-	JournalArticle : "journalArticle", //Zeitschriftenaufsatz
-	Lecture : "presentation", //Vortrag
-	LegalCommentary : "book", //Gesetzeskommentar
-	Manuscript : "manuscript", //Manuskript
-	Map : "map", //Geographische Karte
-	Movie : "videoRecording", //Spielfilm
-	MusicTrack : "audioRecording", //Musiktitel in ...
-	MusicAlbum : "audioRecording", //Musikwerk / Musikalbum
-	NewsAgencyReport : "report", //Agenturmeldung
-	NewspaperArticle : "newspaperArticle", //Zeitungsartikel
-	Patent : "patent", //Patentschrift
-	PersonalCommunication : "email", //Persönliche Mitteilung
-	PressRelease : "report", //Pressemitteilung
-	RadioPlay : "podcast", //Hörspiel
-	SpecialIssue : "book", //Sonderheft, Beiheft
-	Standard : "report", //Norm
-	StatuteOrRegulation : "statute", //Gesetz / Verordnung
-	Thesis : "thesis", //Hochschulschrift
-	Unknown : "document", //Unklarer Dokumententyp
-	UnpublishedWork : "report" //Graue Literatur / Bericht / Report
+	ArchiveMaterial: "manuscript", // Archivgut
+	AudioBook: "book", // Hörbuch
+	AudioOrVideoDocument: "document", // Ton- oder Filmdokument
+	Book: "book", // Buch (Monographie)
+	BookEdited: "book", // Buch (Sammelwerk)
+	Broadcast: "tvBroadcast", // Radio- oder Fernsehsendung
+	CollectedWorks: "book", // Schriften eines Autors
+	ComputerProgram: "computerProgram", // Software
+	ConferenceProceedings: "book", // Tagungsband
+	Contribution: "bookSection", // Beitrag in ...
+	ContributionInLegalCommentary: "bookSection", // Beitrag in Gesetzeskommentar
+	CourtDecision: "case", // Gerichtsentscheid
+	File: "manuscript", // Akte
+	InternetDocument: "webpage", // Internetdokument
+	InterviewMaterial: "interview", // Interviewmaterial
+	JournalArticle: "journalArticle", // Zeitschriftenaufsatz
+	Lecture: "presentation", // Vortrag
+	LegalCommentary: "book", // Gesetzeskommentar
+	Manuscript: "manuscript", // Manuskript
+	Map: "map", // Geographische Karte
+	Movie: "videoRecording", // Spielfilm
+	MusicTrack: "audioRecording", // Musiktitel in ...
+	MusicAlbum: "audioRecording", // Musikwerk / Musikalbum
+	NewsAgencyReport: "report", // Agenturmeldung
+	NewspaperArticle: "newspaperArticle", // Zeitungsartikel
+	Patent: "patent", // Patentschrift
+	PersonalCommunication: "email", // Persönliche Mitteilung
+	PressRelease: "report", // Pressemitteilung
+	RadioPlay: "podcast", // Hörspiel
+	SpecialIssue: "book", // Sonderheft, Beiheft
+	Standard: "report", // Norm
+	StatuteOrRegulation: "statute", // Gesetz / Verordnung
+	Thesis: "thesis", // Hochschulschrift
+	Unknown: "document", // Unklarer Dokumententyp
+	UnpublishedWork: "report" // Graue Literatur / Bericht / Report
 };
 
 async function importItems({ references, doc, citaviVersion, rememberTags, itemIdList, unfinishedReferences, progress }) {
@@ -225,9 +225,11 @@ async function importItems({ references, doc, citaviVersion, rememberTags, itemI
 			if (address) {
 				if (addressType == "Doi" && !item.DOI) {
 					item.DOI = address;
-				} else if (addressType == "PubMedId" && ((item.extra && !item.extra.includes("PMID")) || !item.extra)) {
+				}
+				else if (addressType == "PubMedId" && ((item.extra && !item.extra.includes("PMID")) || !item.extra)) {
 					addExtraLine(item, "PMID", address);
-				} else {
+				}
+				else {
 					// distinguish between local paths and internet addresses
 					// (maybe also encoded in AddressInfo subfield?)
 					item.attachments.push(
@@ -348,7 +350,7 @@ function addHierarchyNumberRecursive(collections, level = null) {
 		collection.name = `${hierarchyNumber} ${collection.name}`;
 		addHierarchyNumberRecursive(
 			collection.children.filter(c => c instanceof Zotero.Collection), hierarchyNumber
-		)
+		);
 	}
 }
 
@@ -389,7 +391,7 @@ function importCategories({ categories, doc, progress }) {
 		}
 		const parentCollection = collectionsMap.get(parentID);
 
-		childIDs.forEach(childID => {
+		childIDs.forEach((childID) => {
 			if (collectionsMap.has(childID)) {
 				parentCollection.children.push(collectionsMap.get(childID));
 				addedChildIDs.push(childID);
@@ -410,7 +412,6 @@ function importCategories({ categories, doc, progress }) {
 		collection.complete();
 		Z.setProgress(++progress.current / progress.total * 100);
 	}
-
 }
 
 async function doImport() {
@@ -425,7 +426,7 @@ async function doImport() {
 		var id = ZU.xpathText(groups[i], './@id');
 		var name = ZU.xpathText(groups[i], './Name');
 		var referenceGroups = ZU.xpath(doc, `//ReferenceGroups/OnetoN[contains(text(), "${id}")]|//KnowledgeItemGroups/OnetoN[contains(text(), "${id}")]`);
-		for (var j = 0; j<referenceGroups.length; j++) {
+		for (var j = 0; j < referenceGroups.length; j++) {
 			var refid = referenceGroups[j].textContent.split(';')[0];
 			if (rememberTags[refid]) {
 				rememberTags[refid].push(name);
@@ -512,7 +513,3 @@ function extractPages(multilineText) {
 	}
 	return '';
 }
-
-/** BEGIN TEST CASES **/
-var testCases = [];
-/** END TEST CASES **/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1526,6 +1526,8 @@ declare namespace Zotero {
 	): Zotero.Translate<SearchTranslator>;
 	function done(returnValue: string | false): void;
 	function debug(str: string, level?: 1 | 2 | 3 | 4 | 5): void;
+	function read(length?: number): any;
+	function getXML(): any;
 
 	const isBookmarklet: boolean;
 	const isConnector: boolean;


### PR DESCRIPTION
This PR implements the following changes to the Citavi 5/6 translator:

- Items are now imported asynchronously
- Collections hierarchy is preserved
- Progress is reported
- Fixed a bug where number prefix was missing for some collections

Additionally I've refactored code to match es-lint rules and added couple of API definitions to `index.d.ts`.