### PR TITLE
Run `npm run lint` only when there's any translator change

### DIFF
--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -6,4 +6,6 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . "$dir/helper.sh"
 
 get_translators_to_check
-npm run lint -- "$TRANSLATORS_TO_CHECK"
+if [ -n "$TRANSLATORS_TO_CHECK" ]; then
+	npm run lint -- "$TRANSLATORS_TO_CHECK"
+fi


### PR DESCRIPTION
Fixes #3211 