### PR TITLE
EBSCOhost: Asyncify network requests and use native API for encoding

### DIFF
--- a/EBSCOhost.js
+++ b/EBSCOhost.js
@@ -56,7 +56,7 @@ function detectWeb(doc, url) {
  * given the text of the delivery page, downloads an item
  */
 async function downloadFunction(text, url, prefs) {
-	if (/^TY\s\s?-/m.test(text)) {
+	if (!/^TY\s\s?-/m.test(text)) {
 		text = "\nTY  - JOUR\n" + text;	// this is probably not going to work if there is garbage text in the begining
 	}
 


### PR DESCRIPTION
- Convert the callback-based processDocuments and doGet into promise-based replacements.
- Remove the custom implementation of btoa() and related functions; replace them with built-in equivalents.

This addresses #3067.

@dstillman, I did a blind transformation of the code into the async style. Could you please test?