### PR TITLE
Update call number field in Primo Normalized XML

### DIFF
--- a/Primo Normalized XML.js
+++ b/Primo Normalized XML.js
@@ -314,14 +314,6 @@ function doImport() {
 			}
 		}
 	}
-	if (!callArray.length) {
-		callNumber = ZU.xpath(doc, '//p:delivery/p:bestlocation/p:callNumber', ns);
-		for (let i = 0; i < callNumber.length; i++) {
-			if (callNumber[i].textContent.search(/\$\$2.+\$/) != -1) {
-				callArray.push(callNumber[i].textContent.match(/\$\$2\(?(.+?)(?:\s*\))?\$/)[1]);
-			}
-		}
-	}
 	if (callArray.length) {
 		// remove duplicate call numbers
 		callArray = dedupeArray(callArray);

--- a/Primo Normalized XML.js
+++ b/Primo Normalized XML.js
@@ -314,6 +314,14 @@ function doImport() {
 			}
 		}
 	}
+	if (!callArray.length) {
+		callNumber = ZU.xpath(doc, '//p:delivery/p:bestlocation/p:callNumber', ns);
+		for (let i = 0; i < callNumber.length; i++) {
+			if (callNumber[i].textContent.search(/\$\$2.+\$/) != -1) {
+				callArray.push(callNumber[i].textContent.match(/\$\$2\(?(.+?)(?:\s*\))?\$/)[1]);
+			}
+		}
+	}
 	if (callArray.length) {
 		// remove duplicate call numbers
 		callArray = dedupeArray(callArray);


### PR DESCRIPTION
Before fix:
Call-number field was taken from '//p:display/p:availlibrary' root in the pnx or '//p:browse/p:callnumber' root in the pnx
and that matched primo pnx format.
In primoVE the call-number field exists in a differnt root '//p:delivery/p:bestlocation/p:callNumber' in the pnx.

After fix:
if call-number is empty it will fetch from '//p:delivery/p:bestlocation/p:callNumber'.