### PR TITLE
ePrint: refactor to modernize, fix issues, and add functionality

### DIFF
--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -208,7 +208,8 @@ async function doWeb(doc, url) {
 			await scrape(await requestDocument(url));
 		}
 	}
-	// TODO: This is never called except if URL value is modified in the function directly to append ".pdf". Instead, the PDF link gets directly opened by the system PDF reader when in Scaffold (and e.g., the test times out) and in browser the standard "Save to Zotero (PDF)" icon appears instead.
+	// Firefox restrictions will prevent this convenience clause from running (Chrome works as expected)
+	// Standard PDF saving (and metadata retrieval) logic will be used instead
 	else if (/\.pdf$/.test(url)) {
 		// Go to the landing page to scrape
 		url = url.replace(/\.pdf$/, "");
@@ -321,55 +322,6 @@ var testCases = [
 					},
 					{
 						"tag": "Permutation network"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://eprint.iacr.org/2016/1013.pdf",
-		"items": [
-			{
-				"itemType": "preprint",
-				"title": "A Formal Security Analysis of the Signal Messaging Protocol",
-				"creators": [],
-				"date": "2016",
-				"abstractNote": "The Signal protocol is a cryptographic messaging protocol that provides end-to-end encryption for instant messaging in WhatsApp, Wire, and Facebook Messenger among many others, serving well over 1 billion active users. Signal includes several uncommon security properties (such as \"future secrecy\" or \"post-compromise security\"), enabled by a novel technique called *ratcheting* in which session keys are updated with every message sent. We conduct a formal security analysis of Signal's initial extended triple Diffie-Hellman (X3DH) key agreement and Double Ratchet protocols as a multi-stage authenticated key exchange protocol. We extract from the implementation a formal description of the abstract protocol, and define a security model which can capture the ratcheting key update structure as a multi-stage model where there can be a tree of stages, rather than just a sequence. We then prove the security of Signal's key exchange core in our model, demonstrating several standard security properties. We have found no major flaws in the design, and hope that our presentation and results can serve as a foundation for other analyses of this widely adopted protocol.Fix omission in description of initial X3DH handshake, reorganize figures for improved presentation. Full list of changes in Appendix D.",
-				"libraryCatalog": "ePrint IACR",
-				"url": "https://eprint.iacr.org/2016/1013",
-				"attachments": [
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					}
-				],
-				"tags": [
-					{
-						"tag": "Signal"
-					},
-					{
-						"tag": "authenticated key exchange"
-					},
-					{
-						"tag": "future secrecy"
-					},
-					{
-						"tag": "messaging"
-					},
-					{
-						"tag": "multi-stage key exchange"
-					},
-					{
-						"tag": "post-compromise security"
-					},
-					{
-						"tag": "protocols"
-					},
-					{
-						"tag": "provable security"
 					}
 				],
 				"notes": [],

--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -129,10 +129,7 @@ async function scrape(doc, url = doc.location.href) {
 	}
 
 	for (let i in keywords) {
-		// Sometimes the keywords split returns an empty tag - those crash the translator if they're pushed.
-		if (keywords[i]) {
-			newItem.tags.push(keywords[i]);
-		}
+		newItem.tags.push(keywords[i]);
 	}
 
 	newItem.attachments = [

--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -3,13 +3,13 @@
 	"label": "ePrint IACR",
 	"creator": "Jonas Schrieb",
 	"target": "^https://eprint\\.iacr\\.org/",
-	"minVersion": "1.0.0b3.r1",
+	"minVersion": "6.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-07-16 13:17:09"
+	"lastUpdated": "2023-07-22 15:15:56"
 }
 
 /*
@@ -35,11 +35,6 @@
 	***** END LICENSE BLOCK *****
 */
 
-// TODO: can this be removed already (with a minimum supported version bump)?
-let preprintType = ZU.fieldIsValidForType('title', 'preprint')
-	? 'preprint'
-	: 'report';
-
 // There are several types of searches available on ePrint, producing pages with different structure, need to distinguish them
 // This covers the standard text-based search
 const SEARCH_TYPE_TEXT = "text";
@@ -60,7 +55,7 @@ function detectWeb(doc, url) {
 	var multipleTimeSearchAllRe = new RegExp(eprintBaseURLRe.source + /complete\/?$/.source);
 
 	if (singleRe.test(url)) {
-		return preprintType;
+		return 'preprint';
 	}
 	else if (multipleTextSearchRe.test(url)) {
 		searchType = SEARCH_TYPE_TEXT;
@@ -112,7 +107,7 @@ async function scrape(doc, url = doc.location.href) {
 	var keywords = doc.querySelectorAll(keywordsSelector);
 	keywords = [...keywords].map(kw => kw.textContent.trim());
 
-	var newItem = new Zotero.Item(preprintType);
+	var newItem = new Zotero.Item('preprint');
 
 	newItem.date = paperYear;
 
@@ -121,12 +116,7 @@ async function scrape(doc, url = doc.location.href) {
 	// TODO: Do we want to differentiate Archive and Library Catalog like this (the latter has FQDN appended)? Do we want to populate both or just one of them? The translator population has all possible approaches.
 	newItem.archive = archiveName;
 	newItem.libraryCatalog = `${archiveName} (${eprintFQDN})`;
-	if (preprintType === 'preprint') {
-		newItem.archiveID = paperID;
-	}
-	else {
-		newItem.reportNumber = paperID;
-	}
+	newItem.archiveID = paperID;
 
 	// Canonicalize the URL to avoid errors if e.g., the user removed or prepended extra zeroes to the paper ID in the original URL
 	newItem.url = urlComponents[0] + "/" + paperID;

--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -2,115 +2,234 @@
 	"translatorID": "04a23cbe-5f8b-d6cd-8eb1-2e23bcc8ae8f",
 	"label": "ePrint IACR",
 	"creator": "Jonas Schrieb",
-	"target": "^https?://eprint\\.iacr\\.org/",
+	"target": "^https://eprint\\.iacr\\.org/",
 	"minVersion": "1.0.0b3.r1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-10-28 16:15:17"
+	"lastUpdated": "2023-07-16 13:17:09"
 }
 
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2010-2023 Jonas Schrieb and contributors
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+// TODO: can this be removed already (with a minimum supported version bump)?
 let preprintType = ZU.fieldIsValidForType('title', 'preprint')
 	? 'preprint'
 	: 'report';
 
+// There are several types of searches available on ePrint, producing pages with different structure, need to distinguish them
+// This covers the standard text-based search
+const SEARCH_TYPE_TEXT = "text";
+// This covers all time-based searches: "All papers" (excluding "Compact view"), "Updates from the last X days", "Listing by year"
+const SEARCH_TYPE_TIME = "time";
+let searchType = "";
+
 function detectWeb(doc, url) {
-	var singleRe   = /^https?:\/\/eprint\.iacr\.org\/(\d{4}\/\d{3}|cgi-bin\/print\.pl)/;
-	var multipleRe = /^https?:\/\/eprint\.iacr\.org\/search\?/;
+	var eprintBaseURLRe = /^https:\/\/eprint\.iacr\.org\//;
+	// Single paper URL format is https://<ePrint FQDN>/<year>/<paper number within the year>
+	// The year is always 4 digits, paper number can technically be 1 digit or more, default is 3 or 4 digits (the former is left-padded with zeroes if smaller than 100)
+	var singleRe = new RegExp(eprintBaseURLRe.source + /\d{4}\/\d+/.source);
+
+	var multipleTextSearchRe = new RegExp(eprintBaseURLRe.source + /search\?/.source);
+	var multipleTimeSearchYearRe = new RegExp(eprintBaseURLRe.source + /\d{4}\/?$/.source);
+	var multipleTimeSearchDaysRe = new RegExp(eprintBaseURLRe.source + /days/.source);
+	// The "Compact view" is explicitly unsupported - it does not use pagination and trying to handle all 20K+ papers at once reliably kills Zotero
+	var multipleTimeSearchAllRe = new RegExp(eprintBaseURLRe.source + /complete\/?$/.source);
+
 	if (singleRe.test(url)) {
 		return preprintType;
-	} else if (multipleRe.test(url)) {
-		return "multiple";
 	}
+	else if (multipleTextSearchRe.test(url)) {
+		searchType = SEARCH_TYPE_TEXT;
+	}
+	else if (multipleTimeSearchYearRe.test(url)
+		|| multipleTimeSearchDaysRe.test(url)
+		|| multipleTimeSearchAllRe.test(url)) {
+		searchType = SEARCH_TYPE_TIME;
+	}
+	if (searchType && getSearchResults(doc, true)) return "multiple";
+
+	return false;
 }
 
-function scrape(doc, url) {
-	var reportNoSelector = "h4";
-	var titleSelector    = "h3";
-	var authorsSelector  = 'meta[name="citation_author"]'
-	var abstractXPath    = "//h5[starts-with(text(),\"Abstract\")]/following-sibling::p/text()";
+async function scrape(doc, url = doc.location.href) {
+	var titleSelector = 'meta[name="citation_title"]';
+	var authorsSelector = 'meta[name="citation_author"]';
+	var archiveSelector = 'meta[name="citation_journal_title"]';
+	var abstractXPath = "//h5[starts-with(text(),'Abstract')]/following-sibling::p[1]";
+	var noteXPath = "//h5[starts-with(text(),'Abstract')]/following-sibling::p[2]/strong[starts-with(text(), 'Note:')]/..";
 	var keywordsSelector = ".keywords > .keyword";
-	var reportNo = text(doc, reportNoSelector);
-	reportNo = reportNo.match(/(\d{4})\/(\d{3,4})$/);
-	if (reportNo){
-		var year = reportNo[1];
-		var no   = reportNo[2];
+	var publicationInfoSelector = "//div[@id='metadata']/dl/dt[starts-with(text(), 'Publication info')]/following-sibling::dd[1]";
+	var paperIDSelector = "#eprintContent h4";
+	var paperID = text(doc, paperIDSelector);
+	// The year is always 4 digits, the paper number is canonicalized (3 or 4 digits) before calling scrape()
+	paperID = paperID.match(/(\d{4})\/(\d{3,4})$/);
+	if (paperID) {
+		var paperYear = paperID[1];
+		var paperNum = paperID[2];
+		paperID = paperYear + "/" + paperNum;
 	}
-	var title = text(doc, titleSelector);
-	title = ZU.trimInternal(title);
+	var title = ZU.trimInternal(attr(doc, titleSelector, 'content'));
+
+	var archiveName = ZU.trimInternal(attr(doc, archiveSelector, 'content'));
 
 	var authors = doc.querySelectorAll(authorsSelector);
 	authors = [...authors].map(author => author.content);
-	
-	var abstr = "";
-	var abstractLines = doc.evaluate(abstractXPath, doc, null, XPathResult.ANY_TYPE, null);
-	var nextLine;
-	while (nextLine = abstractLines.iterateNext()) {
-		// An inner line starting with \n starts a new paragraph in the abstract.
-		if (nextLine.textContent[0] == "\n") {
-			abstr += "\n\n";
-		}
-		abstr +=  ZU.trimInternal(nextLine.textContent);
-	}
-	
+
+	var abstr = ZU.xpathText(doc, abstractXPath);
+	// Remove surplus whitespace, but preserve paragraphs, denoted in the page markup by double newlines with some spaces in between
+	if (abstr) abstr = abstr.replace(/\n\s+\n/g, "\n\n").replace(/[ \t]+/g, " ").trim();
+
+	let note = ZU.xpathText(doc, noteXPath);
+	if (note) note = ZU.trimInternal(note.replace(/^Note: /, ""));
+
+	let publicationInfo = ZU.xpathText(doc, publicationInfoSelector);
+	publicationInfo = ZU.trimInternal(publicationInfo);
+
 	var keywords = doc.querySelectorAll(keywordsSelector);
 	keywords = [...keywords].map(kw => kw.textContent.trim());
 
 	var newItem = new Zotero.Item(preprintType);
-	
-	newItem.date = year;
-	newItem.reportNumber = no;
-	//we want to use this later & make sure we don't make http--> https requests or vice versa. 
-	newItem.url = url.match(/^https?:\/\/[^\/]+/)[0] + "/" + year + "/" + no;
+
+	newItem.date = paperYear;
+
+	let urlComponents = url.match(/^https:\/\/([^/]+)/);
+	let eprintFQDN = urlComponents[1];
+	// TODO: Do we want to differentiate Archive and Library Catalog like this (the latter has FQDN appended)? Do we want to populate both or just one of them? The translator population has all possible approaches.
+	newItem.archive = archiveName;
+	newItem.libraryCatalog = `${archiveName} (${eprintFQDN})`;
+	if (preprintType === 'preprint') {
+		newItem.archiveID = paperID;
+	}
+	else {
+		newItem.reportNumber = paperID;
+	}
+
+	// Canonicalize the URL to avoid errors if e.g., the user removed or prepended extra zeroes to the paper ID in the original URL
+	newItem.url = urlComponents[0] + "/" + paperID;
 	newItem.title = title;
 	newItem.abstractNote = abstr;
-	for (var i in authors) {
-		newItem.creators.push(Zotero.Utilities.cleanAuthor(authors[i], "author"));
-	}
-for (var i = 0; i < keywords.length; i++) {
-	//sometimes the keywords split returns an empty tag - those crash the translator if they're pushed.
-	if (keywords[i] != null){
-		newItem.tags.push(keywords[i]);}
-	}
-	newItem.attachments = [
-		{url:newItem.url+".pdf", title:"Full Text PDF", mimeType:"application/pdf"}
-	];
-	newItem.complete();
 
+	for (let i in authors) {
+		newItem.creators.push(ZU.cleanAuthor(authors[i], "author"));
+	}
+
+	for (let i in keywords) {
+		// Sometimes the keywords split returns an empty tag - those crash the translator if they're pushed.
+		if (keywords[i]) {
+			newItem.tags.push(keywords[i]);
+		}
+	}
+
+	newItem.attachments = [
+		{ url: newItem.url + ".pdf", title: "Full Text PDF", mimeType: "application/pdf" }
+	];
+
+	if (note) newItem.notes.push({ note: note });
+
+	let extra = `Publication info: ${publicationInfo}`;
+	newItem.extra = newItem.extra
+		? newItem.extra + `\n${extra}`
+		: extra;
+
+	newItem.complete();
 }
 
-function doWeb(doc, url) {
-	var nextTitle;
-
-	if (detectWeb(doc, url) == "multiple") {
-		var rowSelector = ".paperList > div, .results > div";
-		var titleSelector = ".papertitle, strong";
-		var linkSelector = ".paperlink, a:first-child";
-
-		let items = {};
-		for (let row of doc.querySelectorAll(rowSelector)) {
-			let title = text(row, titleSelector);
-			let href = attr(row, linkSelector, 'href');
-			if (!title || !href) continue;
-			items[href] = title;
-		}
-
-		var titles = doc.querySelectorAll(titleSelector);
-		var links  = doc.querySelectorAll(linkSelector);
-		Zotero.selectItems(items, function (items) {
-			if (items) ZU.processDocuments(Object.keys(items), scrape);
-		});
-	} else {
-		if (url.search(/\.pdf$/)!= -1) {
-			//go to the landing page to scrape
-			url = url.replace(/\.pdf$/, "");
-			ZU.processDocuments([url], scrape)
-		}
-		else scrape(doc, url)
+function getSearchResults(doc, checkonly) {
+	if (searchType === SEARCH_TYPE_TEXT) {
+		return getTextSearchResults(doc, checkonly);
 	}
-}/** BEGIN TEST CASES **/
+	else if (searchType === SEARCH_TYPE_TIME) {
+		return getTimeSearchResults(doc, checkonly);
+	}
+	return false;
+}
+
+// Standard (text) search results parser
+function getTextSearchResults(doc, checkOnly) {
+	let rowSelector = ".results > div";
+	let titleSelector = "div > strong:first-child";
+	let linkSelector = "a.paperlink";
+
+	let items = {};
+	let found = false;
+	// Each "row" div will contain two nested divs with necessary information
+	for (let row of doc.querySelectorAll(rowSelector)) {
+		let title = text(row, titleSelector);
+		let href = attr(row, linkSelector, 'href');
+		if (!title || !href) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+// Time-based search results parser ("All papers", "Listing by year", "Updates from the last X days")
+function getTimeSearchResults(doc, checkOnly) {
+	let rowSelector = ".paperList > div";
+	let titleSelector = ".papertitle";
+	let linkSelector = "a:first-child";
+
+	let items = {};
+	let found = false;
+	// This search type returns a page with a flat list of divs, odd ones contain links, even ones contain titles
+	// We treat the list as a set of [virtual] rows, each comprised of a pair of divs
+	let rows = doc.querySelectorAll(rowSelector);
+	for (let i = 0; i < rows.length - 1; i += 2) {
+		let href = attr(rows[i], linkSelector, "href");
+		let title = text(rows[i + 1], titleSelector);
+		if (!title || !href) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		let items = await Z.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	// TODO: This is never called except if URL value is modified in the function directly to append ".pdf". Instead, the PDF link gets directly opened by the system PDF reader when in Scaffold (and e.g., the test times out) and in browser the standard "Save to Zotero (PDF)" icon appears instead.
+	else if (/\.pdf$/.test(url)) {
+		// Go to the landing page to scrape
+		url = url.replace(/\.pdf$/, "");
+		await scrape(await requestDocument(url));
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
@@ -132,8 +251,11 @@ var testCases = [
 					}
 				],
 				"date": "2005",
-				"abstractNote": "This paper describes an adaptive-chosen-ciphertext attack on the Cipher Feedback (CFB) mode of encryption as used in OpenPGP. In most circumstances it will allow an attacker to determine 16 bits of any block of plaintext with aboutoracle queries for the initial setup work andoracle queries for each block. Standard CFB mode encryption does not appear to be affected by this attack. It applies to a particular variation of CFB used by OpenPGP. In particular it exploits an ad-hoc integrity check feature in OpenPGP which was meant as a \"quick check\" to determine the correctness of the decrypting symmetric key.",
-				"libraryCatalog": "ePrint IACR",
+				"abstractNote": "This paper describes an adaptive-chosen-ciphertext attack on the Cipher Feedback (CFB) mode of encryption as used in OpenPGP. In most circumstances it will allow an attacker to determine 16 bits of any block of plaintext with about 215 oracle queries for the initial\nsetup work and 215 oracle queries for each block. Standard CFB mode encryption does not appear to be affected by this attack. It applies to a particular variation of CFB used by OpenPGP. In particular it exploits an ad-hoc integrity check feature in OpenPGP which was meant as a \"quick check\" to determine the correctness of the decrypting symmetric key.",
+				"archive": "Cryptology ePrint Archive",
+				"archiveID": "2005/033",
+				"extra": "Publication info: Published elsewhere. Unknown where it was published",
+				"libraryCatalog": "Cryptology ePrint Archive (eprint.iacr.org)",
 				"url": "https://eprint.iacr.org/2005/033",
 				"attachments": [
 					{
@@ -179,8 +301,11 @@ var testCases = [
 					}
 				],
 				"date": "2011",
-				"abstractNote": "We show that homomorphic evaluation of (wide enough) arithmetic circuits can be accomplished with only polylogarithmic overhead. Namely, we present a construction of fully homomorphic encryption (FHE) schemes that for security parametercan evaluate any width-circuit withgates in time. To get low overhead, we use the recent batch homomorphic evaluation techniques of Smart-Vercauteren and Brakerski-Gentry-Vaikuntanathan, who showed that homomorphic operations can be applied to \"packed\" ciphertexts that encrypt vectors of plaintext elements. In this work, we introduce permuting/routing techniques to move plaintext elements across these vectors efficiently. Hence, we are able to implement general arithmetic circuit in a batched fashion without ever needing to \"unpack\" the plaintext vectors. We also introduce some other optimizations that can speed up homomorphic evaluation in certain cases. For example, we show how to use the Frobenius map to raise plaintext elements to powers of~at the \"cost\" of a linear operation.",
-				"libraryCatalog": "ePrint IACR",
+				"abstractNote": "We show that homomorphic evaluation of (wide enough) arithmetic circuits can be accomplished with only polylogarithmic overhead. Namely, we present a construction of fully homomorphic encryption (FHE) schemes that for security parameter \\secparam can evaluate any width-Ω(\\secparam) circuit with t gates in time t⋅polylog(\\secparam).\n\nTo get low overhead, we use the recent batch homomorphic evaluation techniques of Smart-Vercauteren and Brakerski-Gentry-Vaikuntanathan, who showed that homomorphic operations can be applied to \"packed\" ciphertexts that encrypt vectors of plaintext elements. In this work, we introduce permuting/routing techniques to move plaintext elements across\nthese vectors efficiently. Hence, we are able to implement general arithmetic circuit in a batched fashion without ever needing to \"unpack\" the plaintext vectors.\n\nWe also introduce some other optimizations that can speed up homomorphic evaluation in certain cases. For example, we show how to use the Frobenius map to raise plaintext elements to powers of~p at the \"cost\" of a linear operation.",
+				"archive": "Cryptology ePrint Archive",
+				"archiveID": "2011/566",
+				"extra": "Publication info: Published elsewhere. extended abstract in Eurocrypt 2012",
+				"libraryCatalog": "Cryptology ePrint Archive (eprint.iacr.org)",
 				"url": "https://eprint.iacr.org/2011/566",
 				"attachments": [
 					{
@@ -268,7 +393,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "preprint",
-				"title": "The Limits of Provable Security Against Model Extraction",
+				"title": "Theoretical Limits of Provable Security Against Model Extraction by Efficient Observational Defenses",
 				"creators": [
 					{
 						"firstName": "Ari",
@@ -277,8 +402,11 @@ var testCases = [
 					}
 				],
 				"date": "2022",
-				"abstractNote": "Can we hope to provide provable security against model extraction attacks? As a step towards a theoretical study of this question, we unify and abstract a wide range of \"observational\" model extraction defense mechanisms -- roughly, those that attempt to detect model extraction using a statistical analysis conducted on the distribution over the adversary's queries. To accompany the abstract observational model extraction defense, which we call OMED for short, we define the notion of complete defenses -- the notion that benign clients can freely interact with the model -- and sound defenses -- the notion that adversarial clients are caught and prevented from reverse engineering the model. We then propose a system for obtaining provable security against model extraction by complete and sound OMEDs, using (average-case) hardness assumptions for PAC-learning. Our main result nullifies our proposal for provable security, by establishing a computational incompleteness theorem for the OMED: any efficient OMED for a machine learning model computable by a polynomial size decision tree that satisfies a basic form of completeness cannot satisfy soundness, unless the subexponential Learning Parity with Noise (LPN) assumption does not hold. To prove the incompleteness theorem, we introduce a class of model extraction attacks called natural Covert Learning attacks based on a connection to the Covert Learning model of Canetti and Karchmer (TCC '21), and show that such attacks circumvent any defense within our abstract mechanism in a black-box, nonadaptive way. Finally, we further expose the tension between Covert Learning and OMEDs by proving that Covert Learning algorithms require the nonexistence of provable security via efficient OMEDs. Therefore, we observe a \"win-win\" result by obtaining a characterization of the existence of provable security via efficient OMEDs by the nonexistence of natural Covert Learning algorithms.",
-				"libraryCatalog": "ePrint IACR",
+				"abstractNote": "Can we hope to provide provable security against model extraction attacks? As a step towards a theoretical study of this question, we unify and abstract a wide range of \"observational\" model extraction defenses (OMEDs) --- roughly, those that attempt to detect model extraction by analyzing the distribution over the adversary's queries. To accompany the abstract OMED, we define the notion of complete OMEDs --- when benign clients can freely interact with the model --- and sound OMEDs --- when adversarial clients are caught and prevented from reverse engineering the model. Our formalism facilitates a simple argument for obtaining provable security against model extraction by complete and sound OMEDs, using (average-case) hardness assumptions for PAC-learning, in a way that abstracts current techniques in the prior literature.\n\nThe main result of this work establishes a partial computational incompleteness theorem for the OMED: any efficient OMED for a machine learning model computable by a polynomial size decision tree that satisfies a basic form of completeness cannot satisfy soundness, unless the subexponential Learning Parity with Noise (LPN) assumption does not hold. To prove the incompleteness theorem, we introduce a class of model extraction attacks called natural Covert Learning attacks based on a connection to the Covert Learning model of Canetti and Karchmer (TCC '21), and show that such attacks circumvent any defense within our abstract mechanism in a black-box, nonadaptive way. As a further technical contribution, we extend the Covert Learning algorithm of Canetti and Karchmer to work over any \"concise\" product distribution (albeit for juntas of a logarithmic number of variables rather than polynomial size decision trees), by showing that the technique of learning with a distributional inverter of Binnendyk et al. (ALT '22) remains viable in the Covert Learning setting.",
+				"archive": "Cryptology ePrint Archive",
+				"archiveID": "2022/1039",
+				"extra": "Publication info: Published elsewhere. IEEE Secure and Trustworthy Machine Learning (SATML)",
+				"libraryCatalog": "Cryptology ePrint Archive (eprint.iacr.org)",
 				"url": "https://eprint.iacr.org/2022/1039",
 				"attachments": [
 					{
@@ -297,7 +425,11 @@ var testCases = [
 						"tag": "Provable Security"
 					}
 				],
-				"notes": [],
+				"notes": [
+					{
+						"note": "This is an updated version. The paper has been modified to improve readability and argumentation. Some new results have been added in section 5. The previous version of the paper appeared under the title \"The Limits of Provable Security Against Model Extraction.\" The current version is the same as for publication in IEEE SATML '23, except for minor differences and formatting."
+					}
+				],
 				"seeAlso": []
 			}
 		]
@@ -305,6 +437,21 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://eprint.iacr.org/search?q=test",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://eprint.iacr.org/days/7",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://eprint.iacr.org/2021/",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://eprint.iacr.org/complete/",
 		"items": "multiple"
 	}
 ]

--- a/ePrint IACR.js
+++ b/ePrint IACR.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-07-22 15:15:56"
+	"lastUpdated": "2023-07-22 15:29:56"
 }
 
 /*
@@ -45,7 +45,8 @@ let searchType = "";
 function detectWeb(doc, url) {
 	var eprintBaseURLRe = /^https:\/\/eprint\.iacr\.org\//;
 	// Single paper URL format is https://<ePrint FQDN>/<year>/<paper number within the year>
-	// The year is always 4 digits, paper number can technically be 1 digit or more, default is 3 or 4 digits (the former is left-padded with zeroes if smaller than 100)
+	// The year is always 4 digits, paper number can technically be 1 digit or more,
+	// the default is 3 or 4 digits (the former is left-padded with zeroes if smaller than 100)
 	var singleRe = new RegExp(eprintBaseURLRe.source + /\d{4}\/\d+/.source);
 
 	var multipleTextSearchRe = new RegExp(eprintBaseURLRe.source + /search\?/.source);


### PR DESCRIPTION
This is a major refactor of the translator. Main changes:

* Fix lints and bugs, asyncify and restructure according to current translator best practices
* Add processing of all search types (except "Compact view", due to performance reasons)
* Properly populate Archive, Archive ID, Library Catalog, Note fields and add useful information from "Publication info" item into Extra field
* Update existing and add new tests for added functionality

Notes and opens (the latter are also marked with TODO in the code, will remove those when clarified). While clarifying why I went the way I did, I'm open to alternative approaches.
* This is a follow-up to my initial PR #3066 and our discussion there. Given the number of changes, the diff may not be as helpful as usual, just as a fair warning. The changes were intertwined enough so I couldn't come up with any meaningful split into commits and went with a single one.
* I went with straight `https://` as (a) `http://` doesn't exist anyway (redirects to `https://`) and (b) in this day and age, it's highly unlikely ePrint will ever get back to plain HTTP.
* I watched several discussions in other translator-related PRs and tried to keep the code simple and well-commented for better maintainability. As suggested by dstillman in one of the recent reviews, simplicity had priority, so e.g., I kept `getTextSearchResults()` and `getTimeSearchResults()` separate due to different looping logic and selectors. It could be solved, but alternatives looked more convoluted, and the code duplication is not huge.
* Right now Archive and Library Catalog field values vary slightly (the latter has ePrint FQDN appended). Looking through the translators, I see every possible combination implemented for these two fields, so I went with my understanding based on what I saw in other translators, reading the `preprint` item type PR discussion and the item schema description.
* Can we get rid of the `preprint` vs `report` item type check [here](https://github.com/zotero/translators/compare/master...alex-ter:eprint-refactor?expand=1#diff-546a2c246c178f91aaf2791151cf24aad81c586ffa17f3e9a7c27ecadb364d76R39)? The former was added approx. a year ago, so maybe a translator minimum supported version bump would be enough?
* The trick with processing direct links to PDFs [here](https://github.com/zotero/translators/compare/master...alex-ter:eprint-refactor?expand=1#diff-546a2c246c178f91aaf2791151cf24aad81c586ffa17f3e9a7c27ecadb364d76R221) does not really work (see the TODO comment there). In essence, a built-in PDF saving logic seems to take precedence even though [the code](https://github.com/zotero/zotero-connectors/blob/master/src/browserExt/background.js#L603-L611) seems to be properly putting translators first. Is this some known issue? Am I missing something here? As implemented now, that logic doesn't work, so I'm thinking of either fixing or removing it altogether.
   * ADDED LATER: this may be some sort of Firefox-specific bug or behavior, looks like Dan mentioned something very similar in a [recent forum post](https://forums.zotero.org/discussion/comment/438395/#Comment_438395). I used Firefox so far, will check it out in Chrome - but the Scaffold-related piece still stays anyway.

Side note - [translator test results page](https://zotero-translator-tests.s3.amazonaws.com/index.html) referenced in [the docs](https://www.zotero.org/support/dev/translators/testing#automated_testing) seems to be broken (lists no tests). Is that kind of testing no longer used?