### PR TITLE
IEEE Xplore: Don't use export format; save full text PDF

### DIFF
--- a/IEEE Xplore.js
+++ b/IEEE Xplore.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-10-09 10:41:18"
+	"lastUpdated": "2023-10-10 02:08:12"
 }
 
 /*
@@ -204,7 +204,10 @@ async function scrape(doc, url = doc.location.href) {
 	let issueNumber = metadata.isNumber;
 	let publicationNumber = metadata.publicationNumber;
 	if (issueNumber && publicationNumber) {
-		item.attachments.push(getFullTextPDF(articleID, issueNumber, publicationNumber));
+		item.attachments.push(
+			getFullTextPDF(articleID, metadata.openAccessFlag === "T",
+				issueNumber, publicationNumber)
+		);
 	}
 
 	if (metadata.xploreNote) {
@@ -285,11 +288,17 @@ function setSN(item, metadata, snType) {
 	}
 }
 
-function getFullTextPDF(articleID, isNumber, puNumber) {
+function getFullTextPDF(articleID, isOA, isNumber, puNumber) {
 	// "ref" is the base64-encoded canonical URL of article without the
 	// trailing slash. The encoded URL is always ASCII so btoa() suffices.
 	let ref = btoa(`${BASE_URL}/document/${articleID}`);
-	let url = `${BASE_URL}/ielx7/${puNumber}/${isNumber}/${ZU.lpad(articleID, "0", 8)}.pdf?tp=&arnumber=${articleID}&isnumber=${isNumber}&ref=${ref}`;
+	let url;
+	if (isOA) {
+		url = `${BASE_URL}/ielx7/${puNumber}/${isNumber}/${ZU.lpad(articleID, "0", 8)}.pdf?tp=&arnumber=${articleID}&isnumber=${isNumber}&ref=${ref}`;
+	}
+	else {
+		url = `${BASE_URL}/stampPDF/getPDF.jsp?tp=&arnumber=${articleID}&ref=${ref}`;
+	}
 	return { title: "Full Text PDF", url, mimeType: "application/pdf" };
 }
 


### PR DESCRIPTION
The "endpoint" for export formats (BibTeX, RIS, etc.) may be unreliable unless the referrer is sent, but this is not yet feasible for Chromium-family browsers in Connector.

(See: https://forums.zotero.org/discussion/108011/ieee-xplore-falied; cf. #3150)

This is changed to a scraper that looks at just the page content, therefore avoiding the endpoint call.

The pages are rendered on the client side, so we read the data source as JSON directly, without scraping the DOM.

In addition, the following changes are made --

- The full-text PDF file is now saved as an attachment (if the user has access to it).
- The translator now also works on IEEE Xplore's own full-text PDF viewer web app. This is done via an additional network request to the abstract page where the JSON metadata are hosted. A test case for this is added.
- Tags (keywords) are deduplicated.
- Only the electronic-media ISBN and ISSN are kept.
- Other minor bugfixes.