### PR TITLE
DOI: Pull DOIs from URL

### DIFF
--- a/DOI.js
+++ b/DOI.js
@@ -142,7 +142,7 @@ function detectWeb(doc, url) {
 	
 	if (!blacklistRe.test(url)) {
 		let doiOrDOIs = getDOIs(doc, url);
-		if (Array.isArray(doiOrDOIs)) {
+		if (Array.isArray(doiOrDOIs) && doiOrDOIs.length) {
 			return "multiple";
 		}
 		else {


### PR DESCRIPTION
If only the URL contains a DOI (or the URL contains a DOI and the body contains only that same DOI), we now detect a single `journalArticle` item and don't show the Select Items dialog.

Also optimized the page-scraping code a little bit by replacing `Array#includes()` calls (O(n^2) overall) with `Set#has()` (O(n) overall).

Fixes #2964