### PR TITLE
ESLint plugin: Allow array (of objects) as search translator input

### DIFF
--- a/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
+++ b/.ci/eslint-plugin-zotero-translator/lib/rules/test-cases.js
@@ -80,8 +80,15 @@ module.exports = {
 					else if (testCase.type === 'search') {
 						// console.log(JSON.stringify(testCase.input))
 						const expected = ['DOI', 'ISBN', 'PMID', 'identifiers', 'contextObject', 'adsBibcode', 'ericNumber'];
-						if (!Object.keys(testCase.input).every(key => expected.includes(key))) {
-							let invalidKey = Object.keys(testCase.input).find(key => !expected.includes(key));
+						let keys;
+						if (Array.isArray(testCase.input)) {
+							keys = testCase.input.flatMap(Object.keys);
+						}
+						else {
+							keys = Object.keys(testCase.input);
+						}
+						if (!keys.every(key => expected.includes(key))) {
+							let invalidKey = keys.find(key => !expected.includes(key));
 							context.report({
 								message: `${prefix} of type "${testCase.type}" has invalid search term '${invalidKey}' - expected one of ${expected.join(', ')}`,
 								loc,


### PR DESCRIPTION
The input of a search-translator test case can be an array of objects, but ESLint spuriously detects invalid input key. It assumed that the input be a (non-array) object, looked at the numeric keys, and reported error.

This is fixed by adding an `Array.isArray()` test. The keys are extracted from the array elements if the input is indeed an array.