### PR TITLE
Wait for `translatorServer.serve()`

### DIFF
--- a/.ci/pull-request-check/selenium-test.js
+++ b/.ci/pull-request-check/selenium-test.js
@@ -98,7 +98,7 @@ var allPassed = false;
 (async function() {
 	let driver;
 	try {
-		translatorServer.serve();
+		await translatorServer.serve();
 		require('chromedriver');
 		let chrome = require('selenium-webdriver/chrome');
 		let options = new chrome.Options();


### PR DESCRIPTION
Otherwise `getTranslatorsToTest` will fail because `filenameToTranslator` will still be empty.