### PR TITLE
Skip linked resources that contain no rdf metadata to prevent translator from failing

### DIFF
--- a/Wikidata.js
+++ b/Wikidata.js
@@ -865,9 +865,9 @@ var testCases = [
 						"creatorType": "author"
 					},
 					{
-						"firstName":"Luca",
-						"lastName":"Settanni",
-						"creatorType":"author"
+						"firstName": "Luca",
+						"lastName": "Settanni",
+						"creatorType": "author"
 					},
 					{
 						"firstName": "José Paulo",


### PR DESCRIPTION
Fix wikidata translator author bug,
which failed when it encountered a "null"
creator.

This occurs when the wikidata item
it a redirect.

If no value is found, continue to the next
iteration of the loop.

Partial fix of #3108
