### PR TITLE
Fixed some errors in translator for "ABC News Australia"

### DIFF
--- a/ABC News Australia.js
+++ b/ABC News Australia.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-01-09 21:09:32"
+	"lastUpdated": "2024-01-12 21:22:12"
 }
 
 /*
@@ -38,7 +38,7 @@
 
 function detectWeb(doc, _url) {
 	let contentType = attr(doc, 'meta[property="ABC.ContentType"]', 'content');
-	contentType = contentType.toUpperCase();	// Case-insensitive treatment of content type
+	contentType = contentType.toUpperCase(); // Case-insensitive treatment of content type
 	if (contentType == 'CMCHANNEL' && getSearchResults(doc, true)) {
 		return 'multiple';
 	}
@@ -114,8 +114,8 @@ function scrape(doc, url) {
 		var authorNameLinks = doc.querySelectorAll('[data-uri^="coremedia://person/"]');
 		var bylineText = text(doc, '[data-component="Byline"] p, [data-component="Byline"] span');
 		if (authorNameLinks.length > 0) {
-			for (let i = 0; i < authorNameLinks.length; i++) {
-				let authorName = authorNameLinks[i].innerText;
+			for (let authorLink of authorNameLinks) {
+				let authorName = authorLink.textContent;
 				item.creators.push(ZU.cleanAuthor(authorName, "author"));
 			}
 		}
@@ -126,8 +126,8 @@ function scrape(doc, url) {
 			}
 			item.creators = [];
 			var authorsList = bylineText.split(/,|\band\b/);
-			for (let i = 0; i < authorsList.length; i++) {
-				item.creators.push(ZU.cleanAuthor(authorsList[i], "author"));
+			for (let author of authorsList) {
+				item.creators.push(ZU.cleanAuthor(author, "author"));
 			}
 		}
 		


### PR DESCRIPTION
Contributed the following to `ABC News Australia.js`:

1. Made `contentType` comparison for detection case-insensitive. Case-sensitivity was causing one of the test cases to fail because the `contentType` was `video` rather than `Video`.
2. Added code to detect authors by grabbing their names from elements with a `data-uri` attribute starting with `coremedia://person/`, when such elements exist. Previous method of author name detection is now used as a fallback. The previous method fails when author titles such as "weather correspondent" or "global affairs editor" are present.
3. Added a third test case to reflect the above quirk.

Before these modifications, the first test case failed and the second failed detection. Now the first test case passes and the second passes detection, but still fails due to an incorrect `abstractNote`. But this appears to be an issue with a different translator that is being used here (whichever one has GUID equal to `951c027d-74ac-47d4-a107-9c3069ab7b48`).

P.S. This is my first contribution, just learning how Zotero translators work! :-)