### PR TITLE
Don't detect J-Stage PDFs

### DIFF
--- a/J-Stage.js
+++ b/J-Stage.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2019-06-15 19:04:11"
+	"lastUpdated": "2023-04-27 13:09:03"
 }
 
 /*
@@ -35,7 +35,8 @@
 */
 
 function detectWeb(doc, url) {
-	if (url.includes("/article/")) {
+	// don't detect on PDF pages
+	if (url.includes("/article/") && !url.includes("/_pdf")) {
 		return "journalArticle";
 	}
 	else if ((url.includes("/result/") || url.includes("/browse/"))


### PR DESCRIPTION
https://forums.zotero.org/discussion/104661/cannot-download-papers-from-jstage#latest

@dstillman @AbeJellinek -- there's a larger question here about how much effort we should make to actually detect & translate on PDF pages. Here, it's easy to a) detect this is JSTAGE and b) construct the article landing page from the PDF page, so doing a proper translation would require construction that and a processDocument call -- is that worth it or not (FWIW, recognize PDF doesn't work super reliably for JSTAGE PDFs because they have wonky encoding issues)?