### PR TITLE
ESLint rules: Add "ericNumber" to the allowed keys for search translator

### DIFF
--- a/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
+++ b/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
@@ -79,7 +79,7 @@ module.exports = {
 					}
 					else if (testCase.type === 'search') {
 						// console.log(JSON.stringify(testCase.input))
-						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject', 'adsBibcode'];
+						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject', 'adsBibcode', 'ericNumber'];
 						if (!Object.keys(testCase.input).every(key => expected.includes(key))) {
 							let invalidKey = Object.keys(testCase.input).find(key => !expected.includes(key));
 							context.report({


### PR DESCRIPTION
This prevents the spurious lint errors in ERIC.js caused by the key "ericNumber".