### PR TITLE
New York Review of Books: Fix translator broken by site updates.

### DIFF
--- a/The New York Review of Books.js
+++ b/The New York Review of Books.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-03 11:11:09"
+	"lastUpdated": "2023-08-03 11:23:30"
 }
 
 /*
@@ -176,11 +176,11 @@ function urlToDateArray(url) {
 
 // Given the date-array of the issue, find the volume and number by requesting
 // the issue's page and parse the metadata. This function is memoized.
-var issueCache = {};
+var ISSUE_CACHE = {};
 async function getIssue(dateArray) {
 	let key = dateArray.join("/");
-	if (issueCache[key]) {
-		return issueCache[key];
+	if (ISSUE_CACHE[key]) {
+		return ISSUE_CACHE[key];
 	}
 	let issueURL = `https://www.nybooks.com/issues/${key}/`;
 	let issuePageDoc = await requestDocument(issueURL);
@@ -196,7 +196,9 @@ async function getIssue(dateArray) {
 		for (let bcItem of breadcrumbs) {
 			let m = bcItem.name.match(/^volume (\d+), (?:issue|number) (\d+)/i);
 			if (m) {
-				return { volume: m[1], issue: m[2] };
+				let result = { volume: m[1], issue: m[2] };
+				ISSUE_CACHE[key] = result;
+				return result;
 			}
 		}
 	}


### PR DESCRIPTION
(The translator was last updated in 2017; it barely worked on the current website.)

Bugfixes:

- Fix missing or erroneous metadata due to site updates having changed the page structure, embedded metadata, and some URL patterns.
- Fix the inability to select any article on search/issue-display pages.
- For review articles (i.e. most of them), also add the authors whose work are being reviewed as creators of the `"reviewedAuthor"` type.
- Add volume and issue info to magazine articles, in addition to dates.
- Correctly identify the authors who are translators.

Other enhancements:

- In the item-selection dialog, show the names of authors (truncated when too long) in paretheses after the title. This prevents the dialog from being overwhelmed by articles with the same title or similar titles.

Programming details:

- Make the script asynchronous; remove obsolete functions.
- For search results, watch the DOM changes under the result display root element, because the content may shift in and out depending on the filters.
- Fix ESLint errors.
- Bump minVersion.
- Add new test cases and update old ones. Note that the tags are no longer displayed on blog articles, so they become missing in the new tests.
- Defer search-page tests due to its Ajax nature.