### PR TITLE
Update Dialnet

### DIFF
--- a/Dialnet.js
+++ b/Dialnet.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2018-03-28 21:36:40"
+	"lastUpdated": "2023-01-02 19:24:51"
 }
 
 /*
@@ -37,22 +37,26 @@
 
 
 function detectWeb(doc, url) {
-	if (url.indexOf('/servlet/articulo')>-1) {
+	if (url.includes('/servlet/articulo')) {
 		return "journalArticle";
-	} else if (url.indexOf('/servlet/libro')>-1) {
+	}
+	else if (url.includes('/servlet/libro')) {
 		return "book";
-	} else if (url.indexOf('/servlet/tesis')>-1) {
+	}
+	else if (url.includes('/servlet/tesis')) {
 		return "thesis";
-	} else if (getSearchResults(doc, true)) {
+	}
+	else if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
+	return false;
 }
 
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
 	var rows = ZU.xpath(doc, '//p/span[@class="titulo"]/a');
-	for (var i=0; i<rows.length; i++) {
+	for (var i = 0; i < rows.length; i++) {
 		var href = rows[i].href;
 		var title = ZU.trimInternal(rows[i].textContent);
 		if (!href || !title) continue;
@@ -68,7 +72,7 @@ function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
 			if (!items) {
-				return true;
+				return;
 			}
 			var articles = [];
 			for (var i in items) {
@@ -76,38 +80,60 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
 
 function scrape(doc, url) {
+	var creators = doc.querySelectorAll('meta[name="DC.creator"]');
+	var abstracts = doc.querySelectorAll('meta[name="DC.description"]');
+	// Abstracts appear in up to three languages
+	var abstractArray = [];
+	for (let abstract of abstracts) {
+		abstract = abstract.content.replace(/\n/g, " ");
+		abstractArray.push(abstract);
+	}
+	abstracts = abstractArray.join("\n");
+	
 	var translator = Zotero.loadTranslator('web');
 	// Embedded Metadata
 	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
 	translator.setHandler('itemDone', function (obj, item) {
 		item.url = url;
+		item.abstractNote = abstracts;
 		// Delete generic abstract as "Información del artículo <title>"
-		if (item.abstractNote && item.abstractNote.includes(item.title) && item.abstractNote.length<item.title.length+30) {
+		if (item.abstractNote && item.abstractNote.includes(item.title) && item.abstractNote.length < item.title.length + 30) {
 			delete item.abstractNote;
 		}
-		// in case of double issue e.g. "3-4" wrong issue number in Embedded Metadata e,g. "3" 
+		// Swap out authors for DC authors which have proper commas
+		if (item.creators.length == creators.length) {
+			item.creators = [];
+			for (let creator of creators) {
+				creator = creator.content;
+				item.creators.push(ZU.cleanAuthor(creator, "author", true));
+			}
+		}
+
+		// in case of double issue e.g. "3-4" wrong issue number in Embedded Metadata e,g. "3"
 		// clean issue number in case of multiple download
 		var issue = ZU.xpathText(doc, '//*[@id="informacion"]//a[contains(text(), "Nº.")]');
 		if (issue) {
 			// e.g. Vol. 89, Nº. 3-4, 2012
 			item.issue = issue.split('Nº.')[1].split(',')[0];
 		}
- 		
- 		// Delete generic keywords
- 		if (item.tags);
- 			delete item.tags;
+	
+		// Delete generic keywords
+		if (item.tags);
+		delete item.tags;
 		item.complete();
 	});
-	translator.getTranslatorObject(function(trans) {
+	translator.getTranslatorObject(function (trans) {
 		trans.doWeb(doc, url);
 	});
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
@@ -119,8 +145,8 @@ var testCases = [
 				"title": "Libres, buenos y justos como miembros de un mismo cuerpo: lecciones de teoría del derecho y de derecho natural",
 				"creators": [
 					{
-						"firstName": "Julián Vara",
-						"lastName": "Martín",
+						"firstName": "Julián",
+						"lastName": "Vara Martín",
 						"creatorType": "author"
 					}
 				],
@@ -133,7 +159,8 @@ var testCases = [
 				"url": "https://dialnet.unirioja.es/servlet/libro?codigo=293780",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"notes": [],
@@ -150,19 +177,19 @@ var testCases = [
 				"title": "Juicios, discursos y acción política en grupos de jóvenes estudiantes universitarios de Bogotá",
 				"creators": [
 					{
-						"firstName": "Martha Cecilia Lozano",
-						"lastName": "Ardila",
+						"firstName": "Martha Cecilia",
+						"lastName": "Lozano Ardila",
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Sara Victoria Alvarado",
-						"lastName": "Salgado",
+						"firstName": "Sara Victoria",
+						"lastName": "Alvarado Salgado",
 						"creatorType": "author"
 					}
 				],
 				"date": "2011",
 				"ISSN": "1692-715X",
-				"abstractNote": "This article presents the outcome of research conducted between 2006 and 2009 on speeches\nand policy action in seven groups of young university students in Bogotá.\nTheoretical, epistemological and methodological research was supported by the approach of Hannah Arendt\n(2001a, 2001b), were supplemented by the insights of Kohn (2005), Brunet (2007), Sánchez (2003), Rosenthal\n(2006) and Fraser (1997, 2008).\nThe research was developed from four main categories: conceptions of political citizenship; constraints of\npolitics, democracy and citizenship; trigger political action by young people and forms of political action by\nyoung people. It concludes with the need for education for political participation and ethics in Colombia\nreconfiguration.",
+				"abstractNote": "This article presents the outcome of research conducted between 2006 and 2009 on speeches and policy action in seven groups of young university students in Bogotá. Theoretical, epistemological and methodological research was supported by the approach of Hannah Arendt (2001a, 2001b), were supplemented by the insights of Kohn (2005), Brunet (2007), Sánchez (2003), Rosenthal (2006) and Fraser (1997, 2008). The research was developed from four main categories: conceptions of political citizenship; constraints of politics, democracy and citizenship; trigger political action by young people and forms of political action by young people. It concludes with the need for education for political participation and ethics in Colombia reconfiguration.\nEn este artículo se presentan los resultados de la investigación llevada a cabo entre 2006 y 2009 sobre discursos y acción política en siete grupos de jóvenes estudiantes universitarios de Bogotá. Teórica, epistemológica y metodológicamente, se sustentó la investigación en los planteamientos de Hannah Arendt (2001a, 2001b), se complementaron con las comprensiones de Kohn (2005), Brunet (2007), Sánchez (2003), Greppi (2006) y Fraser (1997, 2008). El trabajo se desarrolló desde cuatro categorías fundamentales: concepciones de política, ciudadanía; condicionantes de la política, democracia y la ciudadanía; detonantes de la acción política del los colectivos de jóvenes y las formas de acción política de los jóvenes y las jóvenes. Se Concluye con la necesidad de una educación para la participación política y la reconfiguración ética en Colombia.\nEste artigo apresenta os resultados de uma pesquisa realizada entre 2006 e 2009, em discursos e ação política em sete grupos de jovens universitários em Bogotá. Teóricas, epistemológicas e metodológicas de pesquisa foi suportada pela abordagem de Hannah Arendt (2001a, 2001b), foram complementadas com as idéias de Kohn (2005), Brunet (2007), Sánchez (2003), Rosenthal (2006) e Fraser (1997, 2008). O trabalho foi desenvolvido a partir de quatro categorias principais: as concepções de cidadania política; restrições da política, da democracia e da cidadania; desencadear uma ação política por parte dos jovens e das formas de ação política dos jovens. Conclui-se com a necessidade de educação para a participação política e ética na reconfiguração da Colômbia.",
 				"issue": "1",
 				"language": "spa",
 				"libraryCatalog": "dialnet.unirioja.es",
@@ -176,7 +203,8 @@ var testCases = [
 						"mimeType": "application/pdf"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"notes": [],
@@ -219,7 +247,8 @@ var testCases = [
 				"volume": "89",
 				"attachments": [
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"notes": [],


### PR DESCRIPTION
Mainly to get proper Spanish authors, see https://forums.zotero.org/discussion/comment/425035#Comment_425035 (RIS is only available in the premium version, but this looks like it works fine).
I wasn't sure what to do with multilingual abstract, but I think getting them in all languages -- how they're presented on the site -- is much preferable to just getting an English abstract even when the article is in Spanish or Portuguese (the behavior in the test)