### PR TITLE
EM: Skip adjacent repeated authors (for Optica)

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-01-03 16:51:36"
+	"lastUpdated": "2022-11-21 21:41:54"
 }
 
 /*
@@ -570,6 +570,7 @@ function addHighwireMetadata(doc, newItem, hwType) {
 // process highwire creators; currently only editor and author, but easy to extend
 function processHighwireCreators(creatorNodes, role, doc) {
 	let itemCreators = [];
+	let lastCreator = null;
 	for (let creatorNode of creatorNodes) {
 		let creators = creatorNode.nodeValue.split(/\s*;\s*/);
 		if (creators.length == 1 && creatorNodes.length == 1) {
@@ -595,6 +596,11 @@ function processHighwireCreators(creatorNodes, role, doc) {
 
 			// skip empty authors. Try to match something other than punctuation
 			if (!creator || !creator.match(/[^\s,-.;]/)) continue;
+
+			// Skip adjacent repeated authors
+			if (lastCreator && creator == lastCreator) continue;
+
+			lastCreator = creator;
 
 			creator = ZU.cleanAuthor(creator, role, creator.includes(","));
 			if (creator.firstName) {
@@ -1917,6 +1923,89 @@ var testCases = [
 				"shortTitle": "Windows Privilege Escalation",
 				"url": "https://www.hackingarticles.in/windows-privilege-escalation-kernel-exploit/",
 				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://opg.optica.org/oe/fulltext.cfm?uri=oe-30-21-39188&id=509758",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Self-calibration interferometric stitching test method for cylindrical surfaces",
+				"creators": [
+					{
+						"firstName": "Hao",
+						"lastName": "Hu",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Zizhou",
+						"lastName": "Sun",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Shuai",
+						"lastName": "Xue",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Chaoliang",
+						"lastName": "Guan",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Yifan",
+						"lastName": "Dai",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Junfeng",
+						"lastName": "Liu",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Xiaoqiang",
+						"lastName": "Peng",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Shanyong",
+						"lastName": "Chen",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Yong",
+						"lastName": "Liu",
+						"creatorType": "author"
+					}
+				],
+				"date": "2022/10/10",
+				"DOI": "10.1364/OE.473836",
+				"ISSN": "1094-4087",
+				"abstractNote": "The surface figure accuracy requirement of cylindrical surfaces widely used in rotors of gyroscope, spindles of ultra-precision machine tools and high-energy laser systems is nearly 0.1 µm. Cylindricity measuring instrument that obtains 1-D profile result cannot be utilized for deterministic figuring methods. Interferometric stitching test for cylindrical surfaces utilizes a CGH of which the system error will accumulated to unacceptable extent for large aperture/angular aperture that require many subapertures. To this end, a self-calibration interferometric stitching method for cylindrical surfaces is proposed. The mathematical model of cylindrical surface figure and the completeness condition of self-calibration stitching test of cylindrical surfaces were analyzed theoretically. The effects of shear/stitching motion error and the subapertures lattice on the self-calibration test results were analyzed. Further, a self-calibration interferometric stitching algorithm that can theoretically recover all the necessary components of the system error for testing cylindrical surfaces was proposed. Simulations and experiments on a shaft were conducted to validate the feasibility.",
+				"issue": "21",
+				"journalAbbreviation": "Opt. Express, OE",
+				"language": "EN",
+				"libraryCatalog": "opg.optica.org",
+				"pages": "39188-39206",
+				"publicationTitle": "Optics Express",
+				"rights": "&#169; 2022 Optica Publishing Group",
+				"url": "https://opg.optica.org/oe/abstract.cfm?uri=oe-30-21-39188",
+				"volume": "30",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
 					{
 						"title": "Snapshot",
 						"mimeType": "text/html"


### PR DESCRIPTION
FWIW I think this is really an issue on Optica's end - repeating the same `citation_author` with different `citation_author_institution`s is kind of weird - but I think this fix is unlikely to cause problems on other sites and could potentially fix other issues we haven't caught yet. So it seemed OK to just put it in EM.

https://forums.zotero.org/discussion/comment/422712/#Comment_422712