### PR TITLE
Unbreak NYPL translator when annotatedMarc = null

### DIFF
--- a/NYPL Research Catalog.js
+++ b/NYPL Research Catalog.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-06-22 22:58:06"
+	"lastUpdated": "2024-01-26 23:24:00"
 }
 
 /*

--- a/NYPL Research Catalog.js
+++ b/NYPL Research Catalog.js
@@ -79,7 +79,7 @@ function scrape(doc, _url) {
 	let bib = JSON.parse(jsonText).bib;
 	
 	// it's easiest we get MARC, but some items don't have it
-	if (bib.annotatedMarc.bib.fields.length) {
+	if (bib.annotatedMarc && bib.annotatedMarc.bib.fields.length) {
 		scrapeMARC(bib.annotatedMarc.bib.fields);
 	}
 	else {


### PR DESCRIPTION
NYPL Catalog translator does not work in multiple instances when there bib.annotatedMarc = null in the JSON

E.g., https://www.nypl.org/research/research-catalog/bib/cb2043942

By adding a check, the translator won't fail and it'll fall back to the second (scraper) option