### PR TITLE
Updated Electronic Colloquium on Computational Complexity translator

### DIFF
--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-31 16:38:35"
+	"lastUpdated": "2023-05-31 20:54:48"
 }
 
 /*
@@ -74,6 +74,7 @@ function scrape(doc) {
 	
 	if (hasPreprint) {
 		newItem.archiveID = ZU.xpathText(doc, metaXPath("technical_report_number"));
+		newItem.publisher = "Electronic Colloquium on Computational Complexity";
 	}
 	else {
 		newItem.reportNumber = ZU.xpathText(doc, metaXPath("technical_report_number"));
@@ -162,6 +163,7 @@ var testCases = [
 				"abstractNote": "We study the impact of combinatorial structure in congestion games on the complexity of computing pure Nash equilibria and the convergence time of best response sequences.  In particular, we investigate which properties of the strategy spaces of individual players ensure a polynomial convergence time. We show, if the strategy space of each player consists of the bases of a matroid over the set of resources, then the lengths of all best response sequences are polynomially bounded in the number of players and resources. We can also prove that this result is tight, that is, the matroid property is a necessary and sufficient condition on the players' strategy spaces for guaranteeing polynomial time convergence to a Nash equilibrium. In addition, we present an approach that enables us to devise hardness proofs for various kinds of combinatorial games, including first results about the hardness of market sharing games and congestion games for overlay network design. Our approach also yields a short proof for the PLS-completeness of network congestion games.",
 				"archiveID": "TR06-067",
 				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"repository": "Electronic Colloquium on Computational Complexity",
 				"url": "https://eccc.weizmann.ac.il/report/2006/067/",
 				"attachments": [
 					{
@@ -215,6 +217,7 @@ var testCases = [
 				"abstractNote": "One of the major open problems in complexity theory is proving super-logarithmic lower bounds on the depth of circuits (i.e., $\\mathbf{P}\\not\\subseteq \\mathbf{NC}^{1}$). Karchmer, Raz, and Wigderson (Computational Complexity 5(3/4), 1995) suggested to approach this problem by proving that depth complexity of a composition of functions $f \\diamond g$ is roughly the sum of the depth complexities of $f$ and $g$. They showed that the validity of this conjecture would imply that $\\mathbf{P}\\not\\subseteq\\mathbf{NC}^{1}$.The intuition that underlies the KRW conjecture is that the composition $f \\diamond g$ should behave like a \"direct-sum problem\", in a certain sense, and therefore the depth complexity of $f \\diamond g$ should be the sum of the individual depth complexities. Nevertheless, there are two obstacles toward turning this intuition into a proof: first, we do not know how to prove that $f \\diamond g$ must behave like a direct-sum problem; second, we do not know how to prove that the complexity of the latter direct-sum problem is indeed the sum of the individual complexities.In this work, we focus on the second obstacle. To this end, we study a notion called ``strong composition'', which is the same as $f \\diamond g$ except that it is forced to behave like a direct-sum problem. We prove a variant of the KRW conjecture for strong composition, thus overcoming the above second obstacle. This result demonstrates that the first obstacle above is the crucial barrier toward resolving the KRW conjecture. Along the way, we develop some general techniques that might be of independent interest.",
 				"archiveID": "TR23-078",
 				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"repository": "Electronic Colloquium on Computational Complexity",
 				"shortTitle": "Toward Better Depth Lower Bounds",
 				"url": "https://eccc.weizmann.ac.il/report/2023/078/",
 				"attachments": [

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-02 15:46:17"
+	"lastUpdated": "2023-08-02 16:03:19"
 }
 
 /*
@@ -66,10 +66,13 @@ async function scrape(doc, url = doc.location.href) {
 			item.tags[i] = keywords[i].textContent;
 		}
 
-		var abstractLines = ZU.xpath(doc, "id('box')/p");
+		var abstractParagraphs = ZU.xpath(doc, "id('box')/p");
 		item.abstractNote = "";
-		for (let i = 0; i < abstractLines.length; i++) {
-			item.abstractNote += abstractLines[i].textContent;
+		for (let i = 0; i < abstractParagraphs.length; i++) {
+			var abstractLines = abstractParagraphs[i].innerHTML.split("<br>");
+			for (let j = 0; j < abstractLines.length; j++) {
+				item.abstractNote += abstractLines[j] + "\n";
+			}
 		}
 		item.complete();
 	});
@@ -189,7 +192,7 @@ var testCases = [
 					}
 				],
 				"date": "2007/11/12",
-				"abstractNote": "The sign-rank of a real matrix M is the least rankof a matrix R in which every entry has the same sign as thecorresponding entry of M. We determine the sign-rank of everymatrix of the form M=[ D(|x AND y|) ]_{x,y}, whereD:{0,1,...,n}->{-1,+1} is given and x and y range over {0,1}^n.Specifically, we prove that the sign-rank of M equals 2^{\\tilde Theta(k)}, where k is the number of times D changessign in {0,1,...,n}.\n         Put differently, we prove an optimal lower boundon the unbounded-error communication complexity of everysymmetric function, i.e., a function of the form f(x,y)=D(|x AND y|) for some D. The unbounded-error model isessentially the most powerful of all models of communication(both classical and quantum), and proving lower bounds in itis a substantial challenge. The only previous nontrivial lowerbounds for this model appear in the groundbreaking work ofForster (2001) and its extensions.  As corollaries to ourresult, we give new lower bounds for PAC learning and forthreshold-of-majority circuits.\n         The technical content of our proof is diverse andfeatures random walks on (Z_2)^n, discrete approximation theory,the Fourier transform on (Z_2)^n, linear-programming duality,and matrix analysis.",
+				"abstractNote": "The sign-rank of a real matrix M is the least rank\nof a matrix R in which every entry has the same sign as the\ncorresponding entry of M. We determine the sign-rank of every\nmatrix of the form M=[ D(|x AND y|) ]_{x,y}, where\nD:{0,1,...,n}-&gt;{-1,+1} is given and x and y range over {0,1}^n.\nSpecifically, we prove that the sign-rank of M equals \n2^{\\tilde Theta(k)}, where k is the number of times D changes\nsign in {0,1,...,n}.\n         Put differently, we prove an optimal lower bound\non the unbounded-error communication complexity of every\nsymmetric function, i.e., a function of the form \nf(x,y)=D(|x AND y|) for some D. The unbounded-error model is\nessentially the most powerful of all models of communication\n(both classical and quantum), and proving lower bounds in it\nis a substantial challenge. The only previous nontrivial lower\nbounds for this model appear in the groundbreaking work of\nForster (2001) and its extensions.  As corollaries to our\nresult, we give new lower bounds for PAC learning and for\nthreshold-of-majority circuits.\n         The technical content of our proof is diverse and\nfeatures random walks on (Z_2)^n, discrete approximation theory,\nthe Fourier transform on (Z_2)^n, linear-programming duality,\nand matrix analysis.",
 				"archiveID": "TR07-112",
 				"language": "en",
 				"libraryCatalog": "eccc.weizmann.ac.il",

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -76,12 +76,12 @@ async function scrape(doc, url = doc.location.href) {
 		item.publisher = "Electronic Colloquium on Computational Complexity";
 
 		// Keywords and abstract are not in the metadata; scrape from webpage
-		var keywords = ZU.xpath(doc, "id('box')//a[contains(@href,'keyword')]");
+		var keywords = doc.querySelectorAll("#box a[href^='/keyword/']");
 		for (let i = 0; i < keywords.length; i++) {
 			item.tags[i] = keywords[i].textContent;
 		}
 
-		var abstractParagraphs = ZU.xpath(doc, "id('box')/p");
+		var abstractParagraphs = doc.querySelectorAll("#box p");
 		item.abstractNote = "";
 		for (let i = 0; i < abstractParagraphs.length; i++) {
 			item.abstractNote += abstractParagraphs[i].innerText + "\n";

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-02 15:31:56"
+	"lastUpdated": "2023-08-02 15:46:17"
 }
 
 /*
@@ -41,7 +41,7 @@ const preprintType = ZU.fieldIsValidForType('title', 'preprint')
 
 function detectWeb(doc, url) {
 	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword)\//;
-	var singleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/report\//
+	var singleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/report\//;
 	if (multipleRe.test(url)) {
 		return "multiple";
 	}
@@ -175,27 +175,26 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://eccc.weizmann.ac.il/report/2023/078/",
+		"url": "https://eccc.weizmann.ac.il/report/2007/112/",
 		"detectedItemType": "preprint",
 		"items": [
 			{
 				"itemType": "preprint",
-				"title": "Toward Better Depth Lower Bounds: A KRW-like theorem for Strong Composition",
+				"title": "Unbounded-Error Communication Complexity of Symmetric Functions",
 				"creators": [
 					{
-						"firstName": "Or",
-						"lastName": "Meir",
+						"firstName": "Alexander A.",
+						"lastName": "Sherstov",
 						"creatorType": "author"
 					}
 				],
-				"date": "2023/5/30",
-				"abstractNote": "One of the major open problems in complexity theory is proving super-logarithmic lower bounds on the depth of circuits (i.e., $\\mathbf{P}\\not\\subseteq \\mathbf{NC}^{1}$). Karchmer, Raz, and Wigderson (Computational Complexity 5(3/4), 1995) suggested to approach this problem by proving that depth complexity of a composition of functions $f \\diamond g$ is roughly the sum of the depth complexities of $f$ and $g$. They showed that the validity of this conjecture would imply that $\\mathbf{P}\\not\\subseteq\\mathbf{NC}^{1}$.The intuition that underlies the KRW conjecture is that the composition $f \\diamond g$ should behave like a \"direct-sum problem\", in a certain sense, and therefore the depth complexity of $f \\diamond g$ should be the sum of the individual depth complexities. Nevertheless, there are two obstacles toward turning this intuition into a proof: first, we do not know how to prove that $f \\diamond g$ must behave like a direct-sum problem; second, we do not know how to prove that the complexity of the latter direct-sum problem is indeed the sum of the individual complexities.In this work, we focus on the second obstacle. To this end, we study a notion called ``strong composition'', which is the same as $f \\diamond g$ except that it is forced to behave like a direct-sum problem. We prove a variant of the KRW conjecture for strong composition, thus overcoming the above second obstacle. This result demonstrates that the first obstacle above is the crucial barrier toward resolving the KRW conjecture. Along the way, we develop some general techniques that might be of independent interest.",
-				"archiveID": "TR23-078",
+				"date": "2007/11/12",
+				"abstractNote": "The sign-rank of a real matrix M is the least rankof a matrix R in which every entry has the same sign as thecorresponding entry of M. We determine the sign-rank of everymatrix of the form M=[ D(|x AND y|) ]_{x,y}, whereD:{0,1,...,n}->{-1,+1} is given and x and y range over {0,1}^n.Specifically, we prove that the sign-rank of M equals 2^{\\tilde Theta(k)}, where k is the number of times D changessign in {0,1,...,n}.\n         Put differently, we prove an optimal lower boundon the unbounded-error communication complexity of everysymmetric function, i.e., a function of the form f(x,y)=D(|x AND y|) for some D. The unbounded-error model isessentially the most powerful of all models of communication(both classical and quantum), and proving lower bounds in itis a substantial challenge. The only previous nontrivial lowerbounds for this model appear in the groundbreaking work ofForster (2001) and its extensions.  As corollaries to ourresult, we give new lower bounds for PAC learning and forthreshold-of-majority circuits.\n         The technical content of our proof is diverse andfeatures random walks on (Z_2)^n, discrete approximation theory,the Fourier transform on (Z_2)^n, linear-programming duality,and matrix analysis.",
+				"archiveID": "TR07-112",
 				"language": "en",
 				"libraryCatalog": "eccc.weizmann.ac.il",
 				"repository": "Electronic Colloquium on Computational Complexity",
-				"shortTitle": "Toward Better Depth Lower Bounds",
-				"url": "https://eccc.weizmann.ac.il/report/2023/078/",
+				"url": "https://eccc.weizmann.ac.il/report/2007/112/",
 				"attachments": [
 					{
 						"title": "Full Text PDF",
@@ -204,46 +203,13 @@ var testCases = [
 				],
 				"tags": [
 					{
-						"tag": "Circuit Complexity Lower Bounds"
+						"tag": "Communication complexity"
 					},
 					{
-						"tag": "Depth Lower bounds"
+						"tag": "Sign-rank"
 					},
 					{
-						"tag": "KRW"
-					},
-					{
-						"tag": "KRW composition conjecture"
-					},
-					{
-						"tag": "KRW conjecture"
-					},
-					{
-						"tag": "KW games"
-					},
-					{
-						"tag": "KW relation"
-					},
-					{
-						"tag": "Karchmer Wigderson game"
-					},
-					{
-						"tag": "Karchmer-Raz-Wigderson conjecture"
-					},
-					{
-						"tag": "Karchmer-Wigderson games"
-					},
-					{
-						"tag": "circuit lower bounds"
-					},
-					{
-						"tag": "formula complexity"
-					},
-					{
-						"tag": "formula lower bound"
-					},
-					{
-						"tag": "formula lower bounds"
+						"tag": "Unbounded-error communication complexity"
 					}
 				],
 				"notes": [],

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-02 16:18:22"
+	"lastUpdated": "2023-08-02 16:48:21"
 }
 
 /*
@@ -83,9 +83,8 @@ async function scrape(doc, url = doc.location.href) {
 	});
 }
 
-function doWeb(doc, url) {
-	var articles = [];
-	var items = {};
+async function doWeb(doc, url) {
+	var articles = {};
 
 	if (detectWeb(doc, url) == "multiple") {
 		var titleXPath = "//a[starts-with(@href,'/report/')]/h4";
@@ -94,20 +93,18 @@ function doWeb(doc, url) {
 		var titles = ZU.xpath(doc, titleXPath);
 		var links = ZU.xpath(doc, linkXPath);
 		for (let i = 0; i < titles.length; i++) {
-			items[links[i].href] = titles[i].textContent;
+			articles[links[i].href] = titles[i].textContent;
 		}
-		Zotero.selectItems(items, function (items) {
-			if (!items) {
-				Zotero.done();
-			}
-			for (var i in items) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
-		});
+		let items = await Zotero.selectItems(articles);
+		if (!items) {
+			Zotero.done();
+		}
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
 	}
 	else {
-		scrape(doc, url);
+		await scrape(doc, url);
 	}
 }
 

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -1,94 +1,121 @@
 {
 	"translatorID": "09a9599e-c20e-a405-d10d-35ad4130a426",
 	"label": "Electronic Colloquium on Computational Complexity",
-	"creator": "Jonas Schrieb",
-	"target": "^https?://eccc\\.weizmann\\.ac\\.il/",
+	"creator": "Jonas Schrieb and Morgan Shirley",
+	"target": "^https?://eccc\\.weizmann\\.ac\\.il/(title|year|keyword|report)",
 	"minVersion": "1.0.0b3.r1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
-	"browserSupport": "gcsib",
-	"lastUpdated": "2017-01-05 17:11:41"
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-05-31 16:38:35"
 }
 
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2023 Jonas Schrieb and Morgan Shirley
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
 function detectWeb(doc, url) {
-	var singleRe   = /^https?:\/\/eccc\.weizmann\.ac\.il\/report\/\d{4}\/\d{3}/;
 	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword)\//;
-	if (singleRe.test(url)) {
-		return "report";
-	} else if (multipleRe.test(url)) {
+	if (multipleRe.test(url)) {
 		return "multiple";
 	}
+	else if (ZU.fieldIsValidForType('title', 'preprint')) {
+		return "preprint";
+	}
+	else {
+		return "report";
+	}
+}
+
+// Get a meta tag from the header
+function metaXPath(name) {
+	return `/html/head/meta[contains(@name,'citation_${name}')]/@content`;
 }
 
 function scrape(doc) {
-	var newItem = new Zotero.Item("report");
+	var hasPreprint;
+	if (ZU.fieldIsValidForType('title', 'preprint')) {
+		hasPreprint = true;
+	}
+	var newItem;
+	if (hasPreprint) {
+		newItem = new Zotero.Item("preprint");
+	}
+	else {
+		newItem = new Zotero.Item("report");
+	}
 
 	var url = doc.location.href;
-	var tmp  = url.match(/\/(\d{4})\/(\d{3})\/$/);
-	newItem.date = tmp[1];
-	newItem.reportNumber = tmp[2];
+
 	newItem.url = url;
+	newItem.title = ZU.xpathText(doc, metaXPath("title"));
+	newItem.date = ZU.xpathText(doc, metaXPath("publication_date"));
 	
-
-
-	var titleXPath    = "id('box')//h4";
-	newItem.title = doc.evaluate(titleXPath, doc, null, XPathResult.ANY_TYPE, null).iterateNext().textContent;
-
-
-
-	var authorsXPath  = "id('box')//a[contains(@href,'author')]";
-	var authors = doc.evaluate(authorsXPath, doc, null, XPathResult.ANY_TYPE, null);
-	var nextAuthor;
-	while (nextAuthor = authors.iterateNext()) {
-		newItem.creators.push(Zotero.Utilities.cleanAuthor(nextAuthor.textContent, "author"));
+	if (hasPreprint) {
+		newItem.archiveID = ZU.xpathText(doc, metaXPath("technical_report_number"));
+	}
+	else {
+		newItem.reportNumber = ZU.xpathText(doc, metaXPath("technical_report_number"));
+	}
+	
+	var authors = ZU.xpath(doc, metaXPath("author"));
+	for (let i = 0; i < authors.length; i++) {
+		newItem.creators.push(ZU.cleanAuthor(authors[i].textContent, "author"));
+	}
+	
+	// Keywords and abstract are not in the metadata; scrape from webpage
+	var keywords = ZU.xpath(doc, "id('box')//a[contains(@href,'keyword')]");
+	for (let i = 0; i < keywords.length; i++) {
+		newItem.tags[i] = keywords[i].textContent;
 	}
 
-
-	
-	var keywordsXPath = "id('box')//a[contains(@href,'keyword')]";
-	var keywords = doc.evaluate(keywordsXPath, doc, null, XPathResult.ANY_TYPE, null);
-	var nextKeyword;
-	var i = 0;
-	while (nextKeyword = keywords.iterateNext()) {
-		newItem.tags[i++] = nextKeyword.textContent;
-	}
-
-
-
-	var abstractXPath = "id('box')/text()";
-	var abstractLines = doc.evaluate(abstractXPath, doc, null, XPathResult.ANY_TYPE, null);
+	var abstractLines = ZU.xpath(doc, "id('box')/p");
 	newItem.abstractNote = "";
-	var nextLine;
-	while (nextLine = abstractLines.iterateNext()) {
-		newItem.abstractNote += nextLine.textContent;
+	for (let i = 0; i < abstractLines.length; i++) {
+		newItem.abstractNote += abstractLines[i].textContent;
 	}
-
-
 
 	newItem.attachments = [
-		{url:url, title:"ECCC Snapshot", mimeType:"text/html"},
-		{url:url+"download", title:"ECCC Full Text PDF", mimeType:"application/pdf"}
+		{ url: url, title: "ECCC Snapshot", mimeType: "text/html" },
+		{ url: url + "download", title: "ECCC Full Text PDF", mimeType: "application/pdf" }
 	];
 
 	newItem.complete();
 }
 
 function doWeb(doc, url) {
-	var articles = new Array();
-	var items = new Object();
-	var nextTitle;
+	var articles = [];
+	var items = {};
 
 	if (detectWeb(doc, url) == "multiple") {
 		var titleXPath = "//a[starts-with(@href,'/report/')]/h4";
 		var linkXPath = "//a[starts-with(@href,'/report/')][h4]";
 
-		var titles = doc.evaluate(titleXPath, doc, null, XPathResult.ANY_TYPE, null);
-		var links  = doc.evaluate(linkXPath,  doc, null, XPathResult.ANY_TYPE, null);
-		while (nextTitle = titles.iterateNext()) {
-			nextLink = links.iterateNext();
-			items[nextLink.href] = nextTitle.textContent;
+		var titles = ZU.xpath(doc, titleXPath);
+		var links = ZU.xpath(doc, linkXPath);
+		for (let i = 0; i < titles.length; i++) {
+			items[links[i].href] = titles[i].textContent;
 		}
 		Zotero.selectItems(items, function (items) {
 			if (!items) {
@@ -99,10 +126,12 @@ function doWeb(doc, url) {
 			}
 			ZU.processDocuments(articles, scrape);
 		});
-	} else {
-		scrape(doc, url)
+	}
+	else {
+		scrape(doc, url);
 	}
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
@@ -110,7 +139,8 @@ var testCases = [
 		"url": "https://eccc.weizmann.ac.il/report/2006/067/",
 		"items": [
 			{
-				"itemType": "report",
+				"itemType": "preprint",
+				"title": "On the Impact of Combinatorial Structure on Congestion Games",
 				"creators": [
 					{
 						"firstName": "Heiner",
@@ -128,33 +158,37 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"notes": [],
-				"tags": [
-					"Combinatorial Structure",
-					"Congestion Games",
-					"Convergence Time",
-					"PLS-Completeness"
-				],
-				"seeAlso": [],
+				"date": "2006/5/28",
+				"abstractNote": "We study the impact of combinatorial structure in congestion games on the complexity of computing pure Nash equilibria and the convergence time of best response sequences.  In particular, we investigate which properties of the strategy spaces of individual players ensure a polynomial convergence time. We show, if the strategy space of each player consists of the bases of a matroid over the set of resources, then the lengths of all best response sequences are polynomially bounded in the number of players and resources. We can also prove that this result is tight, that is, the matroid property is a necessary and sufficient condition on the players' strategy spaces for guaranteeing polynomial time convergence to a Nash equilibrium. In addition, we present an approach that enables us to devise hardness proofs for various kinds of combinatorial games, including first results about the hardness of market sharing games and congestion games for overlay network design. Our approach also yields a short proof for the PLS-completeness of network congestion games.",
+				"archiveID": "TR06-067",
+				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"url": "https://eccc.weizmann.ac.il/report/2006/067/",
 				"attachments": [
 					{
-						"url": "https://eccc.weizmann.ac.il/report/2006/067/",
 						"title": "ECCC Snapshot",
 						"mimeType": "text/html"
 					},
 					{
-						"url": "https://eccc.weizmann.ac.il/report/2006/067/download",
 						"title": "ECCC Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
-				"date": "2006",
-				"reportNumber": "067",
-				"url": "https://eccc.weizmann.ac.il/report/2006/067/",
-				"title": "On the Impact of Combinatorial Structure on Congestion Games",
-				"abstractNote": "",
-				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
-				"accessDate": "CURRENT_TIMESTAMP"
+				"tags": [
+					{
+						"tag": "Combinatorial Structure"
+					},
+					{
+						"tag": "Congestion Games"
+					},
+					{
+						"tag": "Convergence Time"
+					},
+					{
+						"tag": "PLS-Completeness"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	},
@@ -162,6 +196,85 @@ var testCases = [
 		"type": "web",
 		"url": "https://eccc.weizmann.ac.il/keyword/13486/",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://eccc.weizmann.ac.il/report/2023/078/",
+		"items": [
+			{
+				"itemType": "preprint",
+				"title": "Toward Better Depth Lower Bounds: A KRW-like theorem for Strong Composition",
+				"creators": [
+					{
+						"firstName": "Or",
+						"lastName": "Meir",
+						"creatorType": "author"
+					}
+				],
+				"date": "2023/5/30",
+				"abstractNote": "One of the major open problems in complexity theory is proving super-logarithmic lower bounds on the depth of circuits (i.e., $\\mathbf{P}\\not\\subseteq \\mathbf{NC}^{1}$). Karchmer, Raz, and Wigderson (Computational Complexity 5(3/4), 1995) suggested to approach this problem by proving that depth complexity of a composition of functions $f \\diamond g$ is roughly the sum of the depth complexities of $f$ and $g$. They showed that the validity of this conjecture would imply that $\\mathbf{P}\\not\\subseteq\\mathbf{NC}^{1}$.The intuition that underlies the KRW conjecture is that the composition $f \\diamond g$ should behave like a \"direct-sum problem\", in a certain sense, and therefore the depth complexity of $f \\diamond g$ should be the sum of the individual depth complexities. Nevertheless, there are two obstacles toward turning this intuition into a proof: first, we do not know how to prove that $f \\diamond g$ must behave like a direct-sum problem; second, we do not know how to prove that the complexity of the latter direct-sum problem is indeed the sum of the individual complexities.In this work, we focus on the second obstacle. To this end, we study a notion called ``strong composition'', which is the same as $f \\diamond g$ except that it is forced to behave like a direct-sum problem. We prove a variant of the KRW conjecture for strong composition, thus overcoming the above second obstacle. This result demonstrates that the first obstacle above is the crucial barrier toward resolving the KRW conjecture. Along the way, we develop some general techniques that might be of independent interest.",
+				"archiveID": "TR23-078",
+				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"shortTitle": "Toward Better Depth Lower Bounds",
+				"url": "https://eccc.weizmann.ac.il/report/2023/078/",
+				"attachments": [
+					{
+						"title": "ECCC Snapshot",
+						"mimeType": "text/html"
+					},
+					{
+						"title": "ECCC Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Circuit Complexity Lower Bounds"
+					},
+					{
+						"tag": "Depth Lower bounds"
+					},
+					{
+						"tag": "KRW"
+					},
+					{
+						"tag": "KRW composition conjecture"
+					},
+					{
+						"tag": "KRW conjecture"
+					},
+					{
+						"tag": "KW games"
+					},
+					{
+						"tag": "KW relation"
+					},
+					{
+						"tag": "Karchmer Wigderson game"
+					},
+					{
+						"tag": "Karchmer-Raz-Wigderson conjecture"
+					},
+					{
+						"tag": "Karchmer-Wigderson games"
+					},
+					{
+						"tag": "circuit lower bounds"
+					},
+					{
+						"tag": "formula complexity"
+					},
+					{
+						"tag": "formula lower bound"
+					},
+					{
+						"tag": "formula lower bounds"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-05-31 20:54:48"
+	"lastUpdated": "2023-06-14 16:16:24"
 }
 
 /*
@@ -35,16 +35,17 @@
 	***** END LICENSE BLOCK *****
 */
 
+const preprintType = ZU.fieldIsValidForType('title', 'preprint')
+	? 'preprint'
+	: 'report';
+
 function detectWeb(doc, url) {
 	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword)\//;
 	if (multipleRe.test(url)) {
 		return "multiple";
 	}
-	else if (ZU.fieldIsValidForType('title', 'preprint')) {
-		return "preprint";
-	}
 	else {
-		return "report";
+		return preprintType;
 	}
 }
 
@@ -54,17 +55,7 @@ function metaXPath(name) {
 }
 
 function scrape(doc) {
-	var hasPreprint;
-	if (ZU.fieldIsValidForType('title', 'preprint')) {
-		hasPreprint = true;
-	}
-	var newItem;
-	if (hasPreprint) {
-		newItem = new Zotero.Item("preprint");
-	}
-	else {
-		newItem = new Zotero.Item("report");
-	}
+	newItem = new Zotero.Item(preprintType);
 
 	var url = doc.location.href;
 
@@ -72,7 +63,7 @@ function scrape(doc) {
 	newItem.title = ZU.xpathText(doc, metaXPath("title"));
 	newItem.date = ZU.xpathText(doc, metaXPath("publication_date"));
 	
-	if (hasPreprint) {
+	if (preprintType == 'preprint') {
 		newItem.archiveID = ZU.xpathText(doc, metaXPath("technical_report_number"));
 		newItem.publisher = "Electronic Colloquium on Computational Complexity";
 	}

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -51,6 +51,20 @@ function detectWeb(doc, url) {
 	else return false;
 }
 
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href^="/report/"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = text(row, "h4");
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
 async function scrape(doc, url = doc.location.href) {
 	let translator = Zotero.loadTranslator('web');
 	// Embedded Metadata

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -2,14 +2,14 @@
 	"translatorID": "09a9599e-c20e-a405-d10d-35ad4130a426",
 	"label": "Electronic Colloquium on Computational Complexity",
 	"creator": "Jonas Schrieb and Morgan Shirley",
-	"target": "^https?://eccc\\.weizmann\\.ac\\.il/(title|year|keyword|report)",
+	"target": "^https?://eccc\\.weizmann\\.ac\\.il/(title|year|keyword|report|search)",
 	"minVersion": "1.0.0b3.r1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-02 16:03:19"
+	"lastUpdated": "2023-08-02 16:18:22"
 }
 
 /*
@@ -40,7 +40,7 @@ const preprintType = ZU.fieldIsValidForType('title', 'preprint')
 	: 'report';
 
 function detectWeb(doc, url) {
-	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword)\//;
+	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword|search)\//;
 	var singleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/report\//;
 	if (multipleRe.test(url)) {
 		return "multiple";
@@ -219,6 +219,12 @@ var testCases = [
 				"seeAlso": []
 			}
 		]
+	},
+	{
+		"type": "web",
+		"url": "https://eccc.weizmann.ac.il/search/?search=combinatorial",
+		"detectedItemType": "multiple",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-02 16:48:21"
+	"lastUpdated": "2023-08-02 17:34:54"
 }
 
 /*
@@ -69,10 +69,7 @@ async function scrape(doc, url = doc.location.href) {
 		var abstractParagraphs = ZU.xpath(doc, "id('box')/p");
 		item.abstractNote = "";
 		for (let i = 0; i < abstractParagraphs.length; i++) {
-			var abstractLines = abstractParagraphs[i].innerHTML.split("<br>");
-			for (let j = 0; j < abstractLines.length; j++) {
-				item.abstractNote += abstractLines[j] + "\n";
-			}
+			item.abstractNote += abstractParagraphs[i].innerText + "\n";
 		}
 		item.complete();
 	});
@@ -189,7 +186,7 @@ var testCases = [
 					}
 				],
 				"date": "2007/11/12",
-				"abstractNote": "The sign-rank of a real matrix M is the least rank\nof a matrix R in which every entry has the same sign as the\ncorresponding entry of M. We determine the sign-rank of every\nmatrix of the form M=[ D(|x AND y|) ]_{x,y}, where\nD:{0,1,...,n}-&gt;{-1,+1} is given and x and y range over {0,1}^n.\nSpecifically, we prove that the sign-rank of M equals \n2^{\\tilde Theta(k)}, where k is the number of times D changes\nsign in {0,1,...,n}.\n         Put differently, we prove an optimal lower bound\non the unbounded-error communication complexity of every\nsymmetric function, i.e., a function of the form \nf(x,y)=D(|x AND y|) for some D. The unbounded-error model is\nessentially the most powerful of all models of communication\n(both classical and quantum), and proving lower bounds in it\nis a substantial challenge. The only previous nontrivial lower\nbounds for this model appear in the groundbreaking work of\nForster (2001) and its extensions.  As corollaries to our\nresult, we give new lower bounds for PAC learning and for\nthreshold-of-majority circuits.\n         The technical content of our proof is diverse and\nfeatures random walks on (Z_2)^n, discrete approximation theory,\nthe Fourier transform on (Z_2)^n, linear-programming duality,\nand matrix analysis.",
+				"abstractNote": "The sign-rank of a real matrix M is the least rank\nof a matrix R in which every entry has the same sign as the\ncorresponding entry of M. We determine the sign-rank of every\nmatrix of the form M=[ D(|x AND y|) ]_{x,y}, where\nD:{0,1,...,n}->{-1,+1} is given and x and y range over {0,1}^n.\nSpecifically, we prove that the sign-rank of M equals\n2^{\\tilde Theta(k)}, where k is the number of times D changes\nsign in {0,1,...,n}.\nPut differently, we prove an optimal lower bound\non the unbounded-error communication complexity of every\nsymmetric function, i.e., a function of the form\nf(x,y)=D(|x AND y|) for some D. The unbounded-error model is\nessentially the most powerful of all models of communication\n(both classical and quantum), and proving lower bounds in it\nis a substantial challenge. The only previous nontrivial lower\nbounds for this model appear in the groundbreaking work of\nForster (2001) and its extensions. As corollaries to our\nresult, we give new lower bounds for PAC learning and for\nthreshold-of-majority circuits.\nThe technical content of our proof is diverse and\nfeatures random walks on (Z_2)^n, discrete approximation theory,\nthe Fourier transform on (Z_2)^n, linear-programming duality,\nand matrix analysis.",
 				"archiveID": "TR07-112",
 				"language": "en",
 				"libraryCatalog": "eccc.weizmann.ac.il",

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-11 17:11:06"
+	"lastUpdated": "2023-08-14 06:03:23"
 }
 
 /*
@@ -166,12 +166,6 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://eccc.weizmann.ac.il/keyword/13486/",
-		"detectedItemType": "multiple",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
 		"url": "https://eccc.weizmann.ac.il/report/2007/112/",
 		"detectedItemType": "preprint",
 		"items": [
@@ -225,6 +219,12 @@ var testCases = [
 		"url": "https://eccc.weizmann.ac.il/search/?search=asdf",
 		"detectedItemType": false,
 		"items": []
+	},
+	{
+		"type": "web",
+		"url": "https://eccc.weizmann.ac.il/keyword/14114/",
+		"detectedItemType": "multiple",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-14 16:16:24"
+	"lastUpdated": "2023-06-14 17:00:22"
 }
 
 /*
@@ -49,51 +49,33 @@ function detectWeb(doc, url) {
 	}
 }
 
-// Get a meta tag from the header
-function metaXPath(name) {
-	return `/html/head/meta[contains(@name,'citation_${name}')]/@content`;
-}
-
-function scrape(doc) {
-	newItem = new Zotero.Item(preprintType);
-
-	var url = doc.location.href;
-
-	newItem.url = url;
-	newItem.title = ZU.xpathText(doc, metaXPath("title"));
-	newItem.date = ZU.xpathText(doc, metaXPath("publication_date"));
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
 	
-	if (preprintType == 'preprint') {
-		newItem.archiveID = ZU.xpathText(doc, metaXPath("technical_report_number"));
-		newItem.publisher = "Electronic Colloquium on Computational Complexity";
-	}
-	else {
-		newItem.reportNumber = ZU.xpathText(doc, metaXPath("technical_report_number"));
-	}
-	
-	var authors = ZU.xpath(doc, metaXPath("author"));
-	for (let i = 0; i < authors.length; i++) {
-		newItem.creators.push(ZU.cleanAuthor(authors[i].textContent, "author"));
-	}
-	
-	// Keywords and abstract are not in the metadata; scrape from webpage
-	var keywords = ZU.xpath(doc, "id('box')//a[contains(@href,'keyword')]");
-	for (let i = 0; i < keywords.length; i++) {
-		newItem.tags[i] = keywords[i].textContent;
-	}
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.publisher = "Electronic Colloquium on Computational Complexity";
 
-	var abstractLines = ZU.xpath(doc, "id('box')/p");
-	newItem.abstractNote = "";
-	for (let i = 0; i < abstractLines.length; i++) {
-		newItem.abstractNote += abstractLines[i].textContent;
-	}
+		// Keywords and abstract are not in the metadata; scrape from webpage
+		var keywords = ZU.xpath(doc, "id('box')//a[contains(@href,'keyword')]");
+		for (let i = 0; i < keywords.length; i++) {
+			item.tags[i] = keywords[i].textContent;
+		}
 
-	newItem.attachments = [
-		{ url: url, title: "ECCC Snapshot", mimeType: "text/html" },
-		{ url: url + "download", title: "ECCC Full Text PDF", mimeType: "application/pdf" }
-	];
+		var abstractLines = ZU.xpath(doc, "id('box')/p");
+		item.abstractNote = "";
+		for (let i = 0; i < abstractLines.length; i++) {
+			item.abstractNote += abstractLines[i].textContent;
+		}
+		item.complete();
+	});
 
-	newItem.complete();
+	await translator.getTranslatorObject(function (trans) {
+		trans.itemType = preprintType;
+		trans.doWeb(doc, url);
+	});
 }
 
 function doWeb(doc, url) {
@@ -129,6 +111,7 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://eccc.weizmann.ac.il/report/2006/067/",
+		"detectedItemType": "preprint",
 		"items": [
 			{
 				"itemType": "preprint",
@@ -153,16 +136,13 @@ var testCases = [
 				"date": "2006/5/28",
 				"abstractNote": "We study the impact of combinatorial structure in congestion games on the complexity of computing pure Nash equilibria and the convergence time of best response sequences.  In particular, we investigate which properties of the strategy spaces of individual players ensure a polynomial convergence time. We show, if the strategy space of each player consists of the bases of a matroid over the set of resources, then the lengths of all best response sequences are polynomially bounded in the number of players and resources. We can also prove that this result is tight, that is, the matroid property is a necessary and sufficient condition on the players' strategy spaces for guaranteeing polynomial time convergence to a Nash equilibrium. In addition, we present an approach that enables us to devise hardness proofs for various kinds of combinatorial games, including first results about the hardness of market sharing games and congestion games for overlay network design. Our approach also yields a short proof for the PLS-completeness of network congestion games.",
 				"archiveID": "TR06-067",
-				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"language": "en",
+				"libraryCatalog": "eccc.weizmann.ac.il",
 				"repository": "Electronic Colloquium on Computational Complexity",
 				"url": "https://eccc.weizmann.ac.il/report/2006/067/",
 				"attachments": [
 					{
-						"title": "ECCC Snapshot",
-						"mimeType": "text/html"
-					},
-					{
-						"title": "ECCC Full Text PDF",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],
@@ -188,11 +168,13 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://eccc.weizmann.ac.il/keyword/13486/",
+		"detectedItemType": "multiple",
 		"items": "multiple"
 	},
 	{
 		"type": "web",
 		"url": "https://eccc.weizmann.ac.il/report/2023/078/",
+		"detectedItemType": "preprint",
 		"items": [
 			{
 				"itemType": "preprint",
@@ -207,17 +189,14 @@ var testCases = [
 				"date": "2023/5/30",
 				"abstractNote": "One of the major open problems in complexity theory is proving super-logarithmic lower bounds on the depth of circuits (i.e., $\\mathbf{P}\\not\\subseteq \\mathbf{NC}^{1}$). Karchmer, Raz, and Wigderson (Computational Complexity 5(3/4), 1995) suggested to approach this problem by proving that depth complexity of a composition of functions $f \\diamond g$ is roughly the sum of the depth complexities of $f$ and $g$. They showed that the validity of this conjecture would imply that $\\mathbf{P}\\not\\subseteq\\mathbf{NC}^{1}$.The intuition that underlies the KRW conjecture is that the composition $f \\diamond g$ should behave like a \"direct-sum problem\", in a certain sense, and therefore the depth complexity of $f \\diamond g$ should be the sum of the individual depth complexities. Nevertheless, there are two obstacles toward turning this intuition into a proof: first, we do not know how to prove that $f \\diamond g$ must behave like a direct-sum problem; second, we do not know how to prove that the complexity of the latter direct-sum problem is indeed the sum of the individual complexities.In this work, we focus on the second obstacle. To this end, we study a notion called ``strong composition'', which is the same as $f \\diamond g$ except that it is forced to behave like a direct-sum problem. We prove a variant of the KRW conjecture for strong composition, thus overcoming the above second obstacle. This result demonstrates that the first obstacle above is the crucial barrier toward resolving the KRW conjecture. Along the way, we develop some general techniques that might be of independent interest.",
 				"archiveID": "TR23-078",
-				"libraryCatalog": "Electronic Colloquium on Computational Complexity",
+				"language": "en",
+				"libraryCatalog": "eccc.weizmann.ac.il",
 				"repository": "Electronic Colloquium on Computational Complexity",
 				"shortTitle": "Toward Better Depth Lower Bounds",
 				"url": "https://eccc.weizmann.ac.il/report/2023/078/",
 				"attachments": [
 					{
-						"title": "ECCC Snapshot",
-						"mimeType": "text/html"
-					},
-					{
-						"title": "ECCC Full Text PDF",
+						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
 				],

--- a/Electronic Colloquium on Computational Complexity.js
+++ b/Electronic Colloquium on Computational Complexity.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-14 17:00:22"
+	"lastUpdated": "2023-08-02 15:31:56"
 }
 
 /*
@@ -41,12 +41,14 @@ const preprintType = ZU.fieldIsValidForType('title', 'preprint')
 
 function detectWeb(doc, url) {
 	var multipleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/(title|year|keyword)\//;
+	var singleRe = /^https?:\/\/eccc\.weizmann\.ac\.il\/report\//
 	if (multipleRe.test(url)) {
 		return "multiple";
 	}
-	else {
+	else if (singleRe.test(url)) {
 		return preprintType;
 	}
+	else return false;
 }
 
 async function scrape(doc, url = doc.location.href) {


### PR DESCRIPTION
I've updated the translator for the Electronic Colloquium on Computational Complexity. The changes:

- Previously, all of the metadata was scraped from the text on the webpage. Some of the data is available in meta tags, and the translator now gets what it can from there.
- Similarly to the Arxiv.org translator, we now use the preprint type if available and fall back to the report type otherwise.
- Abstract scraping was broken. This is now fixed.
- The tests are updated, including a new test to ensure that abstracts with multiple paragraphs work with the new scraping code.
- Made some style fixes for compliance with current guidelines.

This is my first PR here; please let me know if I've done something incorrectly!