### PR TITLE
JSTOR: More reliable way of extract page canonical link; type detection fixes

### DIFF
--- a/JSTOR.js
+++ b/JSTOR.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-23 02:44:06"
+	"lastUpdated": "2023-08-23 04:52:20"
 }
 
 /*
@@ -203,7 +203,7 @@ async function doWeb(doc, url) {
 async function scrape(jid) {
 	var risURL = "/citation/ris/";
 	let risText = await requestText(risURL + jid);
-	await processRIS(risText);
+	await processRIS(risText, jid);
 }
 
 function convertCharRefs(string) {


### PR DESCRIPTION
The canonical link (permalink) of the current page being scraped is directly extracted from the <link rel="canonical"> element in the HTML head.

<s>Note to @dstillman - this is a hotfix and it doesn't address other failing test cases caused by incorrect type detection. I'll push another fix for those, but I need a bit more time.</s>

Edit: I'll add a few more commits that address other failing tests in this branch.

Fixes #3104, from which a test case is added.