### PR TITLE
Update EBSCOhost.js

### DIFF
--- a/EBSCOhost.js
+++ b/EBSCOhost.js
@@ -2,7 +2,7 @@
 	"translatorID": "d0b1914a-11f1-4dd7-8557-b32fe8a3dd47",
 	"label": "EBSCOhost",
 	"creator": "Simon Kornblith, Michael Berkowitz, Josh Geller",
-	"target": "^https?://[^/]+/(eds|bsi|ehost)/(results|detail|folder|pdfviewer)",
+	"target": "^https?://[^/]+/(eds|bsi|ehost|src_ic)/(results|detail|folder|pdfviewer)",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,


### PR DESCRIPTION
Added src_ic to regex to make translator compatible with EBSCO's "Explora" product.

My limited testing shows that this works, but I'd be happy to run through any test suite that you have.