### PR TITLE
Google Scholar: Add delays between consecutive network requests.

### DIFF
--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -145,6 +145,12 @@ async function scrape(doc, url, type) {
 		scrapeCase(doc, url);
 	}
 	else {
+		// This kind of stand-alone article-info page can be navigated to from
+		// a profile page. The page contains links to versions of the article,
+		// and the first one is (likely?) the "canonical" version (of record,
+		// if possible). The Google Scholar id for that version can be
+		// extracted by examining part of the URL of that item's "Related
+		// articles" link.
 		var related = ZU.xpathText(doc, '//a[contains(@href, "q=related:")]/@href');
 		if (!related) {
 			throw new Error("Could not locate related URL");

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-27 06:36:51"
+	"lastUpdated": "2023-06-29 23:52:53"
 }
 
 /*
@@ -1204,7 +1204,7 @@ function addAttachment(item, row) {
 	// attach linked document as attachment if available
 	if (row.attachmentLink) {
 		let	attachment = {
-			title: "Available Version",
+			title: "Available Version via Google Scholar",
 			url: row.attachmentLink,
 		};
 		let mimeType = MIME_TYPES[row.attachmentType];
@@ -1528,7 +1528,7 @@ var testCases = [
 				"url": "https://www.igi-global.com/chapter/linkeddata-story-far/55046",
 				"attachments": [
 					{
-						"title": "Available Version",
+						"title": "Available Version via Google Scholar",
 						"mimeType": "application/pdf"
 					}
 				],

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -616,7 +616,7 @@ function ExternalSearch(searchKey, translatorUUID) {
  * @returns {Promise<Z.Item[]>}
  * TODO: post-processing (for attachment, etc.)
  */
-ExternalSearch.prototype.translate = async function (identifier) {
+ExternalSearch.prototype.translate = function (identifier) {
 	this.translator.setSearch({ [this.key]: identifier });
 
 	Z.debug(`Processing external id ${identifier} (${this.key})`);
@@ -664,6 +664,7 @@ function extractArXiv(row) {
 		return null;
 	}
 	let path = decodeURIComponent(urlObj.pathname);
+	// TODO: additional patterns to "/abs/..."
 	let m = path.match(/\/abs\/([a-z-]+\/\d+|\d+\.\d+)$/);
 	return m && m[1];
 }
@@ -1172,7 +1173,7 @@ async function processCitePage(citeURL, row, referrer) {
 
 		item.complete();
 	});
-	translator.translate();
+	return translator.translate();
 }
 
 /*

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -648,7 +648,7 @@ function extractDOI(row) {
 	// end, e.g. the link in the header title of
 	// https://scholar.google.com/citations?view_op=view_citation&hl=en&user=Cz6X6UYAAAAJ&citation_for_view=Cz6X6UYAAAAJ:zYLM7Y9cAGgC
 	// https://www.nomos-elibrary.de/10.5771/9783845229614-153.pdf
-	let m = path.match(/(10\.\d{4,}\/.+?)(?:\.(?:pdf|htm|html|epub))?$/);
+	let m = path.match(/(10\.\d{4,}\/.+?)(?:\.(?:pdf|htm|html|xhtml|epub|xml))?$/i);
 	return m && m[1];
 }
 
@@ -660,17 +660,16 @@ function extractDOI(row) {
  */
 function extractArXiv(row) {
 	let urlObj = new URL(row.directLink);
-	if (urlObj.hostname !== "arxiv.org") {
+	if (urlObj.hostname.toLowerCase() !== "arxiv.org") {
 		return null;
 	}
 	let path = decodeURIComponent(urlObj.pathname);
-	// TODO: additional patterns to "/abs/..."
-	let m = path.match(/\/abs\/([a-z-]+\/\d+|\d+\.\d+)$/);
+	let m = path.match(/\/\w+\/([a-z-]+\/\d+|\d+\.\d+)$/i);
 	return m && m[1];
 }
 
 // Translation pipeline utilities.
-// The translations are attempted in the order of DOI -> ArXi -> GS native.
+// The translations are attempted in the order of DOI -> ArXiv -> GS native.
 // Each pipeline item will execute the translation and consume the row object
 // if it succeeds, or pass it to the next one if it fails. The pipelines can be
 // composed, building up a chain.

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-13 22:40:37"
+	"lastUpdated": "2023-06-14 00:06:19"
 }
 
 /*
@@ -1114,6 +1114,11 @@ async function processCitePage(citeURL, row, referrer) {
 					item.patentNumber = m[2];
 				}
 			}
+		}
+
+		// Add the title link as the url of the item.
+		if (row.directLink) {
+			item.url = row.directLink;
 		}
 
 		// fix titles in all upper case, e.g. some patents in search results

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -106,7 +106,7 @@ function getProfileResults(doc, checkOnly) {
 
 async function doWeb(doc, url) {
 	var type = detectWeb(doc, url);
-	if (type === "multiple") {
+	if (type == "multiple") {
 		if (getSearchResults(doc, true/* checkOnly */)) {
 			let items = await Z.selectItems(getSearchResults(doc, false/* checkOnly */));
 			if (!items) {
@@ -141,7 +141,7 @@ async function doWeb(doc, url) {
 
 // Scrape one GS entry by its URL.
 async function scrape(doc, url, type) {
-	if (type && type === "case") {
+	if (type && type == "case") {
 		scrapeCase(doc, url);
 	}
 	else {
@@ -300,7 +300,7 @@ async function scrapeIds(doc, ids) {
 	for (let i = 0; i < ids.length; i++) {
 		// We need here 'let' to access ids[i] later in the nested functions
 		let context = doc.querySelector('.gs_r[data-cid="' + ids[i] + '"]');
-		if (!context && ids.length === 1) {
+		if (!context && ids.length == 1) {
 			context = doc;
 		}
 
@@ -308,7 +308,7 @@ async function scrapeIds(doc, ids) {
 		// For 'My Library' we check the search field at the top
 		// and then in these cases change the citeUrl accordingly.
 		let scilib = attr(doc, '#gs_hdr_frm input[name="scilib"]', 'value');
-		if (scilib && scilib === 1) {
+		if (scilib && scilib == 1) {
 			citeUrl = '/scholar?scila=' + ids[i] + '&output=cite&scirp=0&hl=en';
 		}
 

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-13 09:38:47"
+	"lastUpdated": "2023-06-13 22:40:37"
 }
 
 /*
@@ -189,7 +189,7 @@ async function scrape(doc, url, type) {
  * @returns {URL}
  */
 function getEmulatedSearchURL(pfName) {
-	return new URL(`/scholar?hl=${GS_CONFIG.lang}&as_sdt=0%2C5&q=${encodeURIComponent(pfName).replace("%20", "+")}&btnG=`, GS_CONFIG.baseURL);
+	return new URL(`/scholar?hl=${GS_CONFIG.lang}&as_sdt=0%2C5&q=${encodeURIComponent(pfName).replace(/%20/g, "+")}&btnG=`, GS_CONFIG.baseURL);
 }
 
 /**

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-12 10:11:38"
+	"lastUpdated": "2023-06-13 09:38:47"
 }
 
 /*
@@ -1480,7 +1480,16 @@ var testCases = [
 				"pages": "205–227",
 				"publisher": "IGI global",
 				"shortTitle": "Linked data",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Full Text",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -1000,8 +1000,7 @@ function makeGSPipeline(searchReferrer, pause, restOnLead = false) {
  * @returns {AsyncFunction} Multiscraper function that operates on the doc
  * being scraped
  */
-function makeGSScraper(inputStrings, rowGenerator, referrerURL,
-	expensive = false) {
+function makeGSScraper(inputStrings, rowGenerator, referrerURL, expensive = false) {
 	return async function (doc) {
 		let rows = rowGenerator(inputStrings, doc);
 
@@ -1101,7 +1100,7 @@ async function processCitePage(citeURL, row, referrer) {
 	// Note that the page at citeURL has no doctype and is not a complete HTML
 	// document. The browser can parse it in quirks mode but ZU.requestDocument
 	// has trouble with it.
-	const citePage = await ZU.requestText(citeURL, requestOptions);
+	const citePage = await requestText(citeURL, requestOptions);
 
 	let m = citePage.match(/href="((https?:\/\/[a-z.]*)?\/scholar.bib\?[^"]+)/);
 	if (!m) {
@@ -1129,7 +1128,7 @@ async function processCitePage(citeURL, row, referrer) {
 	// set to the origin (e.g. https://scholar.google.com/), imitating
 	// strict-origin-when-cross-origin
 	requestOptions.headers.Referer = GS_CONFIG.baseURL + "/";
-	const bibTeXBody = await ZU.requestText(bibTeXURL, requestOptions);
+	const bibTeXBody = await requestText(bibTeXURL, requestOptions);
 
 	let translator = Z.loadTranslator("import");
 	translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4"); // BibTeX

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-15 00:44:22"
+	"lastUpdated": "2023-06-27 06:36:51"
 }
 
 /*
@@ -1204,7 +1204,7 @@ function addAttachment(item, row) {
 	// attach linked document as attachment if available
 	if (row.attachmentLink) {
 		let	attachment = {
-			title: "Full Text (via Google Scholar)",
+			title: "Available Version",
 			url: row.attachmentLink,
 		};
 		let mimeType = MIME_TYPES[row.attachmentType];
@@ -1212,15 +1212,6 @@ function addAttachment(item, row) {
 			attachment.mimeType = mimeType;
 		}
 		item.attachments.push(attachment);
-	}
-
-	// Attach linked page as snapshot if available
-	if (row.directLink && row.directLink !== row.attachmentLink) {
-		item.attachments.push({
-			url: row.directLink,
-			title: "Snapshot",
-			mimeType: "text/html"
-		});
 	}
 }
 
@@ -1537,12 +1528,8 @@ var testCases = [
 				"url": "https://www.igi-global.com/chapter/linkeddata-story-far/55046",
 				"attachments": [
 					{
-						"title": "Full Text (via Google Scholar)",
+						"title": "Available Version",
 						"mimeType": "application/pdf"
-					},
-					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
 					}
 				],
 				"tags": [],

--- a/Google Scholar.js
+++ b/Google Scholar.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-29 23:52:53"
+	"lastUpdated": "2023-06-30 02:41:02"
 }
 
 /*
@@ -681,7 +681,7 @@ function extractDOI(row) {
 	// end, e.g. the link in the header title of
 	// https://scholar.google.com/citations?view_op=view_citation&hl=en&user=Cz6X6UYAAAAJ&citation_for_view=Cz6X6UYAAAAJ:zYLM7Y9cAGgC
 	// https://www.nomos-elibrary.de/10.5771/9783845229614-153.pdf
-	let m = path.match(/(10\.\d{4,}\/.+?)(?:\.(?:pdf|htm|html|xhtml|epub|xml))?$/i);
+	let m = path.match(/(10\.\d{4,}\/.+?)(?:[./](?:pdf|htm|html|xhtml|epub|xml))?$/i);
 	return m && m[1];
 }
 
@@ -1571,6 +1571,45 @@ var testCases = [
 					{
 						"title": "Google Scholar Judgement",
 						"type": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=RjsFKYEAAAAJ&cstart=20&pagesize=80&citation_for_view=RjsFKYEAAAAJ:5nxA0vEk-isC",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "The Weakness of Power and the Power of Weakness: The Ethics of War in a Time of Terror",
+				"creators": [
+					{
+						"creatorType": "author",
+						"firstName": "Michael",
+						"lastName": "Northcott"
+					}
+				],
+				"date": "04/2007",
+				"DOI": "10.1177/0953946806075493",
+				"ISSN": "0953-9468, 1745-5235",
+				"abstractNote": "In 2002 a significant number of American theologians declared that the ‘war on terror’ was a just war. But the indiscriminate strategies and munitions technologies deployed in the invasion and occupation of Iraq fall short of the just war principles of non-combatant immunity, and proportionate response. The just war tradition is one of Christendom's most enduring legacies to the law of nations. Its practice implies a standard of virtue in war that is undermined by the indiscriminate effects of many modern weapons and by the deliberate targeting of civilian infrastructure. The violent power represented by the technology of what the Vatican calls ‘total war’has occasioned a significant shift in Catholic social teaching on just war since the Second World War. Total war generates an asymmetry of weakness in those subjected to these techniques of terror, and this has only strengthened the violence of the Islamist struggle against the West. But those who draw inspiration and legitimacy from this weakness in their struggle with the West also reject virtue in war. In a time of terror the theological vocation is to speak peace and to recall the terms in which the peace of God was achieved by way of the cross.",
+				"issue": "1",
+				"journalAbbreviation": "Studies in Christian Ethics",
+				"language": "en",
+				"libraryCatalog": "DOI.org (Crossref) via Google Scholar",
+				"pages": "88-101",
+				"publicationTitle": "Studies in Christian Ethics",
+				"shortTitle": "The Weakness of Power and the Power of Weakness",
+				"url": "http://journals.sagepub.com/doi/10.1177/0953946806075493",
+				"volume": "20",
+				"attachments": [
+					{
+						"title": "Available Version via Google Scholar",
+						"mimeType": "application/pdf"
 					}
 				],
 				"tags": [],


### PR DESCRIPTION
When there are multiple items to be translated, the previous implementation fires network requests to Google Scholar server in rapid succession. This increases the likelihood of being rate-limited or denied by the server.

To fix this, an artificial delay of at least 500ms is added between successive network requests.

In addition, calls to the callback-based `doGet()` are replaced with promise-based asynchronous calls.

A few stylistic fixes (such as `===` vs. `==`) are also included.

Resolves #3037.