### PR TITLE
ENH: Recognize static site generated blogs

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -308,6 +308,9 @@ function init(doc, url, callback, forceLoadRDF) {
 				if (lcValue.includes('blogger')
 					|| lcValue.includes('wordpress')
 					|| lcValue.includes('wooframework')
+					|| lcValue.includes('hugo')
+					|| lcValue.includes('eleventy')
+					|| lcValue.includes('jekyll')
 				) {
 					generatorType = 'blogPost';
 				}


### PR DESCRIPTION
Currently, for most pages and posts, Zotero assumes a webpage is the content type. This results in incorrect item types, for the **many** alternate generators of blog posts. I myself use Hugo, but other SSGs (s[tatic site generators](https://jamstack.org/generators/)) like Jekyll are also popular. I am currently forcing the meta tag with Wordpress in my theme but this is silly. It would make more sense for Zotero connector to accept a wider range of generator contents.

This adds some of the more popular ones.