### PR TITLE
Legifrance: fix error on import & parse more fields

### DIFF
--- a/Legifrance.js
+++ b/Legifrance.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-03-20 21:08:59"
+	"lastUpdated": "2023-03-20 21:26:34"
 }
 
 /*
@@ -249,15 +249,9 @@ function scrapelegislation(doc, url) { //Législation
 		// Reconstruit le nom en "Code ___ - Article ____"
 		newItem.nameOfAct = code.concat(" - Article ", codeNumber);
 
-		// Dates: original date and dateDecided
-
-		// Exemple : "/loda/id/LEGIARTI000006284446/1994-07-30/"
-		const origdate = ZU.xpathText(doc, '//p[@class="date"]/a/@href');
-		newItem.extra = "Original Date: ".concat(origdate.match(/[\d-]{10}/g)[1]);
-
-		// Exemple : "Version en vigueur depuis le 30 juillet 1994"
+		// dateDecided / Exemple : "Version en vigueur depuis le 30 juillet 1994"
 		const date = ZU.xpathText(doc, '//h6[@class="version-article"]');
-		newItem.date = date.match(/(\d{1,2} \w+ (\d{4}|\d{2}))/)[0];
+		newItem.date = date.match(/(\d{1,2} [\wéû]+ (\d{4}|\d{2}))/)[0];
 	}
 
 	var b; // Lois 1er modèle
@@ -542,7 +536,6 @@ var testCases = [
 				"dateEnacted": "30 juillet 1994",
 				"code": "Code civil",
 				"codeNumber": "16",
-				"extra": "Original Date: 1994-07-30",
 				"language": "fr-FR",
 				"url": "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006419320",
 				"attachments": [
@@ -693,7 +686,6 @@ var testCases = [
 				"dateEnacted": "27 septembre 2017",
 				"code": "Code du travail",
 				"codeNumber": "R1234-4",
-				"extra": "Original Date: 2017-09-27",
 				"language": "fr-FR",
 				"url": "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000035644695",
 				"attachments": [
@@ -719,7 +711,6 @@ var testCases = [
 				"dateEnacted": "27 septembre 2017",
 				"code": "Code du travail",
 				"codeNumber": "R1234-4",
-				"extra": "Original Date: 2017-09-27",
 				"language": "fr-FR",
 				"url": "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000035644695/2023-01-25",
 				"attachments": [


### PR DESCRIPTION
Hello,

There was an error while parsing statutes from Légifrance (e.g., [this page](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000581393/) or [this one](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000035644695/2023-01-25))
It was also mentioned on the forum: <https://forums.zotero.org/discussion/97635/probleme-denregistrement-sur-le-site-legifrance> (in French)

It was due to a layout(?) change, and the title was no longer available at the previous XPath.
I changed the Xpath and added a few modifications, like adding missing `var` declarations.

I'm not sure I will implement all changes I intended; it might be better to push the bug fixes earlier (and uni is more urgent).
I'm mostly making the PR draft right now to get some feedback, the linter output (doesn't work on my machine), and let you push as soon as you wish to do so.

I would be glad to have some feedback, as I'm fairly new to JS.

# List of changes

## Bug fixes

- [x] Fix `Translation failed: TypeError: title is null` errors on statutes
- [x] Add dates on articles
- [x] Add URLs
- [x] Put law statutes' code number in the proper category

## Feature changes

- [ ] Add multiple selection for Codes (e.g., [this page](https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006072050/LEGISCTA000018483021/2023-01-25/))
- [ ] Add more fields?
  - [x] *fr-FR* language
  - [ ] section
  - [ ] session
  - [ ] history
  - [ ] official code number?
  - [ ] decrees' data (i.e., NOR, JOR, text number)
  - [ ] original date, dependent on the page type
- [x] Download web snapshots
- [ ] Download article text when available?

## Code/lint changes

- [x] add missing var declaration
- [ ] replace the deprecated `processDocuments`
- [x] missing 'url' in scrapecase's signature / abnormal 'url' input from doWeb
- [ ] Run lint and apply changes

## Test changes

- [x] Tests: update old tests -> website no longer offers RFT files on those pages
- [x] Tests: add the two error-causing websites
  - [x] <https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000035644695/2023-01-25>
  - [x] <https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000581393/>
