### PR TITLE
Add Lexis+ Translator

### DIFF
--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-07 19:21:13"
+	"lastUpdated": "2023-04-07 21:55:44"
 }
 
 /*
@@ -76,7 +76,7 @@ function getSearchResults(doc, url) {
 
 			// dates[2] is a citation
 		}
-  
+
 		return items;
 	}
 
@@ -100,7 +100,7 @@ async function scrape(doc, url) {
 	if (detectWeb(doc, url) == "case") {
 		var newCase = new Zotero.Item("case");
 		newCase.url = doc.location.href;
-	
+
 		newCase.title = text(doc, 'h1#SS_DocumentTitle');
 
 		var citation = text(doc, 'span.active-reporter');
@@ -186,7 +186,7 @@ async function scrape(doc, url) {
 				newStatute.section = groups[3];
 			}
 			else { // Starts with letter, organized by code, ex. Tex. Bus. & Com. Code § 26.01
-				let groups = title.match(/^([a-zA-Z. ]+) § ([0-9.()a-zA-Z]+)/);
+				let groups = title.match(/^([a-zA-Z&. ]+) § ([0-9.()a-zA-Z]+)/);
 				newStatute.code = groups[1];
 				newStatute.section = groups[2];
 			}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,12 +9,84 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-06 21:58:14"
+	"lastUpdated": "2023-04-07 14:01:13"
 }
+
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2022 YOUR_NAME <- TODO
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+
+// function detectWeb(doc, url) {
+// 	// TODO: adjust the logic here
+// 	if (url.includes('/article/')) {
+// 		return 'newspaperArticle';
+// 	}
+// 	else if (getSearchResults(doc, true)) {
+// 		return 'multiple';
+// 	}
+// 	return false;
+// }
+
+// function getSearchResults(doc, checkOnly) {
+// 	var items = {};
+// 	var found = false;
+// 	// TODO: adjust the CSS selector
+// 	var rows = doc.querySelectorAll('h2 > a.title[href*="/article/"]');
+// 	for (let row of rows) {
+// 		// TODO: check and maybe adjust
+// 		let href = row.href;
+// 		// TODO: check and maybe adjust
+// 		let title = ZU.trimInternal(row.textContent);
+// 		if (!href || !title) continue;
+// 		if (checkOnly) return true;
+// 		found = true;
+// 		items[href] = title;
+// 	}
+// 	return found ? items : false;
+// }
+
+// async function doWeb(doc, url) {
+// 	if (detectWeb(doc, url) == 'multiple') {
+// 		let items = await Zotero.selectItems(getSearchResults(doc, false));
+// 		if (!items) return;
+// 		for (let url of Object.keys(items)) {
+// 			await scrape(await requestDocument(url));
+// 		}
+// 	}
+// 	else {
+// 		await scrape(doc, url);
+// 	}
+// }
+
+// async function scrape(doc, url = doc.location.href) {
+// 	// TODO: implement or add a scrape function template
+// }
+
+
 
 function scrape(doc, url) {
 	var namespace = doc.documentElement.namespaceURI;
-	var nsResolver = namespace ? function(prefix) {
+	var nsResolver = namespace ? function([prefix]) {
 	if (prefix == "x" ) return namespace; else return null;
 	} : null;
 
@@ -23,24 +95,19 @@ function scrape(doc, url) {
 		var newCase = new Zotero.Item("case");
 		newCase.url = doc.location.href;
 		
-		var xPathofTitle = doc.evaluate('//h1[@id="SS_DocumentTitle"]',
-									 doc, nsResolver, XPathResult.ANY_TYPE, null);
-		newCase.title = xPathofTitle.iterateNext().textContent;
+		newCase.title = text(doc, 'h1#SS_DocumentTitle');
 
-		var xPathofCitation = doc.evaluate('//span[@class="active-reporter"]',
-										   doc, nsResolver, XPathResult.ANY_TYPE, null);
-		var citation = xPathofCitation.iterateNext().textContent;
+		var xPathofCitation = ZU.xpath(doc, '//span[@class="active-reporter"]');
+		var citation = xPathofCitation[0].textContent;
 		newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
 		newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
 		newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
 
-		var xPathofCourt = doc.evaluate('(//p[@class="SS_DocumentInfo"])[1]',
-										doc, nsResolver, XPathResult.ANY_TYPE, null);
-		newCase.court = xPathofCourt.iterateNext().textContent;
+		var xPathofCourt = ZU.xpath(doc, '(//p[@class="SS_DocumentInfo"])[1]', nsResolver);
+		newCase.court = xPathofCourt[0].textContent;
 
-		var xPathofDate = doc.evaluate('//span[@class="date"]',
-									   doc, nsResolver, XPathResult.ANY_TYPE, null);
-		newCase.dateDecided = xPathofDate.iterateNext().textContent;
+		var xPathofDate = ZU.xpath(doc, '//span[@class="date"]', nsResolver);
+		newCase.dateDecided = xPathofDate[0].textContent;
 
 		newCase.complete();
 	}
@@ -49,14 +116,12 @@ function scrape(doc, url) {
 		var newStatute = new Zotero.Item("statute");
 		newStatute.url = doc.location.href;
 
-		var xPathofTitle = doc.evaluate('//h1[@id="SS_DocumentTitle"]',
-									 doc, nsResolver, XPathResult.ANY_TYPE, null);
-		var title = xPathofTitle.iterateNext().textContent;
+		var xPathofTitle = ZU.xpath(doc, '//h1[@id="SS_DocumentTitle"]', nsResolver);
+		var title = xPathofTitle[0].textContent;
 		newStatute.title = title;
 
-		var xPathofInfo = doc.evaluate('//p[@class="SS_DocumentInfo"]',
-										doc, nsResolver, XPathResult.ANY_TYPE, null);
-		var info = xPathofInfo.iterateNext().textContent;
+		var xPathofInfo = ZU.xpath(doc, '//p[@class="SS_DocumentInfo"]', nsResolver);
+		var info = xPathofInfo[0].textContent;
 
 		isolation = info.substring(info.search(
 			/\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/
@@ -68,11 +133,11 @@ function scrape(doc, url) {
 		{
 			// BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
 			var statutesAtLarge, publicLawNo;
-			var xPathofActiveReporter = doc.evaluate('//a[@class="SS_ActiveRptr"]',
-									 				 doc, nsResolver, XPathResult.ANY_TYPE, null);
-			var potentialReporter = xPathofActiveReporter.iterateNext();
-			if (potentialReporter) // Sometimes Lexis is weird and doesn't give an ActiveRptr
+			var xPathofActiveReporter = ZU.xpath(doc, '//a[@class="SS_ActiveRptr"]', nsResolver);
+			if (xPathofActiveReporter.length > 0) // Sometimes Lexis is weird and doesn't give an ActiveRptr
 			{
+        var potentialReporter = xPathofActiveReporter[0];
+        Zotero.debug(potentialReporter.textContent);
 				if (potentialReporter.textContent.match(/[sS]tat\./))
 					statutesAtLarge = potentialReporter.textContent;
 				else if (potentialReporter.textContent.match(/[pP]ub\./) ||
@@ -80,16 +145,16 @@ function scrape(doc, url) {
 					publicLawNo = potentialReporter.textContent;
 			}
 
-			var xPathofNonPaginatedReporter = doc.evaluate('//span[@class="SS_NonPaginatedRptr"]',
-									 					   doc, nsResolver, XPathResult.ANY_TYPE, null);
-			var nextReporter;
-			while (nextReporter = xPathofNonPaginatedReporter.iterateNext())
+			var xPathofNonPaginatedReporter = ZU.xpath(doc, '//span[@class="SS_NonPaginatedRptr"]', nsResolver);
+			
+			for (var i = 0; i < xPathofNonPaginatedReporter.length; i++)
 			{
-				if (nextReporter.textContent.match(/[sS]tat\./))
-					statutesAtLarge = nextReporter.textContent;
-				else if (nextReporter.textContent.match(/[pP]ub\./) ||
-						 nextReporter.textContent.match(/[pP]\.[lL]\./))
-					publicLawNo = nextReporter.textContent;
+        var nextReporter = xPathofNonPaginatedReporter[i].textContent;
+				if (nextReporter.match(/[sS]tat\./))
+					statutesAtLarge = nextReporter;
+				else if (nextReporter.match(/[pP]ub\./) ||
+						 nextReporter.match(/[pP]\.[lL]\./))
+					publicLawNo = nextReporter;
 			}
 
 			// Turn publicLawNo into the public law fields
@@ -98,7 +163,7 @@ function scrape(doc, url) {
 				var numPos = publicLawNo.search(/\d+-\d+/)
 				newStatute.publicLawNumber = publicLawNo.substring(
 					numPos,
-					publiclawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
+					publicLawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
 
 				newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
 			}
@@ -144,17 +209,18 @@ function scrape(doc, url) {
 
 function detectWeb(doc, url) {
 	if (doc.title.match(/.*results.*/)) {
-		return "multiple"
+    Zotero.debug("multiple");
+		return "multiple";
 	}
 	else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/) ||
 			 doc.title.match(/[aA][cC][tT]/) ||
 			 doc.title.match(/[pP]\.[lL]\./)) // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 	{
-		return "statute"
+		return "statute";
 	}
 	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ... 
 	{
-		return "case"
+		return "case";
 	}
 	// TODO secondary sources
 }
@@ -167,30 +233,33 @@ function doWeb(doc, url) {
 
 	var casesOrStatutes = new Array();
 	var items = new Object();
-	var nextTitle;
+	var nextTitle; 
 
 	if (detectWeb(doc, url) == "multiple") {
 		// TODO check what type of element it is (currently only working for 'cases' searches)
-		var titles = doc.evaluate('(//a[@class="titleLink"])',
-								  doc, nsResolver, XPathResult.ANY_TYPE, null);
-		var dates = doc.evaluate('(//span[contains(@class,"metaDataItem")])',
-								 doc, nsResolver, XPathResult.ANY_TYPE, null)
+		var titles = ZU.xpath(doc, '//a[@class="titleLink"]', nsResolver);
+		var dates = ZU.xpath(doc, '(//span[contains(@class,"metaDataItem")])', nsResolver);
 		var nextDate;
-		dates.iterateNext(); // First court name
-		nextDate = dates.iterateNext(); // First date is [2]
-		dates.iterateNext(); // First citation
+    var dateOffset = 1;
+    
+    // dates[0] is first court name
+		nextDate = dates[dateOffset];
+    dateOffset += 3;
+		// dates[2] is first citation
 
-		while (nextTitle = titles.iterateNext()) {
+		for (var i = 0; i < titles.length; i++) {
+      nextTitle = titles[i];
 			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
 			
-			dates.iterateNext(); // Court name
-			nextDate = dates.iterateNext(); // Every 3 items is a date
-			dates.iterateNext(); // Citation
+			// dates[0] is court name
+			nextDate = dates[dateOffset];
+      dateOffset += 3;
+			// dates[2] is a citation
 		}
 
 		items = Zotero.selectItems(items);
-		for(var i in items) {
-			casesOrStatutes.push(i);
+		for(var e in items) {
+			casesOrStatutes.push(e);
 		}
 	}
 	else

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-06 16:12:39"
+	"lastUpdated": "2023-04-06 19:35:50"
 }
 
 function scrape(doc, url) {
@@ -20,24 +20,70 @@ function scrape(doc, url) {
 
 	if (detectWeb(doc, url) == "case")
 	{
+		var newCase = new Zotero.Item("case");
+		newCase.url = doc.location.href;
+		
+		var xPathofTitle = doc.evaluate('//h1[@id="SS_DocumentTitle"]',
+									 doc, nsResolver, XPathResult.ANY_TYPE, null);
+		newCase.title = xPathofTitle.iterateNext().textContent;
 
+		var xPathofCitation = doc.evaluate('//span[@class="active-reporter"]',
+										   doc, nsResolver, XPathResult.ANY_TYPE, null);
+		var citation = xPathofCitation.iterateNext().textContent;
+		newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
+		newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
+		newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
+
+		var xPathofCourt = doc.evaluate('(//p[@class="SS_DocumentInfo"])[1]',
+										doc, nsResolver, XPathResult.ANY_TYPE, null);
+		newCase.court = xPathofCourt.iterateNext().textContent;
+
+		var xPathofDate = doc.evaluate('//span[@class="date"]',
+									   doc, nsResolver, XPathResult.ANY_TYPE, null);
+		newCase.dateDecided = xPathofDate.iterateNext().textContent;
+
+		newCase.complete();
 	}
 	else if (detectWeb(doc, url) == "statute")
 	{
+		var newStatute = new Zotero.Item("statute");
+		newStatute.url = doc.location.href;
 
+		var xPathofTitle = doc.evaluate('//h1[@id="SS_DocumentTitle"]',
+									 doc, nsResolver, XPathResult.ANY_TYPE, null);
+		var title = xPathofTitle.iterateNext().textContent;
+		newStatute.title = title;
+
+		newStatute.codeNumber = title.substring(0, title.indexOf(' '));
+		var isolation = title.substring(title.indexOf(' '), title.lastIndexOf(' ')); // isolate reporter and section symbol
+		newStatute.code = isolation.substring(0, isolation.lastIndexOf(' '));
+		newStatute.section = title.substring(title.lastIndexOf(' ') + 1);
+
+		var xPathofInfo = doc.evaluate('//p[@class="SS_DocumentInfo"]',
+									   doc, nsResolver, XPathResult.ANY_TYPE, null);
+		var info = xPathofInfo.iterateNext().textContent;
+		isolation = info.substring(info.search(/\d+-\d+/)); // isolate public law number on the frontend
+		newStatute.publicLawNumber = isolation.substring(0, isolation.indexOf(' ')).replace(/(^,)|(,$)/g, ''); 
+		newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
+		isolation = info.substring(info.search(
+			/\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/
+			)) // isolate date on the frontend
+		newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
+		Zotero.debug(isolation)
+
+		newStatute.complete();
 	}
 }
 
 function detectWeb(doc, url) {
-	Zotero.debug("Title: " + doc.title)
 	if (doc.title.match(/.*results.*/)) {
 		return "multiple"
 	}
-	else if (doc.title.match(/\d+\s[a-zA-Z\. ]+\s§\s\d+/))
+	else if (doc.title.match(/\d+\s[a-zA-Z\. ]+\s§\s\d+/)) // Match: ... 42 U.S.C.S. § 230 ...
 	{
 		return "statute"
 	}
-	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/))
+	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ... 
 	{
 		return "case"
 	}
@@ -56,9 +102,20 @@ function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
 		var titles = doc.evaluate('(//a[@class="titleLink"])',
 								  doc, nsResolver, XPathResult.ANY_TYPE, null);
+		var dates = doc.evaluate('(//span[contains(@class,"metaDataItem")])',
+								 doc, nsResolver, XPathResult.ANY_TYPE, null)
+		var nextDate;
+		dates.iterateNext(); // First court name
+		nextDate = dates.iterateNext(); // First date is [2]
+		dates.iterateNext(); // First citation
+
 		while (nextTitle = titles.iterateNext()) {
 			// TODO format this a little, maybe add a year parenthetical
-			items[nextTitle.href] = nextTitle.textContent;
+			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
+			
+			dates.iterateNext(); // Court name
+			nextDate = dates.iterateNext(); // Every 3 items is a date
+			dates.iterateNext(); // Citation
 		}
 
 		items = Zotero.selectItems(items);

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -1,15 +1,15 @@
 {
-  "translatorID": "419638d9-9049-44ad-ba08-fa54ed24b5e6",
-  "label": "Lexis+",
-  "creator": "bfahrenfort",
-  "target": "^https://plus.lexis.*/",
-  "minVersion": "5.0",
-  "maxVersion": "",
-  "priority": 100,
-  "inRepository": true,
-  "translatorType": 4,
-  "browserSupport": "gcsibv",
-  "lastUpdated": "2023-04-07 19:21:13"
+	"translatorID": "419638d9-9049-44ad-ba08-fa54ed24b5e6",
+	"label": "Lexis+",
+	"creator": "bfahrenfort",
+	"target": "^https://plus.lexis.*/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-04-07 19:21:13"
 }
 
 /*
@@ -36,201 +36,186 @@
 */
 
 function detectWeb(doc, url) {
-  if (doc.title.match(/.*results.*/)) {
-    return "multiple";
-  }
-  else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/) ||
-           doc.title.match(/act/i) ||
-           doc.title.match(/p\.l\./i)) // Match: ... Tex. Bus. & Com. Code § 26.01 ...
-  {
-    return "statute";
-  }
-  else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ... 
-  {
-    return "case";
-  }
-  // TODO secondary sources
+	if (doc.title.match(/.*results.*/)) {
+		return "multiple";
+	}
+	else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/)
+           || doc.title.match(/act/i)
+           || doc.title.match(/p\.l\./i)) // Match: ... Tex. Bus. & Com. Code § 26.01 ...
+	{
+		return "statute";
+	}
+	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ...
+	{
+		return "case";
+	}
+	// TODO secondary sources
 
-  return false;
+	return false;
 }
 
 function getSearchResults(doc, url) {
-  var casesOrStatutes = new Array();
-  var items = new Object();
-  var nextTitle; 
+	var casesOrStatutes = new Array();
+	var items = new Object();
+	var nextTitle;
 
-  if (detectWeb(doc, url) == "multiple") {
-    // TODO check what type of element it is (currently only working for 'cases' searches)
-    var titles = doc.querySelectorAll('a.titleLink');
-    var dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
-    var nextDate;
-    var dateOffset = 1;
+	if (detectWeb(doc, url) == "multiple") {
+		// TODO check what type of element it is (currently only working for 'cases' searches)
+		var titles = doc.querySelectorAll('a.titleLink');
+		var dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
+		var nextDate;
+		var dateOffset = 1;
     
-    // dates[0] is first court name
-    nextDate = dates[dateOffset];
-    dateOffset += 3;
-    // dates[2] is first citation
-    for (var i = 0; i < titles.length; i++) {
-      nextTitle = titles[i];
-      items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
+		// dates[0] is first court name
+		nextDate = dates[dateOffset];
+		dateOffset += 3;
+		// dates[2] is first citation
+		for (var i = 0; i < titles.length; i++) {
+			nextTitle = titles[i];
+			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
       
-      // dates[0] is court name
-      nextDate = dates[dateOffset];
+			// dates[0] is court name
+			nextDate = dates[dateOffset];
       
-      // dates[2] is a citation
-    }
+			// dates[2] is a citation
+		}
   
-    return items;
-  }
+		return items;
+	}
 
-  return false;
+	return false;
 }
 
 async function doWeb(doc, url) {
-  if (detectWeb(doc, url) == 'multiple') {
-    let items = await Zotero.selectItems(getSearchResults(doc, url));
-    if (!items) return;
-    for (let url of Object.keys(items)) {
-      await scrape(await requestDocument(url));
-    }
-  }
-  else {
-    await scrape(doc, url);
-  }
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, url));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
 }
 
 async function scrape(doc, url) {
-  if (detectWeb(doc, url) == "case")
-  {
-    var newCase = new Zotero.Item("case");
-    newCase.url = doc.location.href;
+	if (detectWeb(doc, url) == "case") {
+		var newCase = new Zotero.Item("case");
+		newCase.url = doc.location.href;
     
-    newCase.title = text(doc, 'h1#SS_DocumentTitle');
+		newCase.title = text(doc, 'h1#SS_DocumentTitle');
 
-    var citation = text(doc, 'span.active-reporter');
-    newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
-    newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
-    newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
+		var citation = text(doc, 'span.active-reporter');
+		newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
+		newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
+		newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
 
-    newCase.court = text(doc, 'p.SS_DocumentInfo', 0);
+		newCase.court = text(doc, 'p.SS_DocumentInfo', 0);
 
-    newCase.dateDecided = text(doc, 'span.date');
+		newCase.dateDecided = text(doc, 'span.date');
 
-  var docket = text(doc, 'p.SS_DocumentInfo', 2);
-  if (docket.match(/^no\./i) ||
-      docket.match(/^\d+/) ||
-    docket.match(/^case no\./i))
-    newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
+		var docket = text(doc, 'p.SS_DocumentInfo', 2);
+		if (docket.match(/^no\./i)
+      || docket.match(/^\d+/)
+    || docket.match(/^case no\./i)) newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
 
-    newCase.complete();
-  }
-  else if (detectWeb(doc, url) == "statute")
-  {
-    var newStatute = new Zotero.Item("statute");
-    newStatute.url = doc.location.href;
+		newCase.complete();
+	}
+	else if (detectWeb(doc, url) == "statute") {
+		var newStatute = new Zotero.Item("statute");
+		newStatute.url = doc.location.href;
 
-    var title = text(doc, 'h1#SS_DocumentTitle'); // Saves some lines to have a temp here
-    newStatute.title = title;
+		var title = text(doc, 'h1#SS_DocumentTitle'); // Saves some lines to have a temp here
+		newStatute.title = title;
 
-    var info = text(doc, 'p.SS_DocumentInfo');
+		var info = text(doc, 'p.SS_DocumentInfo');
 
-    var isolation = info.substring(info.search(
-      /\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/i
-    )) // isolate date on the frontend
-    newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
+		var isolation = info.substring(info.search(
+			/\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/i
+		)); // isolate date on the frontend
+		newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
 
-    if (title.match(/act/i) ||
-        title.match(/of\s[1-2][0-9][0-9][0-9]/i)) // Session law, not codified statute
-    {
-      // BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
-      var statutesAtLarge, publicLawNo;
-      var potentialReporter = text(doc, 'a.SS_ActiveRptr');
-      if (potentialReporter) // Sometimes Lexis is weird and doesn't give an ActiveRptr
-      {
-        if (potentialReporter.textContent.match(/stat\./i))
-          statutesAtLarge = potentialReporter.textContent;
-        else if (potentialReporter.textContent.match(/pub\./i) ||
-                 potentialReporter.textContent.match(/p\.l\./i))
-          publicLawNo = potentialReporter.textContent;
-      }
+		if (title.match(/act/i)
+        || title.match(/of\s[1-2][0-9][0-9][0-9]/i)) // Session law, not codified statute
+		{
+			// BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
+			var statutesAtLarge, publicLawNo;
+			var potentialReporter = text(doc, 'a.SS_ActiveRptr');
+			if (potentialReporter) // Sometimes Lexis is weird and doesn't give an ActiveRptr
+			{
+				if (potentialReporter.textContent.match(/stat\./i)) statutesAtLarge = potentialReporter.textContent;
+				else if (potentialReporter.textContent.match(/pub\./i)
+                 || potentialReporter.textContent.match(/p\.l\./i)) publicLawNo = potentialReporter.textContent;
+			}
 
-      var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
+			var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
       
-      for (var i = 0; i < otherReporters.length; i++)
-      {
-        var nextReporter = otherReporters[i].textContent;
-        if (nextReporter.match(/stat\./i))
-          statutesAtLarge = nextReporter;
-        else if (nextReporter.match(/pub\./i) ||
-                 nextReporter.match(/p\.l\./i))
-          publicLawNo = nextReporter;
-      }
+			for (var i = 0; i < otherReporters.length; i++) {
+				var nextReporter = otherReporters[i].textContent;
+				if (nextReporter.match(/stat\./i)) statutesAtLarge = nextReporter;
+				else if (nextReporter.match(/pub\./i)
+                 || nextReporter.match(/p\.l\./i)) publicLawNo = nextReporter;
+			}
 
-      // Turn publicLawNo into the public law fields
-      if (publicLawNo.match(/\d+-\d+/)) // Ex. P.L. 115-164
-      {
-        var numPos = publicLawNo.search(/\d+-\d+/)
-        newStatute.publicLawNumber = publicLawNo.substring(numPos, publicLawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
+			// Turn publicLawNo into the public law fields
+			if (publicLawNo.match(/\d+-\d+/)) // Ex. P.L. 115-164
+			{
+				var numPos = publicLawNo.search(/\d+-\d+/);
+				newStatute.publicLawNumber = publicLawNo.substring(numPos, publicLawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
 
-        newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
-      }
-      else // Ex. 115 P.L. 164 or 115 Pub. L. No. 164
-      {
-        newStatute.session = publicLawNo.substring(0, publicLawNo.indexOf(' '));
-        newStatute.publicLawNumber = newStatute.session + '-' + publicLawNo.substring(publicLawNo.lastIndexOf(' ') + 1);
-      }
+				newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
+			}
+			else // Ex. 115 P.L. 164 or 115 Pub. L. No. 164
+			{
+				newStatute.session = publicLawNo.substring(0, publicLawNo.indexOf(' '));
+				newStatute.publicLawNumber = newStatute.session + '-' + publicLawNo.substring(publicLawNo.lastIndexOf(' ') + 1);
+			}
 
-      // Turn statutesAtLarge into the code#/code/section fields
-      // TODO in styles, check for "Stat." as the code, and if so, don't append a section symbol
-      newStatute.codeNumber = statutesAtLarge.substring(0, statutesAtLarge.indexOf(' '));
-      newStatute.code = "Stat.";
-      newStatute.section = statutesAtLarge.substring(statutesAtLarge.lastIndexOf(' ') + 1);
-    }
-    else // Codified statute
-    {
-      if (title.match(/^\d+/)) // Starts with digit, organized by title, ex. 47 U.S.C.S. § 230
-      {
-        // Sadly, named groups aren't working
-        let groups = title.match(/^(\d+)\s([a-zA-Z0-9\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
-        newStatute.codeNumber = groups[1];
-        newStatute.code = groups[2];
-        newStatute.section = groups[3];
-      }
-      else // Starts with letter, organized by code, ex. Tex. Bus. & Com. Code § 26.01
-      {
-        let groups = title.match(/^([a-zA-Z\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
-        newStatute.code = groups[1];
-        newStatute.section = groups[2];
-      }
+			// Turn statutesAtLarge into the code#/code/section fields
+			// TODO in styles, check for "Stat." as the code, and if so, don't append a section symbol
+			newStatute.codeNumber = statutesAtLarge.substring(0, statutesAtLarge.indexOf(' '));
+			newStatute.code = "Stat.";
+			newStatute.section = statutesAtLarge.substring(statutesAtLarge.lastIndexOf(' ') + 1);
+		}
+		else // Codified statute
+		{
+			if (title.match(/^\d+/)) // Starts with digit, organized by title, ex. 47 U.S.C.S. § 230
+			{
+				// Sadly, named groups aren't working
+				let groups = title.match(/^(\d+)\s([a-zA-Z0-9\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
+				newStatute.codeNumber = groups[1];
+				newStatute.code = groups[2];
+				newStatute.section = groups[3];
+			}
+			else // Starts with letter, organized by code, ex. Tex. Bus. & Com. Code § 26.01
+			{
+				let groups = title.match(/^([a-zA-Z\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
+				newStatute.code = groups[1];
+				newStatute.section = groups[2];
+			}
 
-      // No way to tell which will be present
-      var pL = info.match(/p\.l\. (\d+-\d+)/i);
-      var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
-      var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
-      var publicLaw = info.match(/public law (\d+-\d+)/i);
-      var publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
-      var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
-      if (pL)
-        newStatute.publicLawNumber = pL[1];
-      if (pubLaw)
-        newStatute.publicLawNumber = pubLaw[1];
-      if (pubLawNo)
-        newStatute.publicLawNumber = pubLawNo[1];
-      if (publicLaw)
-        newStatute.publicLawNumber = publicLaw[1];
-      if (publicLawNo)
-        newStatute.publicLawNumber = publicLawNo[1];
-      if (publicLawNumber)
-        newStatute.publicLawNumber = publicLawNumber[1];
+			// No way to tell which will be present
+			var pL = info.match(/p\.l\. (\d+-\d+)/i);
+			var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
+			var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
+			var publicLaw = info.match(/public law (\d+-\d+)/i);
+			var publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
+			var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
+			if (pL) newStatute.publicLawNumber = pL[1];
+			if (pubLaw) newStatute.publicLawNumber = pubLaw[1];
+			if (pubLawNo) newStatute.publicLawNumber = pubLawNo[1];
+			if (publicLaw) newStatute.publicLawNumber = publicLaw[1];
+			if (publicLawNo) newStatute.publicLawNumber = publicLawNo[1];
+			if (publicLawNumber) newStatute.publicLawNumber = publicLawNumber[1];
 
-      if (newStatute.publicLawNumber)
-        newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
-    }
+			if (newStatute.publicLawNumber) newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
+		}
 
-    newStatute.extra = info; // Since the info section is all over the place, just dump the whole thing in for manual cite checks
+		newStatute.extra = info; // Since the info section is all over the place, just dump the whole thing in for manual cite checks
 
-    newStatute.complete();
-  }
+		newStatute.complete();
+	}
 }
 
 

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,35 +9,34 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-07 14:01:13"
+	"lastUpdated": "2023-04-07 16:00:59"
 }
 
 /*
-    ***** BEGIN LICENSE BLOCK *****
+	***** BEGIN LICENSE BLOCK *****
 
-    Copyright © 2022 YOUR_NAME <- TODO
+	Copyright © 2022 YOUR_NAME <- TODO
 
-    This file is part of Zotero.
+	This file is part of Zotero.
 
-    Zotero is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    Zotero is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
 
-    ***** END LICENSE BLOCK *****
+	***** END LICENSE BLOCK *****
 */
 
 function detectWeb(doc, url) {
 	if (doc.title.match(/.*results.*/)) {
-    Zotero.debug("multiple");
 		return "multiple";
 	}
 	else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/) ||
@@ -70,24 +69,25 @@ function getSearchResults(doc, url) {
 		var titles = ZU.xpath(doc, '//a[@class="titleLink"]', nsResolver);
 		var dates = ZU.xpath(doc, '(//span[contains(@class,"metaDataItem")])', nsResolver);
 		var nextDate;
-    var dateOffset = 1;
-    
-    // dates[0] is first court name
+	var dateOffset = 1;
+	
+	// dates[0] is first court name
 		nextDate = dates[dateOffset];
-    dateOffset += 3;
+	dateOffset += 3;
 		// dates[2] is first citation
-
+    Zotero.debug(titles.length);
 		for (var i = 0; i < titles.length; i++) {
-      nextTitle = titles[i];
+      Zotero.debug(titles[i].textContent);
+	    nextTitle = titles[i];
 			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
 			
 			// dates[0] is court name
 			nextDate = dates[dateOffset];
-      dateOffset += 3;
+	    dateOffset += 3;
 			// dates[2] is a citation
-
-      return items;
 		}
+    
+    return items;
   }
 
   return false;
@@ -158,8 +158,8 @@ async function scrape(doc, url) {
 			var xPathofActiveReporter = ZU.xpath(doc, '//a[@class="SS_ActiveRptr"]', nsResolver);
 			if (xPathofActiveReporter.length > 0) // Sometimes Lexis is weird and doesn't give an ActiveRptr
 			{
-        var potentialReporter = xPathofActiveReporter[0];
-        Zotero.debug(potentialReporter.textContent);
+		var potentialReporter = xPathofActiveReporter[0];
+		Zotero.debug(potentialReporter.textContent);
 				if (potentialReporter.textContent.match(/[sS]tat\./))
 					statutesAtLarge = potentialReporter.textContent;
 				else if (potentialReporter.textContent.match(/[pP]ub\./) ||
@@ -171,7 +171,7 @@ async function scrape(doc, url) {
 			
 			for (var i = 0; i < xPathofNonPaginatedReporter.length; i++)
 			{
-        var nextReporter = xPathofNonPaginatedReporter[i].textContent;
+		var nextReporter = xPathofNonPaginatedReporter[i].textContent;
 				if (nextReporter.match(/[sS]tat\./))
 					statutesAtLarge = nextReporter;
 				else if (nextReporter.match(/[pP]ub\./) ||

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -40,8 +40,8 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (doc.title.match(/[a-zA-Z. ]+\s§\s\d+/)
-           || doc.title.match(/act/i)
-           || doc.title.match(/p\.l\./i)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
+	|| doc.title.match(/act/i)
+	|| doc.title.match(/p\.l\./i)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}
 	else if (doc.title.match(/\d+\s[a-zA-Z0-9. ]+\s\d+/)) { // Match: ... 5 U.S. 137 ...
@@ -62,7 +62,7 @@ function getSearchResults(doc, url) {
 		var dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
 		var nextDate;
 		var dateOffset = 1;
-    
+	
 		// dates[0] is first court name
 		nextDate = dates[dateOffset];
 		dateOffset += 3;
@@ -70,10 +70,10 @@ function getSearchResults(doc, url) {
 		for (var i = 0; i < titles.length; i++) {
 			nextTitle = titles[i];
 			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
-      
+	  
 			// dates[0] is court name
 			nextDate = dates[dateOffset];
-      
+	  
 			// dates[2] is a citation
 		}
   
@@ -100,7 +100,7 @@ async function scrape(doc, url) {
 	if (detectWeb(doc, url) == "case") {
 		var newCase = new Zotero.Item("case");
 		newCase.url = doc.location.href;
-    
+	
 		newCase.title = text(doc, 'h1#SS_DocumentTitle');
 
 		var citation = text(doc, 'span.active-reporter');
@@ -114,8 +114,10 @@ async function scrape(doc, url) {
 
 		var docket = text(doc, 'p.SS_DocumentInfo', 2);
 		if (docket.match(/^no\./i)
-      || docket.match(/^\d+/)
-    || docket.match(/^case no\./i)) newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
+		|| docket.match(/^\d+/)
+		|| docket.match(/^case no\./i)) {
+			newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
+		}
 
 		newCase.complete();
 	}
@@ -134,23 +136,27 @@ async function scrape(doc, url) {
 		newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
 
 		if (title.match(/act/i)
-        || title.match(/of\s[1-2][0-9][0-9][0-9]/i)) { // Session law, not codified statute
+		|| title.match(/of\s[1-2][0-9][0-9][0-9]/i)) { // Session law, not codified statute
 			// BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
 			var statutesAtLarge, publicLawNo;
 			var potentialReporter = text(doc, 'a.SS_ActiveRptr');
 			if (potentialReporter) { // Sometimes Lexis is weird and doesn't give an ActiveRptr
 				if (potentialReporter.textContent.match(/stat\./i)) statutesAtLarge = potentialReporter.textContent;
 				else if (potentialReporter.textContent.match(/pub\./i)
-                 || potentialReporter.textContent.match(/p\.l\./i)) publicLawNo = potentialReporter.textContent;
+				|| potentialReporter.textContent.match(/p\.l\./i)) {
+					publicLawNo = potentialReporter.textContent;
+				}
 			}
 
 			var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
-      
+	  
 			for (var i = 0; i < otherReporters.length; i++) {
 				var nextReporter = otherReporters[i].textContent;
 				if (nextReporter.match(/stat\./i)) statutesAtLarge = nextReporter;
 				else if (nextReporter.match(/pub\./i)
-                 || nextReporter.match(/p\.l\./i)) publicLawNo = nextReporter;
+				|| nextReporter.match(/p\.l\./i)) {
+					publicLawNo = nextReporter;
+				}
 			}
 
 			// Turn publicLawNo into the public law fields

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -190,7 +190,7 @@ async function scrape(doc, url) {
 			var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
 			var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
 			var publicLaw = info.match(/public law (\d+-\d+)/i);
-			var publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
+			publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
 			var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
 			if (pL) newStatute.publicLawNumber = pL[1];
 			if (pubLaw) newStatute.publicLawNumber = pubLaw[1];

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -1,237 +1,236 @@
 {
-	"translatorID": "419638d9-9049-44ad-ba08-fa54ed24b5e6",
-	"label": "Lexis+",
-	"creator": "bfahrenfort",
-	"target": "^https://plus.lexis.*/",
-	"minVersion": "5.0",
-	"maxVersion": "",
-	"priority": 100,
-	"inRepository": true,
-	"translatorType": 4,
-	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-07 19:21:13"
+  "translatorID": "419638d9-9049-44ad-ba08-fa54ed24b5e6",
+  "label": "Lexis+",
+  "creator": "bfahrenfort",
+  "target": "^https://plus.lexis.*/",
+  "minVersion": "5.0",
+  "maxVersion": "",
+  "priority": 100,
+  "inRepository": true,
+  "translatorType": 4,
+  "browserSupport": "gcsibv",
+  "lastUpdated": "2023-04-07 19:21:13"
 }
 
 /*
-	***** BEGIN LICENSE BLOCK *****
+  ***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2023 Brandon Fahrenfort
+  Copyright © 2023 Brandon Fahrenfort
 
-	This file is part of Zotero.
+  This file is part of Zotero.
 
-	Zotero is free software: you can redistribute it and/or modify
-	it under the terms of the GNU Affero General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+  Zotero is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-	Zotero is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-	GNU Affero General Public License for more details.
+  Zotero is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-	You should have received a copy of the GNU Affero General Public License
-	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU Affero General Public License
+  along with Zotero. If not, see <http://www.gnu.org/licenses/>.
 
-	***** END LICENSE BLOCK *****
+  ***** END LICENSE BLOCK *****
 */
 
 function detectWeb(doc, url) {
-	if (doc.title.match(/.*results.*/)) {
-		return "multiple";
-	}
-	else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/) ||
-		   doc.title.match(/act/i) ||
-		   doc.title.match(/p\.l\./i)) // Match: ... Tex. Bus. & Com. Code § 26.01 ...
-	{
-		return "statute";
-	}
-	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ... 
-	{
-		return "case";
-	}
-	// TODO secondary sources
+  if (doc.title.match(/.*results.*/)) {
+    return "multiple";
+  }
+  else if (doc.title.match(/[a-zA-Z\. ]+\s§\s\d+/) ||
+           doc.title.match(/act/i) ||
+           doc.title.match(/p\.l\./i)) // Match: ... Tex. Bus. & Com. Code § 26.01 ...
+  {
+    return "statute";
+  }
+  else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/)) // Match: ... 5 U.S. 137 ... 
+  {
+    return "case";
+  }
+  // TODO secondary sources
 
   return false;
 }
 
 function getSearchResults(doc, url) {
-	var casesOrStatutes = new Array();
-	var items = new Object();
-	var nextTitle; 
+  var casesOrStatutes = new Array();
+  var items = new Object();
+  var nextTitle; 
 
-	if (detectWeb(doc, url) == "multiple") {
-		// TODO check what type of element it is (currently only working for 'cases' searches)
-		var titles = doc.querySelectorAll('a.titleLink');
-		var dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
-		var nextDate;
-	var dateOffset = 1;
-	
-	// dates[0] is first court name
-	nextDate = dates[dateOffset];
-	dateOffset += 3;
-		// dates[2] is first citation
-		for (var i = 0; i < titles.length; i++) {
-	  Zotero.debug(titles[i].textContent);
-		nextTitle = titles[i];
-			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
-			
-			// dates[0] is court name
-			nextDate = dates[dateOffset];
-		dateOffset += 3;
-			// dates[2] is a citation
-		}
-	
-	return items;
+  if (detectWeb(doc, url) == "multiple") {
+    // TODO check what type of element it is (currently only working for 'cases' searches)
+    var titles = doc.querySelectorAll('a.titleLink');
+    var dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
+    var nextDate;
+    var dateOffset = 1;
+    
+    // dates[0] is first court name
+    nextDate = dates[dateOffset];
+    dateOffset += 3;
+    // dates[2] is first citation
+    for (var i = 0; i < titles.length; i++) {
+      nextTitle = titles[i];
+      items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
+      
+      // dates[0] is court name
+      nextDate = dates[dateOffset];
+      
+      // dates[2] is a citation
+    }
+  
+    return items;
   }
 
   return false;
 }
 
 async function doWeb(doc, url) {
-	if (detectWeb(doc, url) == 'multiple') {
-		let items = await Zotero.selectItems(getSearchResults(doc, url));
-		if (!items) return;
-		for (let url of Object.keys(items)) {
-			await scrape(await requestDocument(url));
-		}
-	}
-	else {
-		await scrape(doc, url);
-	}
+  if (detectWeb(doc, url) == 'multiple') {
+    let items = await Zotero.selectItems(getSearchResults(doc, url));
+    if (!items) return;
+    for (let url of Object.keys(items)) {
+      await scrape(await requestDocument(url));
+    }
+  }
+  else {
+    await scrape(doc, url);
+  }
 }
 
 async function scrape(doc, url) {
-	if (detectWeb(doc, url) == "case")
-	{
-		var newCase = new Zotero.Item("case");
-		newCase.url = doc.location.href;
-		
-		newCase.title = text(doc, 'h1#SS_DocumentTitle');
+  if (detectWeb(doc, url) == "case")
+  {
+    var newCase = new Zotero.Item("case");
+    newCase.url = doc.location.href;
+    
+    newCase.title = text(doc, 'h1#SS_DocumentTitle');
 
-		var citation = text(doc, 'span.active-reporter');
-		newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
-		newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
-		newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
+    var citation = text(doc, 'span.active-reporter');
+    newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
+    newCase.reporter = citation.substring(citation.indexOf(' ') + 1, citation.lastIndexOf(' '));
+    newCase.firstPage = citation.substring(citation.lastIndexOf(' ') + 1);
 
-		newCase.court = text(doc, 'p.SS_DocumentInfo', 0);
+    newCase.court = text(doc, 'p.SS_DocumentInfo', 0);
 
-		newCase.dateDecided = text(doc, 'span.date');
+    newCase.dateDecided = text(doc, 'span.date');
 
-	var docket = text(doc, 'p.SS_DocumentInfo', 2);
-	if (docket.match(/^no\./i) ||
-		  docket.match(/^\d+/) ||
-		docket.match(/^case no\./i))
-	  newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
+  var docket = text(doc, 'p.SS_DocumentInfo', 2);
+  if (docket.match(/^no\./i) ||
+      docket.match(/^\d+/) ||
+    docket.match(/^case no\./i))
+    newCase.docketNumber = docket; // This won't be in perfect cite form, shouldn't be a hassle unless you're citing dozens of memorandum opinions
 
-		newCase.complete();
-	}
-	else if (detectWeb(doc, url) == "statute")
-	{
-		var newStatute = new Zotero.Item("statute");
-		newStatute.url = doc.location.href;
+    newCase.complete();
+  }
+  else if (detectWeb(doc, url) == "statute")
+  {
+    var newStatute = new Zotero.Item("statute");
+    newStatute.url = doc.location.href;
 
-		var title = text(doc, 'h1#SS_DocumentTitle'); // Saves some lines to have a temp here
-	newStatute.title = title;
+    var title = text(doc, 'h1#SS_DocumentTitle'); // Saves some lines to have a temp here
+    newStatute.title = title;
 
-		var info = text(doc, 'p.SS_DocumentInfo');
+    var info = text(doc, 'p.SS_DocumentInfo');
 
-		isolation = info.substring(info.search(
-			/\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/i
-		)) // isolate date on the frontend
-		newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
+    var isolation = info.substring(info.search(
+      /\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)/i
+    )) // isolate date on the frontend
+    newStatute.dateEnacted = isolation.substring(0, isolation.search(/[1-2][0-9][0-9][0-9]/) + 4);
 
-		if (title.match(/act/i) ||
-			  title.match(/of\s[1-2][0-9][0-9][0-9]/i)) // Session law, not codified statute
-		{
-			// BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
-			var statutesAtLarge, publicLawNo;
-			var potentialReporter = text(doc, 'a.SS_ActiveRptr');
-			if (potentialReporter) // Sometimes Lexis is weird and doesn't give an ActiveRptr
-			{
-				if (potentialReporter.textContent.match(/stat\./i))
-					statutesAtLarge = potentialReporter.textContent;
-				else if (potentialReporter.textContent.match(/pub\./i) ||
-							   potentialReporter.textContent.match(/p\.l\./i))
-					publicLawNo = potentialReporter.textContent;
-			}
+    if (title.match(/act/i) ||
+        title.match(/of\s[1-2][0-9][0-9][0-9]/i)) // Session law, not codified statute
+    {
+      // BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
+      var statutesAtLarge, publicLawNo;
+      var potentialReporter = text(doc, 'a.SS_ActiveRptr');
+      if (potentialReporter) // Sometimes Lexis is weird and doesn't give an ActiveRptr
+      {
+        if (potentialReporter.textContent.match(/stat\./i))
+          statutesAtLarge = potentialReporter.textContent;
+        else if (potentialReporter.textContent.match(/pub\./i) ||
+                 potentialReporter.textContent.match(/p\.l\./i))
+          publicLawNo = potentialReporter.textContent;
+      }
 
-			var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
-			
-			for (var i = 0; i < otherReporters.length; i++)
-			{
-			var nextReporter = otherReporters[i].textContent;
-				if (nextReporter.match(/stat\./i))
-					statutesAtLarge = nextReporter;
-				else if (nextReporter.match(/pub\./i) ||
-							   nextReporter.match(/p\.l\./i))
-					publicLawNo = nextReporter;
-			}
+      var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
+      
+      for (var i = 0; i < otherReporters.length; i++)
+      {
+        var nextReporter = otherReporters[i].textContent;
+        if (nextReporter.match(/stat\./i))
+          statutesAtLarge = nextReporter;
+        else if (nextReporter.match(/pub\./i) ||
+                 nextReporter.match(/p\.l\./i))
+          publicLawNo = nextReporter;
+      }
 
-			// Turn publicLawNo into the public law fields
-			if (publicLawNo.match(/\d+-\d+/)) // Ex. P.L. 115-164
-			{
-				var numPos = publicLawNo.search(/\d+-\d+/)
-				newStatute.publicLawNumber = publicLawNo.substring(numPos, publicLawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
+      // Turn publicLawNo into the public law fields
+      if (publicLawNo.match(/\d+-\d+/)) // Ex. P.L. 115-164
+      {
+        var numPos = publicLawNo.search(/\d+-\d+/)
+        newStatute.publicLawNumber = publicLawNo.substring(numPos, publicLawNo.substring(numPos + 1).indexOf(' ')); // Gets 115-164
 
-				newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
-			}
-			else // Ex. 115 P.L. 164 or 115 Pub. L. No. 164
-			{
-				newStatute.session = publicLawNo.substring(0, publicLawNo.indexOf(' '));
-				newStatute.publicLawNumber = newStatute.session + '-' + publicLawNo.substring(publicLawNo.lastIndexOf(' ') + 1);
-			}
+        newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
+      }
+      else // Ex. 115 P.L. 164 or 115 Pub. L. No. 164
+      {
+        newStatute.session = publicLawNo.substring(0, publicLawNo.indexOf(' '));
+        newStatute.publicLawNumber = newStatute.session + '-' + publicLawNo.substring(publicLawNo.lastIndexOf(' ') + 1);
+      }
 
-			// Turn statutesAtLarge into the code#/code/section fields
-			// TODO in styles, check for "Stat." as the code, and if so, don't append a section symbol
-			newStatute.codeNumber = statutesAtLarge.substring(0, statutesAtLarge.indexOf(' '));
-			newStatute.code = "Stat.";
-			newStatute.section = statutesAtLarge.substring(statutesAtLarge.lastIndexOf(' ') + 1);
-		}
-		else // Codified statute
-		{
-			if (title.match(/^\d+/)) // Starts with digit, organized by title, ex. 47 U.S.C.S. § 230
-			{
-		// Sadly, named groups aren't working
-		let groups = title.match(/^(\d+)\s([a-zA-Z0-9\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
-				newStatute.codeNumber = groups[1];
-		newStatute.code = groups[2];
-		newStatute.section = groups[3];
-			}
-			else // Starts with letter, organized by code, ex. Tex. Bus. & Com. Code § 26.01
-			{
-		let groups = title.match(/^([a-zA-Z\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
-				newStatute.code = groups[1];
-				newStatute.section = groups[2];
-			}
+      // Turn statutesAtLarge into the code#/code/section fields
+      // TODO in styles, check for "Stat." as the code, and if so, don't append a section symbol
+      newStatute.codeNumber = statutesAtLarge.substring(0, statutesAtLarge.indexOf(' '));
+      newStatute.code = "Stat.";
+      newStatute.section = statutesAtLarge.substring(statutesAtLarge.lastIndexOf(' ') + 1);
+    }
+    else // Codified statute
+    {
+      if (title.match(/^\d+/)) // Starts with digit, organized by title, ex. 47 U.S.C.S. § 230
+      {
+        // Sadly, named groups aren't working
+        let groups = title.match(/^(\d+)\s([a-zA-Z0-9\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
+        newStatute.codeNumber = groups[1];
+        newStatute.code = groups[2];
+        newStatute.section = groups[3];
+      }
+      else // Starts with letter, organized by code, ex. Tex. Bus. & Com. Code § 26.01
+      {
+        let groups = title.match(/^([a-zA-Z\. ]+) § ([0-9\.\(\)a-zA-Z]+)/);
+        newStatute.code = groups[1];
+        newStatute.section = groups[2];
+      }
 
-	  // No way to tell which will be present
-	  var pL = info.match(/p\.l\. (\d+-\d+)/i);
-	  var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
-	  var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
-	  var publicLaw = info.match(/public law (\d+-\d+)/i);
-	  var publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
-	  var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
-			if (pL)
-		newStatute.publicLawNumber = pL[1];
-	  if (pubLaw)
-		newStatute.publicLawNumber = pubLaw[1];
-	  if (pubLawNo)
-		newStatute.publicLawNumber = pubLawNo[1];
-	  if (publicLaw)
-		newStatute.publicLawNumber = publicLaw[1];
-	  if (publicLawNo)
-		newStatute.publicLawNumber = publicLawNo[1];
-	  if (publicLawNumber)
-		newStatute.publicLawNumber = publicLawNumber[1];
+      // No way to tell which will be present
+      var pL = info.match(/p\.l\. (\d+-\d+)/i);
+      var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
+      var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
+      var publicLaw = info.match(/public law (\d+-\d+)/i);
+      var publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
+      var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
+      if (pL)
+        newStatute.publicLawNumber = pL[1];
+      if (pubLaw)
+        newStatute.publicLawNumber = pubLaw[1];
+      if (pubLawNo)
+        newStatute.publicLawNumber = pubLawNo[1];
+      if (publicLaw)
+        newStatute.publicLawNumber = publicLaw[1];
+      if (publicLawNo)
+        newStatute.publicLawNumber = publicLawNo[1];
+      if (publicLawNumber)
+        newStatute.publicLawNumber = publicLawNumber[1];
 
-	  if (newStatute.publicLawNumber)
-			  newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
-		}
+      if (newStatute.publicLawNumber)
+        newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
+    }
 
-		newStatute.extra = info; // Since the info section is all over the place, just dump the whole thing in for manual cite checks
+    newStatute.extra = info; // Since the info section is all over the place, just dump the whole thing in for manual cite checks
 
-		newStatute.complete();
-	}
+    newStatute.complete();
+  }
 }
 
 

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -70,10 +70,10 @@ function getSearchResults(doc, url) {
 		for (var i = 0; i < titles.length; i++) {
 			nextTitle = titles[i];
 			items[nextTitle.href] = nextTitle.textContent + "(" + nextDate.textContent + ")";
-	  
+
 			// dates[0] is court name
 			nextDate = dates[dateOffset];
-	  
+
 			// dates[2] is a citation
 		}
   
@@ -149,7 +149,7 @@ async function scrape(doc, url) {
 			}
 
 			var otherReporters = doc.querySelectorAll('span.SS_NonPaginatedRptr');
-	  
+
 			for (var i = 0; i < otherReporters.length; i++) {
 				var nextReporter = otherReporters[i].textContent;
 				if (nextReporter.match(/stat\./i)) statutesAtLarge = nextReporter;

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -1,0 +1,79 @@
+{
+	"translatorID": "419638d9-9049-44ad-ba08-fa54ed24b5e6",
+	"label": "Lexis+",
+	"creator": "Brandon F",
+	"target": "https://plus.lexis.*/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-04-06 16:12:39"
+}
+
+function scrape(doc, url) {
+	var namespace = doc.documentElement.namespaceURI;
+	var nsResolver = namespace ? function(prefix) {
+	if (prefix == "x" ) return namespace; else return null;
+	} : null;
+
+	if (detectWeb(doc, url) == "case")
+	{
+
+	}
+	else if (detectWeb(doc, url) == "statute")
+	{
+
+	}
+}
+
+function detectWeb(doc, url) {
+	Zotero.debug("Title: " + doc.title)
+	if (doc.title.match(/.*results.*/)) {
+		return "multiple"
+	}
+	else if (doc.title.match(/\d+\s[a-zA-Z\. ]+\s§\s\d+/))
+	{
+		return "statute"
+	}
+	else if (doc.title.match(/\d+\s[a-zA-Z0-9\. ]+\s\d+/))
+	{
+		return "case"
+	}
+}
+
+function doWeb(doc, url) {
+	var namespace = doc.documentElement.namespaceURI;
+	var nsResolver = namespace ? function(prefix) {
+	if (prefix == "x" ) return namespace; else return null;
+	} : null;
+
+	var casesOrStatutes = new Array();
+	var items = new Object();
+	var nextTitle;
+
+	if (detectWeb(doc, url) == "multiple") {
+		var titles = doc.evaluate('(//a[@class="titleLink"])',
+								  doc, nsResolver, XPathResult.ANY_TYPE, null);
+		while (nextTitle = titles.iterateNext()) {
+			// TODO format this a little, maybe add a year parenthetical
+			items[nextTitle.href] = nextTitle.textContent;
+		}
+
+		items = Zotero.selectItems(items);
+		for(var i in items) {
+			casesOrStatutes.push(i);
+		}
+	}
+	else
+	{
+		casesOrStatutes = [url]
+	}
+
+	Zotero.Utilities.processDocuments(casesOrStatutes, scrape, function(){Zotero.done();});
+	Zotero.wait();
+}/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -62,7 +62,7 @@ function getSearchResults(doc, url) {
 		let dates = doc.querySelectorAll('span.metaDataItem'); // Not technically only dates, but that's all I use it for atm
 		var nextDate;
 		var dateOffset = 1;
-	
+
 		// dates[0] is first court name
 		nextDate = dates[dateOffset];
 		dateOffset += 3;

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -152,14 +152,12 @@ async function scrape(doc, url) {
 
 			// Remove some unnecessary information
 			var cleanedTitle = title;
-			var dating = title.match(/act of\s[1-2][0-9][0-9][0-9](?!.*act of\s[1-2][0-9][0-9][0-9])/); // Last occurrence of 'act of 2017' etc
 			var pLCite = title.match(/(\d+ p\.l\. \d+)/i);
 			var statCite = title.match(/(\d+ stat\. \d+)/i);
 			var enactedCite = title.match(/\d+ enacted [a-zA-Z0-9.]+ \d+/gi);
 			var part = title.match(/(part \d+(?: of \d+)?)/i);
 			if (pLCite) cleanedTitle = cleanedTitle.replace(pLCite[1], '');
 			if (statCite) cleanedTitle = cleanedTitle.replace(statCite[1], '');
-			if (dating) cleanedTitle = cleanedTitle.replace(dating[1], '');
 			if (part) cleanedTitle = cleanedTitle.replace(part[1], '');
 			if (enactedCite) {
 				// Remove every enacted cite
@@ -175,7 +173,7 @@ async function scrape(doc, url) {
 				if (pLCite) cleanedTitle = pLCite[1];
 				else if (statCite) cleanedTitle = statCite[1];
 				else if (enactedCite) {
-					cleanedTitle = enactedCite[0] + " & " + (Object.keys(enactedCite).length - 1) + " more"
+					cleanedTitle = enactedCite[0] + " & " + (Object.keys(enactedCite).length - 1) + " more";
 				}
 			}
 			newStatute.title = cleanedTitle;

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -170,7 +170,7 @@ async function scrape(doc, url) {
 			cleanedTitle = cleanedTitle.replace(/(^\s*,)|(,\s*$)/g, ''); // Trim commas and whitespace
 			cleanedTitle = cleanedTitle.replace(/(^\s*,)|(,\s*$)/g, ''); // Another one
 			Zotero.debug(cleanedTitle);
-			if (ZU.trim(cleanedTitle) === "") { // If the title's empty now, put it as the highest precedence citation available
+			if (ZU.trim(cleanedTitle) === "") { // If the title's empty now, put it as the highest precedence citation in the title
 				Zotero.debug("ha");
 				if (pLCite) cleanedTitle = pLCite[1];
 				else if (statCite) cleanedTitle = statCite[1];

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-07 21:55:44"
+	"lastUpdated": "2023-04-09 22:52:49"
 }
 
 /*
@@ -99,9 +99,12 @@ async function doWeb(doc, url) {
 async function scrape(doc, url) {
 	if (detectWeb(doc, url) == "case") {
 		var newCase = new Zotero.Item("case");
-		newCase.url = doc.location.href;
+		//newCase.url = doc.location.href; // Disabled for style reasons
 
-		newCase.title = text(doc, 'h1#SS_DocumentTitle');
+		var title = text(doc, 'h1#SS_DocumentTitle');
+		newCase.title = title;
+
+		newCase.notes.push({note: "Snapshot: " + newCase.title + doc.getElementById('document-content').innerHTML});
 
 		var citation = text(doc, 'span.active-reporter');
 		newCase.reporterVolume = citation.substring(0, citation.indexOf(' '));
@@ -123,10 +126,13 @@ async function scrape(doc, url) {
 	}
 	else if (detectWeb(doc, url) == "statute") {
 		var newStatute = new Zotero.Item("statute");
-		newStatute.url = doc.location.href;
+
+		//newStatute.url = doc.location.href; // Disabled for style reasons
 
 		var title = text(doc, 'h1#SS_DocumentTitle'); // Saves some lines to have a temp here
 		newStatute.title = title;
+
+		newStatute.notes.push({note: "Snapshot: " + newStatute.title + doc.getElementById('document-content').innerHTML});
 
 		var info = text(doc, 'p.SS_DocumentInfo');
 
@@ -208,7 +214,7 @@ async function scrape(doc, url) {
 			if (newStatute.publicLawNumber) newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
 		}
 
-		newStatute.extra = info; // Since the info section is all over the place, just dump the whole thing in for manual cite checks
+		newStatute.notes.push({note: "Document Info: " + info}); // Since the info section is all over the place, just dump the whole thing in for manual cite checks
 
 		newStatute.complete();
 	}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -147,8 +147,9 @@ async function scrape(doc, url) {
 			// BB 21st ed. requires parallel cite to Pub. L. No. and Stat. for session laws
 
 			// Title formatting
-			// ZU doesn't capitalize titles right and I'm not writing a capitalization routine
-			//if (title == title.toUpperCase()) newStatute.title = ZU.capitalizeTitle(title.toLowerCase(), true); // Some acts are capitalized
+			// TODO ZU's capitalizer is good, but doesn't work with closed-up abbreviations like P.L. or U.S.
+			//  This could break titles in future. I do remove P.L. below though.
+			if (title === title.toUpperCase()) title = ZU.capitalizeTitle(title.toLowerCase(), true); // Some acts are capitalized
 
 			// Remove some unnecessary information
 			var cleanedTitle = title;
@@ -208,15 +209,17 @@ async function scrape(doc, url) {
 				newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
 			}
 			else { // Ex. 115 P.L. 164 or 115 Pub. L. No. 164
-				newStatute.session = publicLawNo.substring(0, publicLawNo.indexOf(' '));
-				newStatute.publicLawNumber = newStatute.session + '-' + publicLawNo.substring(publicLawNo.lastIndexOf(' ') + 1);
+				var pLNumbers = publicLawNo.match(/(\d+) p\.l\. (\d+)/i);
+				newStatute.session = pLNumbers[1];
+				newStatute.publicLawNumber = pLNumbers[1] + '-' + pLNumbers[2];
 			}
 
 			// Turn statutesAtLarge into the code#/code/section fields
 			// TODO in styles, check for "Stat." as the code, and if so, don't append a section symbol
-			newStatute.codeNumber = statutesAtLarge.substring(0, statutesAtLarge.indexOf(' '));
+			var statNumbers = statutesAtLarge.match(/(\d+) stat\. (\d+)/i);
+			newStatute.codeNumber = statNumbers[1];
 			newStatute.code = "Stat.";
-			newStatute.section = statutesAtLarge.substring(statutesAtLarge.lastIndexOf(' ') + 1);
+			newStatute.section = statNumbers[2];
 		}
 		else { // Codified statute
 			// Title & citation formatting

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -197,19 +197,19 @@ async function scrape(doc, url) {
 				newStatute.section = groups[2];
 			}
 
-			// No way to tell which will be present
-			var pL = info.match(/p\.l\. (\d+-\d+)/i);
-			var pubLaw = info.match(/pub\. law (\d+-\d+)/i);
-			var pubLawNo = info.match(/pub\. law no\. (\d+-\d+)/i);
-			var publicLaw = info.match(/public law (\d+-\d+)/i);
-			publicLawNo = info.match(/public law no\. (\d+-\d+)/i);
-			var publicLawNumber = info.match(/public law number (\d+-\d+)/i);
-			if (pL) newStatute.publicLawNumber = pL[1];
-			if (pubLaw) newStatute.publicLawNumber = pubLaw[1];
-			if (pubLawNo) newStatute.publicLawNumber = pubLawNo[1];
-			if (publicLaw) newStatute.publicLawNumber = publicLaw[1];
-			if (publicLawNo) newStatute.publicLawNumber = publicLawNo[1];
-			if (publicLawNumber) newStatute.publicLawNumber = publicLawNumber[1];
+			/*
+			 * Matches: 
+			 * P.L. 117-327
+			 * Pub. L. 117-327
+			 * Pub. Law 117-327
+			 * Pub. L. No. 117-327
+			 * Pub. Law No. 117-327
+			 * Public Law 117-327
+			 * Public Law Number 117-327
+			 * Public Law No. 117-327
+			 */
+			var pL = info.match(/(p\.l\.|pub\. l(?:aw|\.)(?: no\.)?|public law(?: number| no\.)?)\s(\d+-\d+)/i);
+			if (pL) newStatute.publicLawNumber = pL[2];
 
 			if (newStatute.publicLawNumber) newStatute.session = newStatute.publicLawNumber.substring(0, newStatute.publicLawNumber.indexOf('-'));
 		}


### PR DESCRIPTION
## Background
This is a translator for the online legal research database Lexis+ by LexisNexis. The current LexisNexis translator is several years old and no longer functional, so this is a new solution from scratch.

Lexis+ is a paid service with licensing for educational institutions and business entities. You will need access through an institutional account to access the targets for this translator.

## Current Functionality
- Web scraper-type translator
- Case names, reporters, volumes, page info, dates, courts
- Statute names, codified location, volumes, sections, dates
- Session law names, locations (public law & statutes at large), sections, dates

## Aims
My goal is to create a LaTeX workflow for law journals which improves on the current processes (many involve conforming to a complex naming scheme for documents, uploading them all to institutional SharePoint, and then going back and forth between SharePoint and Word). HeinOnline is the other primary location for sources, and thankfully it's already supported. My next step is updating the current Bluebook Zotero citation style, which I can use with `citeproc-lua` to format Zotero-exported `biblatex` bibliographies.

Feedback is appreciated. Thanks!

Edit: side note, I'd lint the code myself, but I'm getting `Error: Failed to load plugin 'zotero-translator' declared in '.eslintrc': no header` when running `npx eslint Lexis+.js`.