### PR TITLE
Fix for EBSCO DL

### DIFF
--- a/EBSCO Discovery Layer.js
+++ b/EBSCO Discovery Layer.js
@@ -2,14 +2,14 @@
 	"translatorID": "660fcf3e-3414-41b8-97a5-e672fc2e491d",
 	"label": "EBSCO Discovery Layer",
 	"creator": "Sebastian Karcher",
-	"target": "^https?://discovery\\.ebsco\\.com/",
+	"target": "^https?://(discovery|research)\\.ebsco\\.com/",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-02-12 03:36:07"
+	"lastUpdated": "2023-09-16 00:45:19"
 }
 
 /*


### PR DESCRIPTION
https://forums.zotero.org/discussion/107688/zotero-connector-ebsco-discovery-service/p1

Only have the one guest access, but looks like this is really just a change in the base URL.