### PR TITLE
News Corp Australia: Scraping updates for more recent website editions

### DIFF
--- a/News Corp Australia.js
+++ b/News Corp Australia.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-07-03 14:16:41"
+	"lastUpdated": "2023-07-14 10:46:05"
 }
 
 /*
@@ -88,7 +88,14 @@ function scrape(doc, url) {
 	// purposes
 	item.publicationTitle = meta.publisher.name.match(/^(.+?)(?:[—|].*)?$/)[1].trim();
 	item.section = getSection(doc);
-	item.url = url;
+	if (meta.mainEntityOfPage["@type"] === "WebPage"
+		&& /^https?:\/\//.test(meta.mainEntityOfPage["@id"])) {
+		// Page URL from JSON-LD should be less prone to line noise
+		item.url = meta.mainEntityOfPage["@id"];
+	}
+	if (!item.url) {
+		item.url = url;
+	}
 	item.libraryCatalog = '';
 	item.attachments.push({
 		title: "Snapshot",


### PR DESCRIPTION
- Update the selectors for breadcrumb navigation (for section title), and stop using lastChild which can be a text node.
- Use page URL directly as the URL field, because URL in JSON data may point to a different domain.
- Prefer title scraped from page body, because the one from JSON data may fail to match the former, possibly due to social media SEO.
- More robust determination of authors, accounting for different data formats across different sites.

See also:
https://forums.zotero.org/discussion/105950/attempt-to-save-using-embedded-metadata