### PR TITLE
Note HTML: Replace bidi control chars with HTML

### DIFF
--- a/Note HTML.js
+++ b/Note HTML.js
@@ -14,7 +14,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 2,
-	"lastUpdated": "2022-10-26 10:47:11"
+	"lastUpdated": "2024-01-02 18:26:09"
 }
 
 /*
@@ -140,7 +140,11 @@ function doExport() {
 					}
 				}
 
-				let items = Array.from(span.querySelectorAll('.citation-item')).map(x => x.textContent);
+				let items = Array.from(span.querySelectorAll('.citation-item'))
+					.map(x => x.innerText
+						// Replace bidi control characters (FIRST STRONG ISOLATE, POP DIRECTIONAL ISOLATE)
+						// with an HTML equivalent so they don't show as placeholders in Office apps
+						.replace(/\u2068([^\u2069]*)\u2069/g, '<span style="unicode-bidi: isolate">$1</span>'));
 				// Fallback to pre v5 note-editor schema that was serializing citations as plain text i.e.:
 				// <span class="citation" data-citation="...">(Jang et al., 2005, p. 14; Kongsgaard et al., 2009, p. 790)</span>
 				if (!items.length) {


### PR DESCRIPTION
This is intended to fix zotero/zotero#3552. I don't have access to desktop Office and the problem doesn't occur in Word Online, so this is just a best guess.

We could use `<bdi>`, but `<span>` seems safer; very old editors (`<bdi>` was implemented in browsers around 2012) might handle an unknown tag badly.

All editors I tried - Word Online, Google Docs, TextEdit, Zotero's note editor - strip the `<span>`s when pasting, so they're harmless but also maybe useless. I think I like the idea of keeping them because they *do* serve a purpose, but we could also just remove them fully.