### PR TITLE
Web of Science Tagged: More robust against trailing space characters.

### DIFF
--- a/Web of Science Tagged.js
+++ b/Web of Science Tagged.js
@@ -8,7 +8,7 @@
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2023-06-15 10:22:48"
+	"lastUpdated": "2023-06-15 10:54:59"
 }
 
 /*
@@ -228,12 +228,12 @@ function doImport(text) {
 	var rawLine;
 	while ((rawLine = Zotero.read()) !== false) {    // until EOF
 		//Z.debug("line: " + rawLine);
-		let split = rawLine.match(/^([A-Z0-9]{2})\s(?:([^\n]*))?/);
-		// EF is equivalent to the end of file.
 		if (/^EF\s*/.test(rawLine)) {
 			Z.debug("Encountered EF (equivalent to End of File)");
 			break;
 		}
+
+		let split = rawLine.match(/^([A-Z0-9]{2})\s(?:([^\n]*))?/);
 		// Force a match for ER
 		if (rawLine == "ER") split = ["","ER",""];
 		if (split) {


### PR DESCRIPTION
If there are trailing whitespace characters after the EF "tag", the script fails because it interprets "EF" as an unknown tag rather than end of file.

This is fixed by interpreting EF as intended, see the table of export field tags at Clarivate:
https://webofscience.help.clarivate.com/en-us/Content/export-records.htm#mc-dropdown-body6dc16a03-4cb8-43e1-b72a-ff5a3197f8f0

Bug reported by gxy1932582, see
https://forums.zotero.org/discussion/comment/436794/#Comment_436794