### PR TITLE
Add responsive html as arXiv attachment

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -230,6 +230,14 @@ function parseXML(text) {
 		url: pdfUrl,
 		mimeType: "application/pdf"
 	});
+	
+	var htmlUrl = "https://ar5iv.labs.arxiv.org/html/" + articleID + (version ? "v" + version : "");
+	newItem.attachments.push({
+		title: "arXiv Responsive HTML",
+		url: htmlUrl,
+		mimeType: "text/html"
+	});
+	
 	newItem.attachments.push({
 		title: "arXiv.org Snapshot",
 		url: newItem.url,


### PR DESCRIPTION
This PR aims to add articles from [arXiv.org](https://arxiv.org/) as responsive HTML5 web pages from [ar5iv](https://ar5iv.labs.arxiv.org/). This format of article is more suitable for human-reading and annotating, especially now that the latest Zotero 7 Beta provides [support for reading html snapshots](https://forums.zotero.org/discussion/106716/available-for-beta-testing-updated-reader-with-epub-snapshot-support-and-new-annotation-types/p1).