### PR TITLE
Add HKLII v2 Translator

### DIFF
--- a/HKLIIv2.js
+++ b/HKLIIv2.js
@@ -1,0 +1,253 @@
+{
+	"translatorID": "3660386b-6bd1-40ae-a4f9-dcfc16db520c",
+	"label": "HKLIIv2",
+	"creator": "Sin Wah Tsang",
+	"target": "^https?://v2\\.hklii\\.hk",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-03-24 18:39:29"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2023 Sin Wah Tsang
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	if (url.includes('cases')) {
+		return 'case';
+	} else if (getSearchResults(doc, true)) { 
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('table > tbody > tr > td.pr-3 > a');	
+	for (let i = 0; i < rows.length; i++) {
+		let href = rows[i].href;
+		let title = ZU.trimInternal(rows[i].textContent);
+		if (!href || !title) continue;
+		if (!href.includes('cases')) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}	
+	return found ? items : false;
+}
+
+function doWeb(doc, url) {
+	var type = detectWeb(doc, url);
+	if (type == 'multiple') {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return true;
+			}
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrape);
+		}
+		);
+	} else {
+		scrape(doc, url);
+	}
+	return false;
+}
+
+function scrape(doc, url){
+	var type = detectWeb(doc, url);
+	var newItem = new Zotero.Item(type);
+	
+	if (text(doc, '#app')) {
+		
+		if (type == 'case') {
+			
+			// All page titles have '|', except for UKPC cases which do not have it
+			// UKPC cases refer to the United Kingdom Privy Council Judgments for Hong Kong
+			var pageTitle = text(doc, 'head > title');
+
+			// e.g. NG KA LING AND ANOTHER V. THE DIRECTOR OF IMMIGRATION | HKLII
+			if (pageTitle.includes('|')) {
+				caseTitle = pageTitle.replace(/\s?\|.*$/, '');
+			} else {
+				caseTitle = pageTitle ;
+			}
+			newItem.caseName = caseTitle; 				
+			
+			var dateDecided = text(doc, '#infotable > div > div:nth-child(1) > div.pl-1 > span');
+			if (dateDecided) {
+				newItem.dateDecided = dateDecided;
+			}
+			
+			var court = text(doc, 'li:nth-child(5) > a > span');
+			if (court) {
+				newItem.court = court;
+			}
+
+			var actionNo = text(doc, 'div:nth-child(3) > div > span > div > span');
+			if (actionNo) {
+				newItem.number = actionNo;
+			}
+			
+			// Extract the Neutral Citation
+			var neutralCit = text(doc, 'li > div > span');
+			if (neutralCit) {
+				newItem.extra = `Neutral Cit: ${neutralCit} \n`;
+			}
+			
+			// Extract the first Parallel Citation
+			var firstParallelCit = text(doc, 'div:nth-child(7) > div.pl-1 > span > div:nth-child(1) > span');
+			if (firstParallelCit) {
+				newItem.extra += `Parallel Cit: ${firstParallelCit} \n`;
+			}
+		} else {
+			newItem.title = text(doc, 'head > title');
+		}
+	} else {
+		newItem.title = text(doc, 'head > title');
+	}
+		
+	newItem.url = url;
+		
+	newItem.attachments.push({
+		document: doc,
+		title: 'Snapshot',
+		mimeType:'text/html'
+	});
+		
+	newItem.complete();	
+}
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://v2.hklii.hk/en/cases/hkcfi/2019/1191",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "NG TAT KUEN V. TAM CHE FU AND OTHERS",
+				"creators": [],
+				"dateDecided": "3 May, 2019",
+				"court": "Court of First Instance",
+				"docketNumber": "HCPI896/2013",
+				"extra": "Neutral Cit: [2019] HKCFI 1191 \nParallel Cit: [2019] 4 HKC 533",
+				"url": "https://v2.hklii.hk/en/cases/hkcfi/2019/1191",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://v2.hklii.hk/en/cases/hkcfi/2002/202",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "LI SAU YING V. KINCHENG BANKING CORPORATION AND ANOTHER",
+				"creators": [],
+				"dateDecided": "30 May, 2002",
+				"court": "Court of First Instance",
+				"docketNumber": "HCA18515/1999",
+				"extra": "Neutral Cit: [2002] HKCFI 202",
+				"url": "https://v2.hklii.hk/en/cases/hkcfi/2002/202",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://v2.hklii.hk/en/cases/ukpc/1997/40",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "Yuen v. The Royal Hong Kong Golf Club",
+				"creators": [],
+				"dateDecided": "1 Jan, 1997",
+				"court": "United Kingdom Privy Council Judgments for Hong Kong",
+				"extra": "Neutral Cit: [1997] UKPC 40",
+				"url": "https://v2.hklii.hk/en/cases/ukpc/1997/40",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://v2.hklii.hk/en/cases/hkcfa/1999/72",
+		"items": [
+			{
+				"itemType": "case",
+				"caseName": "NG KA LING AND ANOTHER V. THE DIRECTOR OF IMMIGRATION",
+				"creators": [],
+				"dateDecided": "29 Jan, 1999",
+				"court": "Court of Final Appeal",
+				"docketNumber": "FACV14/1998",
+				"extra": "Neutral Cit: [1999] HKCFA 72 \nParallel Cit: (1999) 2 HKCFAR 4",
+				"url": "https://v2.hklii.hk/en/cases/hkcfa/1999/72",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://v2.hklii.hk/search?searchType=advanced&title=Ng%20Ka%20Ling",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/


### PR DESCRIPTION
## Background

The Hong Kong Legal Information Institute (HKLII) provides free access to legal information specifically for Hong Kong, similar to other Legal Information Institutes such as AustLII, BAILII, and CanLII which offer access to legal information for other regions.

The "HKLII v2" website (officially called "[Upgraded HKLII](https://v2.hklii.hk/)" ([v2.hklii.hk](https://v2.hklii.hk/))) is an improved version of the [Classic HKLII](https://www.hklii.hk/) website, providing upgraded features and a user-friendly design for the legal information service. Both the Classic HKLII and Upgraded HKLII websites are currently available in parallel.

## Difficulty Retrieving Desired Data on Search Result Pages

I'm new to JavaScript and I'm developing an HKLII v2 translator for Zotero. Unfortunately, I'm having trouble with the translator on search result pages ("multiple").

### Objective

My goal is to make the translator function similarly to the "AustLII and NZLII" translator so that I can retrieve the desired data from search result pages accurately.

### Attempts

While the translator can identify a search results page that includes cases, it is unable to save the name of the selected case. Instead, it only displays the case name as "Hong Kong Legal Information Institute (HKLII)", as shown below.

The `doWeb` result for a selected case of "multiple":
URL: https://v2.hklii.hk/search?searchType=advanced&title=Ng%20Ka%20Ling

```md
Running doWeb
Returned item:
   {
	 "itemType": "case"
	 "creators": []
	 "notes": []
	 "tags": []
	 "seeAlso": []
	 "attachments": [
	   {
		 "document": "[object Document]"
		 "title": "Snapshot"
		 "mimeType": "text/html"
	   }
	 ]
 -   "title": "Hong Kong Legal Information Institute (HKLII)"
	 "url": "https://v2.hklii.hk/en/cases/hkcfa/1999/72"
 +   "caseName": "Hong Kong Legal Information Institute (HKLII)"
   }
Translation successful
```

I've tried to use `Z.monitorDOMChanges` with various selectors in the `detectweb` function. However, as a beginner, I didn't know how to use it to achieve the desired outcome, so I didn't include it in the submitted translator file. 

The [HKLII Privacy Policy & Usage Policy](https://v2.hklii.hk/legal) state that they block all spiders and other automated agents from accessing their case-law via the Robots Exclusion Standard. It's unclear if this caused the "multiple" failure. However, while AustLII has similar [Usage](http://www8.austlii.edu.au/austlii/copyright.html) and [Privacy Policy](http://www8.austlii.edu.au/austlii/privacy.html), the use of AustLII translator on search results pages for getting the selected case name is not affected.

Also, I discovered that the responsive search results table can cause the query selector's path to become invalid. If the browser window is too narrow, the table (normal: three columns) collapses into a single column, breaking the query selector's path. This makes the detectWeb function report that the item didn't match any type, instead of the expected "multiple" type.

If it's not possible to get a desired result from the "multiple",  I'm okay with removing the detection of "multiple" from the translator.

Any advice or help in resolving this issue would be greatly appreciated. Thank you!