### PR TITLE
Add suport for HAL_ID BibTeX key

### DIFF
--- a/BibTeX.js
+++ b/BibTeX.js
@@ -18,7 +18,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 3,
-	"lastUpdated": "2022-10-31 23:11:08"
+	"lastUpdated": "2023-01-01 03:54:00"
 }
 
 /*
@@ -121,7 +121,8 @@ var extraIdentifiers = {
 	mrnumber: 'MR',
 	zmnumber: 'Zbl',
 	pmid: 'PMID',
-	pmcid: 'PMCID'
+	pmcid: 'PMCID',
+	halid: 'HAL_ID'
 	
 	//Mostly from Wikipedia citation templates
 	//asin - Amazon ID


### PR DESCRIPTION
Add support for the HAL_ID key to import with the "HAL archives ouvertes" translator from that[ kind of webpage](https://hal.archives-ouvertes.fr/hal-00186916v1/bibtex).
The key would be imported as "HAL_ID" in the extra field of Zotero for compatibility with other translators.