### PR TITLE
Use https when access export.arxiv.org

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -111,7 +111,7 @@ function doWeb(doc, url) {
 			
 			var urls = [];
 			for (var id in items) {
-				urls.push('http://export.arxiv.org/oai2'
+				urls.push('https://export.arxiv.org/oai2'
 					+ '?verb=GetRecord&metadataPrefix=oai_dc'
 					+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(id)
 				);
@@ -137,7 +137,7 @@ function doWeb(doc, url) {
 		}
 		if (!id) throw new Error('Could not find arXiv ID on page.');
 		id = id.trim().replace(/^arxiv:\s*|v\d+|\s+.*$/ig, '');
-		var apiurl = 'http://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
+		var apiurl = 'https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
 			+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(id);
 		ZU.doGet(apiurl, parseXML);
 	}

--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 12,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-05-12 01:25:32"
+	"lastUpdated": "2024-01-05 12:21:40"
 }
 
 /*


### PR DESCRIPTION
This avoid some failure when save arxiv due to using http.