### PR TITLE
New Web Translator request: Dharitri (Odia-language newspaper)

### DIFF
--- a/Dharitri.js
+++ b/Dharitri.js
@@ -178,7 +178,9 @@ function scrape(doc, url) {
 		trans.itemType = itemType;
 		trans.doWeb(doc, url);
 	});
-}/** BEGIN TEST CASES **/
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",


### PR DESCRIPTION
This web translator is to scrape metadata from the Odia newspaper Dharitri considering its significance in Odia Wikipedia and otherwise