### PR TITLE
Fix selector for getting abstract from page for SAGE Journals

### DIFF
--- a/SAGE Journals.js
+++ b/SAGE Journals.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-12-06 18:57:06"
+	"lastUpdated": "2023-05-04 14:14:25"
 }
 
 /*
@@ -107,7 +107,7 @@ function scrape(doc, url) {
 		if (text.includes("DA  - ")) {
 			text = text.replace(/Y1[ ]{2}- .*\r?\n/, '');
 		}
-		
+
 		var translator = Zotero.loadTranslator("import");
 		translator.setTranslator("32d59d2d-b65a-4da4-b0a3-bdd3cfb979e7");
 		translator.setString(text);
@@ -125,12 +125,11 @@ function scrape(doc, url) {
 			}
 			// The encoding of apostrophs in the RIS are incorrect and
 			// therefore we extract the abstract again from the website.
-			var abstract = ZU.xpathText(doc, '//article//div[contains(@class, "abstractSection")]/p');
+			var abstract = doc.querySelector("#abstract > div").innerText;
 			if (abstract) {
 				item.abstractNote = abstract;
 			}
-			
-			
+
 			for (let tag of tags) {
 				item.tags.push(tag.textContent);
 			}
@@ -142,7 +141,7 @@ function scrape(doc, url) {
 					item.creators[i] = ZU.cleanAuthor(item.creators[i].lastName, type, comma);
 				}
 			}
-			
+
 			item.notes = [];
 			item.language = ZU.xpathText(doc, '//meta[@name="dc.Language"]/@content');
 			item.attachments.push({
@@ -160,24 +159,24 @@ function scrape(doc, url) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://journals.sagepub.com/doi/abs/10.1177/1754073910380971",
+		"url": "https://journals.sagepub.com/doi/abs/10.1177/1754073910380971",
+		"detectedItemType": "journalArticle",
 		"items": [
 			{
 				"itemType": "journalArticle",
 				"title": "Emotion and Regulation are One!",
 				"creators": [
 					{
-						"firstName": "Arvid",
 						"lastName": "Kappas",
+						"firstName": "Arvid",
 						"creatorType": "author"
 					}
 				],
-				"date": "January 1, 2011",
+				"date": "2011-01-01",
 				"DOI": "10.1177/1754073910380971",
 				"ISSN": "1754-0739",
 				"abstractNote": "Emotions are foremost self-regulating processes that permit rapid responses and adaptations to situations of personal concern. They have biological bases and are shaped ontogenetically via learning and experience. Many situations and events of personal concern are social in nature. Thus, social exchanges play an important role in learning about rules and norms that shape regulation processes. I argue that (a) emotions often are actively auto-regulating—the behavior implied by the emotional reaction bias to the eliciting event or situation modifies or terminates the situation; (b) certain emotion components are likely to habituate dynamically, modifying the emotional states; (c) emotions are typically intra- and interpersonal processes at the same time, and modulating forces at these different levels interact; (d) emotions are not just regulated—they regulate. Important conclusions of my arguments are that the scientific analysis of emotion should not exclude regulatory processes, and that effortful emotion regulation should be seen relative to a backdrop of auto-regulation and habituation, and not the ideal notion of a neutral baseline. For all practical purposes unregulated emotion is not a realistic concept.",
 				"issue": "1",
-				"journalAbbreviation": "Emotion Review",
 				"language": "en",
 				"libraryCatalog": "SAGE Journals",
 				"pages": "17-25",
@@ -190,17 +189,7 @@ var testCases = [
 						"mimeType": "application/pdf"
 					}
 				],
-				"tags": [
-					{
-						"tag": "emotion regulation"
-					},
-					{
-						"tag": "facial expression"
-					},
-					{
-						"tag": "facial feedback"
-					}
-				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}
@@ -208,8 +197,9 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://journals.sagepub.com/toc/rera/86/3",
-		"items": "multiple"
+		"url": "https://journals.sagepub.com/toc/rera/86/3",
+		"detectedItemType": false,
+		"items": []
 	},
 	{
 		"type": "web",
@@ -359,6 +349,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://journals.sagepub.com/doi/10.1177/0263276404046059",
+		"detectedItemType": "journalArticle",
 		"items": [
 			{
 				"itemType": "journalArticle",
@@ -370,12 +361,11 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "October 1, 2004",
+				"date": "2004-10-01",
 				"DOI": "10.1177/0263276404046059",
 				"ISSN": "0263-2764",
 				"abstractNote": "This article is concerned with how to conceptualize and theorize the nature of the ‘car system’ that is a particularly key, if surprisingly neglected, element in ‘globalization’. The article deploys the notion of systems as self-reproducing or autopoietic. This notion is used to understand the origins of the 20th-century car system and especially how its awesome pattern of path dependency was established and exerted a particularly powerful and self-expanding pattern of domination across the globe. The article further considers whether and how the 20th-century car system may be transcended. It elaborates a number of small changes that are now occurring in various test sites, factories, ITC sites, cities and societies. The article briefly considers whether these small changes may in their contingent ordering end this current car system. The article assesses whether such a new system could emerge well before the end of this century, whether in other words some small changes now may produce the very large effect of a new post-car system that would have great implications for urban life, for mobility and for limiting projected climate change.",
 				"issue": "4-5",
-				"journalAbbreviation": "Theory, Culture & Society",
 				"language": "en",
 				"libraryCatalog": "SAGE Journals",
 				"pages": "25-39",
@@ -388,23 +378,56 @@ var testCases = [
 						"mimeType": "application/pdf"
 					}
 				],
-				"tags": [
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://journals.sagepub.com/doi/10.1177/1071181322661302",
+		"detectedItemType": "journalArticle",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Deidentification of Drivers’ Face Videos: Scope and Challenges in Human Factors Research",
+				"creators": [
 					{
-						"tag": "automobility"
+						"lastName": "Thapa",
+						"firstName": "Surendrabikram",
+						"creatorType": "author"
 					},
 					{
-						"tag": "path dependence"
+						"lastName": "Cook",
+						"firstName": "Julie",
+						"creatorType": "author"
 					},
 					{
-						"tag": "technology"
-					},
-					{
-						"tag": "time-space"
-					},
-					{
-						"tag": "tipping point"
+						"lastName": "Sarkar",
+						"firstName": "Abhijit",
+						"creatorType": "author"
 					}
 				],
+				"date": "2022-09-01",
+				"DOI": "10.1177/1071181322661302",
+				"ISSN": "2169-5067",
+				"abstractNote": "Data sharing across disciplines helps to build collaboration, and advance research. With recent development in data-driven models, there is an unprecedented need for data. However, data collected from human research subjects are required to follow proper ethical guidelines. Researchers have an obligation to protect the privacy of research participants and address ethical and safety concerns when data contains personally identifying information (PII). This paper addresses this problem with a focus on sharing drivers’ face videos for transportation research. The paper first gives an overview of the multitude of problems that are associated with sharing drivers’ videos. Then it demonstrates the possible directions for data sharing by de-identifying drivers’ faces using artificial intelligence-based techniques. The results achieved through the proposed techniques were evaluated qualitatively and quantitatively to prove the validity of the suggested methods. We specifically demonstrated how face-swapping algorithms can effectively de-identify faces while still preserving important attributes related to human factor research including eye movements, head movements, mouth movements, etc. Finally, we discuss possible measures to share such de-identified videos with the greater research community.",
+				"issue": "1",
+				"language": "en",
+				"libraryCatalog": "SAGE Journals",
+				"pages": "1509-1513",
+				"publicationTitle": "Proceedings of the Human Factors and Ergonomics Society Annual Meeting",
+				"shortTitle": "Deidentification of Drivers’ Face Videos",
+				"url": "https://doi.org/10.1177/1071181322661302",
+				"volume": "66",
+				"attachments": [
+					{
+						"title": "SAGE PDF Full Text",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}


### PR DESCRIPTION
Issue reported here: https://forums.zotero.org/discussion/101602/sage-translator-apostrophes-in-abstracts-import-as-papercut-in-titles-ok#latest

The cause of the issue is that apostrophes are incorrectly encoded as question marks in RIS for SAGE Journals. The translator already had a workaround to get the abstract directly from the page, but the page structure must have changed and the xpath to get abstract text no longer worked. 