### PR TITLE
DOI web translator: Offer the current page as a choice among the multiple

### DIFF
--- a/DOI.js
+++ b/DOI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-10-18 11:11:59"
+	"lastUpdated": "2023-10-18 13:29:55"
 }
 
 /*
@@ -258,7 +258,7 @@ async function retrieveDOIs(doiOrDOIs, fallbackDoc) {
 async function doWeb(doc, url) {
 	let doiOrDOIs = getDOIs(doc, url);
 	Z.debug(doiOrDOIs);
-	await retrieveDOIs(doiOrDOIs);
+	await retrieveDOIs(doiOrDOIs, doc);
 }
 
 // Build a key -> title mapping to be passed to Z.selectItems().


### PR DESCRIPTION
If the DOI translator turns out to be the one that matches the current page, and if the DOI (this) translator detects the item type as "multiple", offer the current page as one of the choices (indeed, the first choice).

In the item selection dialog, this special choice will show up as "Current Webpage", followed by the page title in parenthesis if the title is present.

The specific situation that triggers this behavior is the following

1. None other than the DOI web translator (lowest priority) matches the current page
2. The current page itself is not the main resource identified by DOI present on the current page (e.g. a page with its own DOI in URL)

Resolves #3126.