### PR TITLE
ACS Publications: Fix PDF attachment and supplements; recognize more target pages; efficiency improvements

### DIFF
--- a/ACS Publications.js
+++ b/ACS Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-09-14 09:56:33"
+	"lastUpdated": "2023-09-16 00:07:05"
 }
 
 /*
@@ -94,8 +94,9 @@ function getSupplements(doc, supplementAsLink = false) {
 		let elem = supplementLinks[i];
 		let url = elem.href;
 		if (!url) continue;
-		let cleanURL = url.replace(/[?#].+$/, "");
-		let ext = cleanURL.split(".").at(-1).toLowerCase();
+		let pathComponents = url.replace(/[?#].+$/, "").split(".");
+		// possible location of file extension (following the last dot)
+		let ext = pathComponents[pathComponents.length - 1].toLowerCase();
 		let mimeType = suppTypeMap[ext];
 		// Only save file when MIME type is known *and* when we aren't
 		// specifically told otherwise
@@ -250,7 +251,7 @@ async function scrape(doc, url, supplementAsLink) {
 			// standard pdf
 			item.attachments.push({
 				title: "Full Text PDF",
-				url: new URL(`/doi/pdf/${doi}`, url).href,
+				url: `/doi/pdf/${doi}`,
 				mimeType: "application/pdf"
 			});
 		}


### PR DESCRIPTION
For #3089, we now use the correct PDF links for ACS articles.

The supplements will be saved as attachments if the [hidden prefs](https://www.zotero.org/support/preferences/hidden_preferences#translator_preferences1) say so.

The translator now also works on the "epdf" viewer page and the standalone citation export page.

When the full text PDF is available, the webpage snapshot is no longer saved.

The translator will now try to conserve bandwidth, and it will not retrieve the page if the URL is sufficient for the output. The page document will be used when supplements are requested, because the supplement URLs are only available in the page content.

Successive requests for RIS files are spaced by 0.5 seconds.

**NOTE** that the tests don't cover the saving of supplements, because this depends on the hidden prefs and the default behaviour is to not save them.