### PR TITLE
Lexis+: Oops

### DIFF
--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-26 03:42:30"
+	"lastUpdated": "2023-05-26 04:09:26"
 }
 
 /*
@@ -40,7 +40,7 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (/[a-zA-Z. ]+\s§\s\d+/.test(doc.title)
-	|| /\W(act)\W|\W(act)$|\W(acts)\W|\W(acts)$/i.test(doc.title)
+	|| /\W(acts?)(\W|$)/i.test(doc.title)
 	|| /p\.l\./i.test(doc.title)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-26 03:38:49"
+	"lastUpdated": "2023-05-26 03:42:30"
 }
 
 /*
@@ -40,7 +40,7 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (/[a-zA-Z. ]+\s§\s\d+/.test(doc.title)
-	|| /\W*(act)\W|\W*(act)$/i.test(doc.title)
+	|| /\W(act)\W|\W(act)$|\W(acts)\W|\W(acts)$/i.test(doc.title)
 	|| /p\.l\./i.test(doc.title)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-26 03:27:41"
+	"lastUpdated": "2023-05-26 03:38:49"
 }
 
 /*
@@ -40,7 +40,7 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (/[a-zA-Z. ]+\s§\s\d+/.test(doc.title)
-	|| /\W*(act)\W/i.test(doc.title)
+	|| /\W*(act)\W|\W*(act)$/i.test(doc.title)
 	|| /p\.l\./i.test(doc.title)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-04-10 03:15:48"
+	"lastUpdated": "2023-05-26 03:27:41"
 }
 
 /*
@@ -40,7 +40,7 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (/[a-zA-Z. ]+\s§\s\d+/.test(doc.title)
-	|| /act/i.test(doc.title)
+	|| /\W*(act)\W/i.test(doc.title)
 	|| /p\.l\./i.test(doc.title)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}

--- a/Lexis+.js
+++ b/Lexis+.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-26 04:09:26"
+	"lastUpdated": "2023-05-26 04:11:53"
 }
 
 /*
@@ -40,7 +40,7 @@ function detectWeb(doc, _url) {
 		return "multiple";
 	}
 	else if (/[a-zA-Z. ]+\s§\s\d+/.test(doc.title)
-	|| /\W(acts?)(\W|$)/i.test(doc.title)
+	|| /\W(acts?)(\W|$)/i.test(doc.title) // Match: The Airports Acts, Civil Rights Act of 1865
 	|| /p\.l\./i.test(doc.title)) { // Match: ... Tex. Bus. & Com. Code § 26.01 ...
 		return "statute";
 	}


### PR DESCRIPTION
I discovered a bug with word capture today, turns out `/act/i` will match Interactive, leading cases to be flagged as statutes and fail. Easy fix.

Edit: Lexis+ dynamically changes titles so it probably wouldn't ever happen, but my regex should probably match if it's at the end of a string.