### PR TITLE
Update CNKI refworks output post method

### DIFF
--- a/CNKI.js
+++ b/CNKI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-02-22 03:17:44"
+	"lastUpdated": "2023-03-02 03:17:44"
 }
 
 /*
@@ -40,27 +40,39 @@
 // ids should be in the form [{dbname: "CDFDLAST2013", filename: "1013102302.nh"}]
 function getRefWorksByID(ids, onDataAvailable) {
 	if (!ids.length) return;
-	var { dbname, filename } = ids.shift();
-	var postData = "formfilenames=" + encodeURIComponent(dbname + "!" + filename + "!1!0,")
-		+ '&hid_kLogin_headerUrl=/KLogin/Request/GetKHeader.ashx%3Fcallback%3D%3F'
-		+ '&hid_KLogin_FooterUrl=/KLogin/Request/GetKHeader.ashx%3Fcallback%3D%3F'
-		+ '&CookieName=FileNameS';
-	ZU.doPost('https://kns.cnki.net/kns/ViewPage/viewsave.aspx?displayMode=Refworks', postData,
+	var { dbname, filename, url } = ids.shift();
+	let postData = "filename=" + filename + 
+		"&displaymode=Refworks&orderparam=0&ordertype=desc&selectfield=&dbname=" + 
+		dbname + "&random=0.2111567532240084";
+	
+	ZU.doPost('https://kns.cnki.net/KNS8/manage/ShowExport', postData,
 		function (text) {
-			var parser = new DOMParser();
-			var html = parser.parseFromString(text, "text/html");
-			var data = ZU.xpath(html, "//table[@class='mainTable']//td")[0].innerHTML
-				.replace(/<br>/g, '\n')
-				.replace(/^RT\s+Dissertation\/Thesis/gmi, 'RT Dissertation')
-				.replace(
-					/^(A[1-4]|U2)\s*([^\r\n]+)/gm,
-					function (m, tag, authors) {
-						authors = authors.split(/\s*[;，,]\s*/); // that's a special comma
-						if (!authors[authors.length - 1].trim()) authors.pop();
-						return tag + ' ' + authors.join('\n' + tag + ' ');
-					}
-				);
-			onDataAvailable(data);
+			let data = text
+				.replace("<ul class='literature-list'><li>", "")
+            	.replace("<br></li></ul>", "")
+            	.replace("</li><li>", "") // divide results
+            	.replace(/<br>|\r/g, "\n")
+            	.replace(/vo (\d+)\n/, "VO $1\n") // Divide VO and IS to different line
+            	.replace(/IS 0(\d+)\n/g, "IS $1\n")  // Remove leading 0
+            	.replace(/VO 0(\d+)\n/g, "VO $1\n")
+            	.replace(/\n+/g, "\n")
+            	.replace(/\n([A-Z][A-Z1-9]\s)/g, "<br>$1")
+            	.replace(/\n/g, "")
+            	.replace(/<br>/g, "\n")
+            	.replace(/\t/g, "") // \t in abstract
+            	.replace(
+            	    /^RT\s+Conference Proceeding/gim,
+            	    "RT Conference Proceedings"
+            	)
+            	.replace(/^RT\s+Dissertation\/Thesis/gim, "RT Dissertation")
+            	.replace(/^(A[1-4]|U2)\s*([^\r\n]+)/gm, function (m, tag, authors) {
+            	    authors = authors.split(/\s*[;，,]\s*/); // that's a special comma
+            	    if (!authors[authors.length - 1].trim()) authors.pop();
+            	    return tag + " " + authors.join("\n" + tag + " ");
+            	})
+            	.trim();
+			// Z.debug(data);
+			onDataAvailable(data, url);
 			// If more results, keep going
 			if (ids.length) {
 				getRefWorksByID(ids, onDataAvailable);


### PR DESCRIPTION
The CNKI has deprecated the old post method for exporting citation. I've updated the post URL and post data string.