### PR TITLE
Encyclopedia of Korean Culture

### DIFF
--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 02:06:12"
+	"lastUpdated": "2023-09-15 02:07:55"
 }
 
 /*
@@ -99,8 +99,8 @@ async function scrape(doc, url = doc.location.href) {
 			});
 		}
 	}
-	item.complete();
 	item.attachments.push({ title: "Snapshot", document: doc, mimeType: "text/html" });
+	item.complete();
 }/** BEGIN TEST CASES **/
 var testCases = [
 	{

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -61,11 +61,11 @@ function scrape(doc, url) {
 		// For simplicity, assume one character surnames for everybody (there are rare exceptions)
 		for (let author of authors.split('·')) {
 			item.creators.push({
-				"lastName": author[0],
-				"firstName": author.slice(1),
-				"creatorType": "author"
+				lastName: author[0],
+				firstName: author.slice(1),
+				creatorType: "author"
 			});
-		} 
+		}
 	}
 	item.complete();
 }/** BEGIN TEST CASES **/

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-27 23:38:58"
+	"lastUpdated": "2023-08-28 00:04:42"
 }
 
 /*
@@ -35,8 +35,13 @@
 	***** END LICENSE BLOCK *****
 */
 
+function text(docOrElem, selector, index) {
+	var elem = index ? docOrElem.querySelectorAll(selector).item(index) : docOrElem.querySelector(selector);
+	return elem ? elem.textContent : null;
+}
+
 function detectWeb(doc, url) {
-	return url.match(/E\d{7}(#.*)?/) ? 'encyclopediaArticle' : false;
+	return 'encyclopediaArticle';
 }
 
 function doWeb(doc, url) {
@@ -46,14 +51,14 @@ function doWeb(doc, url) {
 function scrape(doc, url) {
 	item = new Zotero.Item('encyclopediaArticle');
 
-	// Title is formatted: hangulName(hanjaName); adding space between
+	// Title initially formatted: hangulName(hanjaName); adding space between
 	item.title = doc.title.split(' - ')[0].replace('(', ' (');
 	item.encyclopediaTitle = "Encyclopedia of Korean Culture";
 	item.publisher = "Academy of Korean Studies";
 	item.language = "ko";
 	item.url = url;
 
-	// Author processing; may be multiple and names will be in Korean
+	// Author processing; may be 0 or more names, would be in Korean
 	var authors = doc.querySelector('div[class="author-wrap"] > span');
 
 	if (authors) {
@@ -74,49 +79,77 @@ var testCases = [
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
 		"detectedItemType": "encyclopediaArticle",
-		"items": [{
-             "itemType": "encyclopediaArticle",
-             "creators": [{
-                     "lastName": "오",
-                     "firstName": "건환",
-                     "creatorType": "author"
-                 }, {
-                     "lastName": "김",
-                     "firstName": "건유",
-                     "creatorType": "author"
-                 }
-             ],
-             "notes": [],
-             "tags": [],
-             "seeAlso": [],
-             "attachments": [],
-             "title": "다대포 (多大浦)",
-             "encyclopediaTitle": "Encyclopedia of Korean Culture",
-             "publisher": "Academy of Korean Studies",
-             "language": "ko",
-             "url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
-             "libraryCatalog": "Encyclopedia of Korean Culture"
-         }]
+		"items": [
+			{
+				"itemType": "encyclopediaArticle",
+				"title": "다대포 (多大浦)",
+				"creators": [
+					{
+						"lastName": "오",
+						"firstName": "건환",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "김",
+						"firstName": "건유",
+						"creatorType": "author"
+					}
+				],
+				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"language": "ko",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"publisher": "Academy of Korean Studies",
+				"url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	},
 	{
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/E0002855",
 		"detectedItemType": "encyclopediaArticle",
+		"items": [
+			{
+				"itemType": "encyclopediaArticle",
+				"title": "경주 남산 탑곡 마애불상군 (慶州 南山 塔谷 磨崖佛像群)",
+				"creators": [],
+				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"language": "ko",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"publisher": "Academy of Korean Studies",
+				"url": "https://encykorea.aks.ac.kr/Article/E0002855",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://encykorea.aks.ac.kr/Article/E0025488",
+		"detectedItemType": "encyclopediaArticle",
 		"items": [{
-			 "itemType": "encyclopediaArticle",
-             "creators": [],
-             "notes": [],
-             "tags": [],
-             "seeAlso": [],
-             "attachments": [],
-             "title": "경주 남산 탑곡 마애불상군 (慶州 南山 塔谷 磨崖佛像群)",
-             "encyclopediaTitle": "Encyclopedia of Korean Culture",
-             "publisher": "Academy of Korean Studies",
-             "language": "ko",
-             "url": "https://encykorea.aks.ac.kr/Article/E0002855",
-             "libraryCatalog": "Encyclopedia of Korean Culture"
+				"itemType": "encyclopediaArticle",
+				"title": "사랑 (舍廊)",
+				"creators": [{
+						"lastName": "김",
+						"firstName": "동욱",
+						"creatorType": "author"
+					}],
+				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"language": "ko",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"publisher": "Academy of Korean Studies",
+				"url": "https://encykorea.aks.ac.kr/Article/E0025488",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 		}]
 	}
-
 ]
 /** END TEST CASES **/

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-10 10:33:20"
+	"lastUpdated": "2023-09-10 11:01:49"
 }
 
 /*
@@ -78,12 +78,12 @@ async function doWeb(doc, url) {
 async function scrape(doc, url = doc.location.href) {
 	var item = new Zotero.Item('encyclopediaArticle');
 
-	// Title initially formatted: hangulName(hanjaName); adding space between
 	item.title = ZU.trimInternal(text(doc, ".content-head-title"));
 	item.encyclopediaTitle = "Encyclopedia of Korean Culture";
 	item.publisher = "Academy of Korean Studies";
 	item.language = "ko";
-	item.url = url;
+	// Clean url by removing # terms
+	item.url = url.replace(/#.*/, "");
 
 	// Author processing; may be 0 or more names, would be in Korean
 	var authors = doc.querySelector('div[class="author-wrap"] > span');
@@ -126,7 +126,7 @@ var testCases = [
 				"language": "ko",
 				"libraryCatalog": "Encyclopedia of Korean Culture",
 				"publisher": "Academy of Korean Studies",
-				"url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
+				"url": "https://encykorea.aks.ac.kr/Article/E0013414",
 				"attachments": [],
 				"tags": [],
 				"notes": [],

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,30 +9,30 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-10 10:28:51"
+	"lastUpdated": "2023-09-10 10:33:20"
 }
 
 /*
-    ***** BEGIN LICENSE BLOCK *****
+	***** BEGIN LICENSE BLOCK *****
 
-    Copyright © 2023 jacoblee36251
+	Copyright © 2023 jacoblee36251
 
-    This file is part of Zotero.
+	This file is part of Zotero.
 
-    Zotero is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    Zotero is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
 
-    ***** END LICENSE BLOCK *****
+	***** END LICENSE BLOCK *****
 */
 
 
@@ -44,7 +44,6 @@ function detectWeb(doc, url) {
 	else if (getSearchResults(doc, true)) {
 		return 'multiple';
 	}
-	Zotero.debug("nothing detected") // TODO: REMOVE ME
 	return false;
 }
 
@@ -60,7 +59,6 @@ function getSearchResults(doc, checkOnly) {
 		found = true;
 		items[href] = title;
 	}
-	// Zotero.debug(found ? items : false)
 	return found ? items : false;
 }
 
@@ -81,7 +79,7 @@ async function scrape(doc, url = doc.location.href) {
 	var item = new Zotero.Item('encyclopediaArticle');
 
 	// Title initially formatted: hangulName(hanjaName); adding space between
-	item.title = ZU.trimInternal(text(doc, ".content-head-title"))
+	item.title = ZU.trimInternal(text(doc, ".content-head-title"));
 	item.encyclopediaTitle = "Encyclopedia of Korean Culture";
 	item.publisher = "Academy of Korean Studies";
 	item.language = "ko";

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 01:46:27"
+	"lastUpdated": "2023-09-15 01:59:49"
 }
 
 /*
@@ -38,7 +38,7 @@
 
 function detectWeb(doc, url) {
 	// TODO: adjust the logic here
-	if (/^https?:\/\/[^\/]+\/Article\/E\d+/.test(url)) {
+	if (/^https?:\/\/[^/]+\/Article\/E\d+/.test(url)) {
 		return 'encyclopediaArticle';
 	}
 	else if (getSearchResults(doc, true)) {

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -44,7 +44,7 @@ function doWeb(doc, url) {
 }
 
 function scrape(doc, url) {
-	item = new Zotero.Item('encyclopediaArticle');
+	var item = new Zotero.Item('encyclopediaArticle');
 
 	// Title initially formatted: hangulName(hanjaName); adding space between
 	item.title = doc.title.split(' - ')[0].replace('(', ' (');

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -1,0 +1,122 @@
+{
+	"translatorID": "dc879929-ae39-45b3-b49b-dab2c80815ab",
+	"label": "Encyclopedia of Korean Culture",
+	"creator": "jacoblee36251",
+	"target": "^https?://(www.)?encykorea.aks.ac.kr/Article/E\\d{7}(#.*)?",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2023-08-27 23:38:58"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2023 jacoblee36251
+	
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	return url.match(/E\d{7}(#.*)?/) ? 'encyclopediaArticle' : false;
+}
+
+function doWeb(doc, url) {
+	scrape(doc, url);
+}
+
+function scrape(doc, url) {
+	item = new Zotero.Item('encyclopediaArticle');
+
+	// Title is formatted: hangulName(hanjaName); adding space between
+	item.title = doc.title.split(' - ')[0].replace('(', ' (');
+	item.encyclopediaTitle = "Encyclopedia of Korean Culture";
+	item.publisher = "Academy of Korean Studies";
+	item.language = "ko";
+	item.url = url;
+
+	// Author processing; may be multiple and names will be in Korean
+	var authors = doc.querySelector('div[class="author-wrap"] > span');
+
+	if (authors) {
+		authors = authors.textContent;
+		// For simplicity, assume one character surnames for everybody (there are rare exceptions)
+		for (let author of authors.split('·')) {
+			item.creators.push({
+				"lastName": author[0],
+				"firstName": author.slice(1),
+				"creatorType": "author"
+			});
+		} 
+	}
+	item.complete();
+}/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
+		"detectedItemType": "encyclopediaArticle",
+		"items": [{
+             "itemType": "encyclopediaArticle",
+             "creators": [{
+                     "lastName": "오",
+                     "firstName": "건환",
+                     "creatorType": "author"
+                 }, {
+                     "lastName": "김",
+                     "firstName": "건유",
+                     "creatorType": "author"
+                 }
+             ],
+             "notes": [],
+             "tags": [],
+             "seeAlso": [],
+             "attachments": [],
+             "title": "다대포 (多大浦)",
+             "encyclopediaTitle": "Encyclopedia of Korean Culture",
+             "publisher": "Academy of Korean Studies",
+             "language": "ko",
+             "url": "https://encykorea.aks.ac.kr/Article/E0013414#cm_multimedia",
+             "libraryCatalog": "Encyclopedia of Korean Culture"
+         }]
+	},
+	{
+		"type": "web",
+		"url": "https://encykorea.aks.ac.kr/Article/E0002855",
+		"detectedItemType": "encyclopediaArticle",
+		"items": [{
+			 "itemType": "encyclopediaArticle",
+             "creators": [],
+             "notes": [],
+             "tags": [],
+             "seeAlso": [],
+             "attachments": [],
+             "title": "경주 남산 탑곡 마애불상군 (慶州 南山 塔谷 磨崖佛像群)",
+             "encyclopediaTitle": "Encyclopedia of Korean Culture",
+             "publisher": "Academy of Korean Studies",
+             "language": "ko",
+             "url": "https://encykorea.aks.ac.kr/Article/E0002855",
+             "libraryCatalog": "Encyclopedia of Korean Culture"
+		}]
+	}
+
+]
+/** END TEST CASES **/

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 02:07:55"
+	"lastUpdated": "2023-09-15 08:28:26"
 }
 
 /*
@@ -37,7 +37,6 @@
 
 
 function detectWeb(doc, url) {
-	// TODO: adjust the logic here
 	if (/^https?:\/\/[^/]+\/Article\/E\d+/.test(url)) {
 		return 'encyclopediaArticle';
 	}
@@ -50,7 +49,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = doc.querySelectorAll('li.item > a[href*="/Article/"]');
+	var rows = doc.querySelectorAll('li.item > a[href^="/Article/E"]');
 	for (let row of rows) {
 		let href = row.href;
 		let title = ZU.trimInternal(row.querySelector('div.title').textContent);
@@ -101,7 +100,8 @@ async function scrape(doc, url = doc.location.href) {
 	}
 	item.attachments.push({ title: "Snapshot", document: doc, mimeType: "text/html" });
 	item.complete();
-}/** BEGIN TEST CASES **/
+}
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 01:59:49"
+	"lastUpdated": "2023-09-15 02:06:12"
 }
 
 /*
@@ -186,6 +186,16 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/Search/%ED%95%99%EC%9B%90?field=&type=&alias=false&body=false&containdesc=false&keyword=%ED%95%99%EC%9B%90",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://encykorea.aks.ac.kr/Article/List/Field/%EC%98%88%EC%88%A0%C2%B7%EC%B2%B4%EC%9C%A1%3E%EC%A1%B0%EA%B0%81",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://encykorea.aks.ac.kr/Article/List/Type/%EC%9C%A0%EC%A0%81",
 		"items": "multiple"
 	}
 ]

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 08:34:47"
+	"lastUpdated": "2023-09-15 10:31:10"
 }
 
 /*
@@ -124,9 +124,9 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0013414",
 				"attachments": [],
@@ -145,9 +145,9 @@ var testCases = [
 				"itemType": "encyclopediaArticle",
 				"title": "경주 남산 탑곡 마애불상군 (慶州 南山 塔谷 磨崖佛像群)",
 				"creators": [],
-				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0002855",
 				"attachments": [],
@@ -172,9 +172,9 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"encyclopediaTitle": "Encyclopedia of Korean Culture",
+				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "Encyclopedia of Korean Culture",
+				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0025488",
 				"attachments": [],

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 10:31:10"
+	"lastUpdated": "2023-09-15 20:07:33"
 }
 
 /*
@@ -126,10 +126,15 @@ var testCases = [
 				],
 				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0013414",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -147,10 +152,15 @@ var testCases = [
 				"creators": [],
 				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0002855",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -174,10 +184,15 @@ var testCases = [
 				],
 				"encyclopediaTitle": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
 				"language": "ko",
-				"libraryCatalog": "한국민족문화대백과사전 [Encyclopedia of Korean Culture]",
+				"libraryCatalog": "Encyclopedia of Korean Culture",
 				"publisher": "Academy of Korean Studies",
 				"url": "https://encykorea.aks.ac.kr/Article/E0025488",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -187,16 +202,19 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/Search/%ED%95%99%EC%9B%90?field=&type=&alias=false&body=false&containdesc=false&keyword=%ED%95%99%EC%9B%90",
+		"detectedItemType": "multiple",
 		"items": "multiple"
 	},
 	{
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/List/Field/%EC%98%88%EC%88%A0%C2%B7%EC%B2%B4%EC%9C%A1%3E%EC%A1%B0%EA%B0%81",
+		"detectedItemType": "multiple",
 		"items": "multiple"
 	},
 	{
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/List/Type/%EC%9C%A0%EC%A0%81",
+		"detectedItemType": "multiple",
 		"items": "multiple"
 	}
 ]

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -2,14 +2,14 @@
 	"translatorID": "dc879929-ae39-45b3-b49b-dab2c80815ab",
 	"label": "Encyclopedia of Korean Culture",
 	"creator": "jacoblee36251",
-	"target": "^https?://(www\\\\.)?encykorea\\\\.aks\\\\.ac\\\\.kr/Article/",
+	"target": "^https?://(www\\.)?encykorea\\.aks\\.ac\\.kr/Article/",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-10 11:01:49"
+	"lastUpdated": "2023-09-15 01:46:27"
 }
 
 /*
@@ -38,7 +38,7 @@
 
 function detectWeb(doc, url) {
 	// TODO: adjust the logic here
-	if (url.match(/E\d{7}(#.*)?/)) {
+	if (/^https?:\/\/[^\/]+\/Article\/E\d+/.test(url)) {
 		return 'encyclopediaArticle';
 	}
 	else if (getSearchResults(doc, true)) {
@@ -50,10 +50,10 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = doc.querySelectorAll('li[class="item"] > a[href*="/Article/"]');
+	var rows = doc.querySelectorAll('li.item > a[href*="/Article/"]');
 	for (let row of rows) {
 		let href = row.href;
-		let title = ZU.trimInternal(row.querySelector('div[class="title"]').textContent);
+		let title = ZU.trimInternal(row.querySelector('div.title').textContent);
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -79,14 +79,14 @@ async function scrape(doc, url = doc.location.href) {
 	var item = new Zotero.Item('encyclopediaArticle');
 
 	item.title = ZU.trimInternal(text(doc, ".content-head-title"));
-	item.encyclopediaTitle = "Encyclopedia of Korean Culture";
+	item.encyclopediaTitle = "한국민족문화대백과사전 [Encyclopedia of Korean Culture]";
 	item.publisher = "Academy of Korean Studies";
 	item.language = "ko";
 	// Clean url by removing # terms
 	item.url = url.replace(/#.*/, "");
 
 	// Author processing; may be 0 or more names, would be in Korean
-	var authors = doc.querySelector('div[class="author-wrap"] > span');
+	var authors = doc.querySelector('div.author-wrap > span');
 
 	if (authors) {
 		authors = authors.textContent;
@@ -100,6 +100,7 @@ async function scrape(doc, url = doc.location.href) {
 		}
 	}
 	item.complete();
+	item.attachments.push({ title: "Snapshot", document: doc, mimeType: "text/html" });
 }/** BEGIN TEST CASES **/
 var testCases = [
 	{

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-08-28 00:04:42"
+	"lastUpdated": "2023-08-28 00:11:25"
 }
 
 /*
@@ -35,12 +35,7 @@
 	***** END LICENSE BLOCK *****
 */
 
-function text(docOrElem, selector, index) {
-	var elem = index ? docOrElem.querySelectorAll(selector).item(index) : docOrElem.querySelector(selector);
-	return elem ? elem.textContent : null;
-}
-
-function detectWeb(doc, url) {
+function detectWeb() {
 	return 'encyclopediaArticle';
 }
 
@@ -132,14 +127,15 @@ var testCases = [
 		"type": "web",
 		"url": "https://encykorea.aks.ac.kr/Article/E0025488",
 		"detectedItemType": "encyclopediaArticle",
-		"items": [{
+		"items": [
+			{
 				"itemType": "encyclopediaArticle",
 				"title": "사랑 (舍廊)",
 				"creators": [{
-						"lastName": "김",
-						"firstName": "동욱",
-						"creatorType": "author"
-					}],
+					"lastName": "김",
+					"firstName": "동욱",
+					"creatorType": "author"
+				}],
 				"encyclopediaTitle": "Encyclopedia of Korean Culture",
 				"language": "ko",
 				"libraryCatalog": "Encyclopedia of Korean Culture",
@@ -149,7 +145,8 @@ var testCases = [
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
-		}]
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/Encyclopedia of Korean Culture.js
+++ b/Encyclopedia of Korean Culture.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-15 08:28:26"
+	"lastUpdated": "2023-09-15 08:34:47"
 }
 
 /*
@@ -101,6 +101,7 @@ async function scrape(doc, url = doc.location.href) {
 	item.attachments.push({ title: "Snapshot", document: doc, mimeType: "text/html" });
 	item.complete();
 }
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{


### PR DESCRIPTION
Wrote a quick translator for the [Encyclopedia of Korean Culture](https://encykorea.aks.ac.kr/) ([background info in eng here](https://en.wikipedia.org/wiki/Encyclopedia_of_Korean_Culture)). It's pretty widely referenced on the English and Korean Wikipedias.

Some notes:
* Is handling multiples required? For this website, referencing a search is bad practice I think. It's subject to link rot as the search alg changes; I myself have seen this issue on Wikipedia for this website.
* Family name handling. For now I added the assumption that the surname will always be one character (see [Korean name](https://en.wikipedia.org/wiki/Korean_name)), which is true probably >99% of the time in Korea. Koreans don't put a space between their given and family name, so it's hard to tell where it ends. Partial solution would be to write out a dictionary of all registered surnames in South Korea and cross check the full name with the possibility that it has a two char surname, but even then it can be impossible to reliably tell. Imo not worth pursuing.