### PR TITLE
Add translator for Dutch newspaper NRC

### DIFF
--- a/NRC.nl.js
+++ b/NRC.nl.js
@@ -2,14 +2,14 @@
 	"translatorID": "8e708ceb-ce42-446f-bffd-21e2bdeb0742",
 	"label": "NRC.nl",
 	"creator": "Martijn Staal",
-	"target": "^https?://www.nrc.nl",
+	"target": "^https?://www\\.nrc\\.nl",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-15 13:47:40"
+	"lastUpdated": "2023-06-17 08:54:24"
 }
 
 /*
@@ -39,32 +39,86 @@ function detectWeb(doc, url) {
 	if (url.includes('/nieuws/')) {
 		return "newspaperArticle";
 	}
+	else if (url.endsWith(".nl/") || url.endsWith(".nl") || url.includes("/index/") || url.includes("/search/")) {
+		return "multiple";
+	}
 
 	return false;
 }
 
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll("a.nmt-item__link");
+	var isSearchPage = false;
+
+	if (rows.length == 0) {
+		// We are probably not in an index page, but in a search results page.
+		rows = doc.querySelectorAll("div.search-results__item")
+		isSearchPage = true;
+	}
+
+	for (let row of rows) {
+		var href;
+		var title;
+		if (isSearchPage) {
+			href = row.getAttribute("data-article-url");
+			title = row.getAttribute("data-headline");
+		} else {
+			href = row.href;
+
+			if (row.textContent.includes(">")) {
+				title = ZU.trimInternal(row.textContent.split(">")[1]);
+			} else {
+				title = ZU.trimInternal(row.textContent);
+			}
+		}
+
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+
+	return found ? items : false;
+}
+
 function doWeb(doc, url) {
-	return scrape(doc, url)
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return true;
+			}
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrape);
+		});
+	} else {
+		return scrape(doc, url);
+	}
 }
 
 function scrape(doc, url) {
-	let item = new Zotero.Item("newspaperArticle");
+	var translator = Zotero.loadTranslator('web');
 
-	item.title = doc.querySelector("meta[property='og:title']").content
-	item.language = "nl"
-	item.url = doc.querySelector("meta[property='og:url']").content
-	item.abstractNote = doc.querySelector("meta[property='og:description']").content
-	item.rights = doc.querySelector("meta[name='dcterms.rights']").content
-	item.date = doc.querySelector("meta[property='og:url']").content.match(/\d\d\d\d\/\d\d\/\d\d/)[0].replace(/\//g, "-");
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
 
-	item.attachments.push({
-		title: "Snapshot",
-		url: item.url,
-		mimeType: 'text/html',
-		snapshot: true
-	})
+	translator.setHandler('itemDone', function(obj, item) {
+		item.language = "nl-NL";
+		authors = Array.from(doc.querySelectorAll("a[rel='author']")).map(a => a.textContent);
+		item.creators = authors.map(a => ZU.cleanAuthor(a, 'author', false));
 
-	item.complete();
+		item.complete();
+	});
+
+	translator.getTranslatorObject(function(trans) {
+		trans.itemType = "newspaperArticle";
+		trans.doWeb(doc, url);
+	});
 }
 
 /** BEGIN TEST CASES **/
@@ -77,18 +131,24 @@ var testCases = [
 			{
 				"itemType": "newspaperArticle",
 				"title": "Lot van natuurherstelwet Timmermans blijft erg onzeker na belangrijke stemming",
-				"creators": [],
+				"creators": [
+					{
+						"firstName": "Clara van de",
+						"lastName": "Wiel",
+						"creatorType": "author"
+					}
+				],
 				"date": "2023-06-15",
 				"abstractNote": "Natuurherstel: Een aanzienlijke groep in het Europees Parlement is bereid om natuurplannen van Frans Timmermans de nek om te draaien, zo bleek donderdag.",
-				"language": "nl",
-				"libraryCatalog": "NRC.nl",
+				"language": "nl-NL",
+				"libraryCatalog": "www.nrc.nl",
+				"publicationTitle": "NRC",
 				"rights": "Copyright Mediahuis NRC BV",
 				"url": "https://www.nrc.nl/nieuws/2023/06/15/lot-van-natuurherstelwet-timmermans-blijft-erg-onzeker-na-belangrijke-stemming-a4167267",
 				"attachments": [
 					{
 						"title": "Snapshot",
-						"mimeType": "text/html",
-						"snapshot": true
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -108,15 +168,15 @@ var testCases = [
 				"creators": [],
 				"date": "1987-06-13",
 				"abstractNote": "Door onze correspondent ROB MEINES BERLIJN, 13 juni - In zijn toespraak aan de Berlijnse Muur bij de Brandenburger Poort heeft president Ronald Reagan gisteren Sovjet-leider…",
-				"language": "nl",
-				"libraryCatalog": "NRC.nl",
+				"language": "nl-NL",
+				"libraryCatalog": "www.nrc.nl",
+				"publicationTitle": "NRC",
 				"rights": "Copyright Mediahuis NRC BV",
 				"url": "https://www.nrc.nl/nieuws/1987/06/13/reagan-vraagt-russen-de-muur-af-te-breken-kb_000035184-a3528803",
 				"attachments": [
 					{
 						"title": "Snapshot",
-						"mimeType": "text/html",
-						"snapshot": true
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -133,18 +193,24 @@ var testCases = [
 			{
 				"itemType": "newspaperArticle",
 				"title": "Column | Wikipedia wordt onbetrouwbaar. Alweer",
-				"creators": [],
+				"creators": [
+					{
+						"firstName": "Maxim",
+						"lastName": "Februari",
+						"creatorType": "author"
+					}
+				],
 				"date": "2022-12-03",
 				"abstractNote": "Column:Maxim Februari",
-				"language": "nl",
-				"libraryCatalog": "NRC.nl",
+				"language": "nl-NL",
+				"libraryCatalog": "www.nrc.nl",
+				"publicationTitle": "NRC",
 				"rights": "Copyright Mediahuis NRC BV",
 				"url": "https://www.nrc.nl/nieuws/2022/12/03/wikipedia-wordt-onbetrouwbaar-alweer-a4150299",
 				"attachments": [
 					{
 						"title": "Snapshot",
-						"mimeType": "text/html",
-						"snapshot": true
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],
@@ -152,6 +218,18 @@ var testCases = [
 				"seeAlso": []
 			}
 		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.nrc.nl/index/economie/",
+		"detectedItemType": "multiple",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.nrc.nl/index/economie/",
+		"detectedItemType": "multiple",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/

--- a/NRC.nl.js
+++ b/NRC.nl.js
@@ -39,7 +39,7 @@ function detectWeb(doc, url) {
 	if (url.includes('/nieuws/')) {
 		return "newspaperArticle";
 	}
-	else if (url.endsWith(".nl/") || url.endsWith(".nl") || url.includes("/index/") || url.includes("/search/")) {
+	else if ((url.endsWith(".nl/") || url.endsWith(".nl") || url.includes("/index/") || url.includes("/search/")) && getSearchResults(doc, true)) {
 		return "multiple";
 	}
 

--- a/NRC.nl.js
+++ b/NRC.nl.js
@@ -1,0 +1,157 @@
+{
+	"translatorID": "8e708ceb-ce42-446f-bffd-21e2bdeb0742",
+	"label": "NRC.nl",
+	"creator": "Martijn Staal",
+	"target": "^https?://www.nrc.nl",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-06-15 13:47:40"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2023 Martijn Staal
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	if (url.includes('/nieuws/')) {
+		return "newspaperArticle";
+	}
+
+	return false;
+}
+
+function doWeb(doc, url) {
+	return scrape(doc, url)
+}
+
+function scrape(doc, url) {
+	let item = new Zotero.Item("newspaperArticle");
+
+	item.title = doc.querySelector("meta[property='og:title']").content
+	item.language = "nl"
+	item.url = doc.querySelector("meta[property='og:url']").content
+	item.abstractNote = doc.querySelector("meta[property='og:description']").content
+	item.rights = doc.querySelector("meta[name='dcterms.rights']").content
+	item.date = doc.querySelector("meta[property='og:url']").content.match(/\d\d\d\d\/\d\d\/\d\d/)[0].replace(/\//g, "-");
+
+	item.attachments.push({
+		title: "Snapshot",
+		url: item.url,
+		mimeType: 'text/html',
+		snapshot: true
+	})
+
+	item.complete();
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.nrc.nl/nieuws/2023/06/15/lot-van-natuurherstelwet-timmermans-blijft-erg-onzeker-na-belangrijke-stemming-a4167267",
+		"detectedItemType": "newspaperArticle",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Lot van natuurherstelwet Timmermans blijft erg onzeker na belangrijke stemming",
+				"creators": [],
+				"date": "2023-06-15",
+				"abstractNote": "Natuurherstel: Een aanzienlijke groep in het Europees Parlement is bereid om natuurplannen van Frans Timmermans de nek om te draaien, zo bleek donderdag.",
+				"language": "nl",
+				"libraryCatalog": "NRC.nl",
+				"rights": "Copyright Mediahuis NRC BV",
+				"url": "https://www.nrc.nl/nieuws/2023/06/15/lot-van-natuurherstelwet-timmermans-blijft-erg-onzeker-na-belangrijke-stemming-a4167267",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.nrc.nl/nieuws/1987/06/13/reagan-vraagt-russen-de-muur-af-te-breken-kb_000035184-a3528803?t=1686835084",
+		"detectedItemType": "newspaperArticle",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Reagan vraagt Russen de Muur af te breken",
+				"creators": [],
+				"date": "1987-06-13",
+				"abstractNote": "Door onze correspondent ROB MEINES BERLIJN, 13 juni - In zijn toespraak aan de Berlijnse Muur bij de Brandenburger Poort heeft president Ronald Reagan gisteren Sovjet-leider…",
+				"language": "nl",
+				"libraryCatalog": "NRC.nl",
+				"rights": "Copyright Mediahuis NRC BV",
+				"url": "https://www.nrc.nl/nieuws/1987/06/13/reagan-vraagt-russen-de-muur-af-te-breken-kb_000035184-a3528803",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.nrc.nl/nieuws/2022/12/03/wikipedia-wordt-onbetrouwbaar-alweer-a4150299",
+		"detectedItemType": "newspaperArticle",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Column | Wikipedia wordt onbetrouwbaar. Alweer",
+				"creators": [],
+				"date": "2022-12-03",
+				"abstractNote": "Column:Maxim Februari",
+				"language": "nl",
+				"libraryCatalog": "NRC.nl",
+				"rights": "Copyright Mediahuis NRC BV",
+				"url": "https://www.nrc.nl/nieuws/2022/12/03/wikipedia-wordt-onbetrouwbaar-alweer-a4150299",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/NRC.nl.js
+++ b/NRC.nl.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-18 11:03:36"
+	"lastUpdated": "2023-06-20 08:03:28"
 }
 
 /*
@@ -54,7 +54,7 @@ function getSearchResults(doc, checkOnly) {
 
 	if (rows.length == 0) {
 		// We are probably not in an index page, but in a search results page.
-		rows = doc.querySelectorAll("div.search-results__item")
+		rows = doc.querySelectorAll("div.search-results__item");
 		isSearchPage = true;
 	}
 
@@ -64,12 +64,14 @@ function getSearchResults(doc, checkOnly) {
 		if (isSearchPage) {
 			href = row.getAttribute("data-article-url");
 			title = row.getAttribute("data-headline");
-		} else {
+		}
+		else {
 			href = row.href;
 
 			if (row.textContent.includes(">")) {
 				title = ZU.trimInternal(row.textContent.split(">")[1]);
-			} else {
+			}
+			else {
 				title = ZU.trimInternal(row.textContent);
 			}
 		}
@@ -90,8 +92,9 @@ async function doWeb(doc, url) {
 		for (let url of Object.keys(items)) {
 			await scrape(await requestDocument(url));
 		}
-	} else {
-		return scrape(doc, url);
+	}
+	else {
+		await scrape(doc, url);
 	}
 }
 
@@ -101,15 +104,15 @@ async function scrape(doc, url = doc.location.href) {
 	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
 	translator.setDocument(doc);
 
-	translator.setHandler('itemDone', function(obj, item) {
+	translator.setHandler('itemDone', function (obj, item) {
 		item.language = "nl-NL";
-		authors = Array.from(doc.querySelectorAll("a[rel='author']")).map(a => a.textContent);
+		var authors = Array.from(doc.querySelectorAll("a[rel='author']")).map(a => a.textContent);
 		item.creators = authors.map(a => ZU.cleanAuthor(a, 'author', false));
 
 		item.complete();
 	});
 
-	translator.getTranslatorObject(function(trans) {
+	translator.getTranslatorObject(function (trans) {
 		trans.itemType = "newspaperArticle";
 		trans.doWeb(doc, url);
 	});
@@ -212,12 +215,6 @@ var testCases = [
 				"seeAlso": []
 			}
 		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.nrc.nl/index/economie/",
-		"detectedItemType": "multiple",
-		"items": "multiple"
 	},
 	{
 		"type": "web",

--- a/NRC.nl.js
+++ b/NRC.nl.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-06-17 08:54:24"
+	"lastUpdated": "2023-06-18 11:03:36"
 }
 
 /*
@@ -83,26 +83,20 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-function doWeb(doc, url) {
+async function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) {
-				return true;
-			}
-			var articles = [];
-			for (var i in items) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
-		});
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
 	} else {
 		return scrape(doc, url);
 	}
 }
 
-function scrape(doc, url) {
+async function scrape(doc, url = doc.location.href) {
 	var translator = Zotero.loadTranslator('web');
-
 	// Embedded Metadata
 	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
 	translator.setDocument(doc);


### PR DESCRIPTION
Here's a PR for a translator for the Dutch newspaper [NRC](https://www.nrc.nl/). It works both for recent articles, as for re-published articles from their [archive](https://www.nrc.nl/index/archief/).

It's my first translator, so any feedback is much appreciated :smile: 