### PR TITLE
Add translator for CITATION.cff file references (`CFF-References`)

### DIFF
--- a/CFF-References.js
+++ b/CFF-References.js
@@ -71,8 +71,6 @@ function writeAuthors(itemCreators) {
 function doExport() {
 	var item;
 
-	var references_spacing = '    '
-
 	Zotero.write('# This CITATION.cff reference content was generated from Zotero.\n');
 	Zotero.write('references:\n');
 

--- a/CFF-References.js
+++ b/CFF-References.js
@@ -34,34 +34,35 @@
 	***** END LICENSE BLOCK *****
 */
 
+// set a global for spacing purposes under the references key of a citation.cff file
+var references_spacing = '    '
+
 function writeKeywords(tags) {
 	if (!tags.length) return false;
 	let keywords = "\n";
 	for (let tag of tags) {
-		keywords += "  - " + tag.tag + "\n";
+		keywords += references_spacing + "  - " + tag.tag + "\n";
 	}
 	return keywords.replace(/\\n$/, "");
 }
 
 function writeDOI(itemDOI) {
 	if (!itemDOI) return false;
-	let doi = "\n  - type: doi\n    value: " + itemDOI + "\n";
+	let doi = "\n" + references_spacing + "  - type: doi\n" + references_spacing + "    value: " + itemDOI + "\n";
 	return doi;
 }
 
 function writeAuthors(itemCreators) {
 	let itemAuthors = [];
 	for (let creator of itemCreators) {
-		if (creator.creatorType == "author" || creator.creatorType == "programmer") {
-			itemAuthors.push(creator);
-		}
+		itemAuthors.push(creator);
 	}
 	if (!itemAuthors.length) return false;
 	let authors = "\n";
 	for (let author of itemAuthors) {
-		authors += "  - family-names: " + author.lastName + "\n";
+		authors += references_spacing + "  - family-names: " + author.lastName + "\n";
 		if (author.firstName) {
-			authors += "    given-names: " + author.firstName + "\n";
+			authors += references_spacing + "    given-names: " + author.firstName + "\n";
 		}
 	}
 	return authors;
@@ -70,6 +71,8 @@ function writeAuthors(itemCreators) {
 function doExport() {
 	var item;
 
+	var references_spacing = '    '
+
 	Zotero.write('# This CITATION.cff reference content was generated from Zotero.\n');
 	Zotero.write('references:\n');
 
@@ -77,7 +80,7 @@ function doExport() {
 	while (item = Zotero.nextItem()) {
 
 		var cff = {};
-		cff.title = " >-\n  " + item.title;
+		cff.title = ">-\n" + references_spacing + "  " + item.title + "\n";
 		cff.abstract = item.abstractNote;
 		cff.type = item.itemType;
 		cff.license = item.rights;
@@ -94,13 +97,22 @@ function doExport() {
 		}
 		cff.identifiers = writeDOI(item.DOI);
 
+		// prep the entry as a new item
+		Zotero.write('  - ')
+
+		// loop through the cff elements and write output
 		for (let field in cff) {
 			if (!cff[field]) continue;
-			if (field == "authors" || field == "keywords") {
+			if( field == "title"){
+				// rely on prep dash for item start above for titles
 				Zotero.write(field + ": " + cff[field]);
-			}
-			else {
-				Zotero.write(field + ": " + cff[field] + "\n");
+			}else if (field == "abstract"){
+				// special case for abstract, which can sometimes be large
+				Zotero.write(references_spacing + field + ": |\n" + references_spacing + "  " + cff[field] + "\n");
+			}else if (field == "authors" || field == "keywords") {
+				Zotero.write(references_spacing + field + ": " + cff[field]);
+			}else {
+				Zotero.write(references_spacing + field + ": " + cff[field] + "\n");
 			}
 		}
 	}

--- a/CFF-References.js
+++ b/CFF-References.js
@@ -1,0 +1,112 @@
+{
+	"translatorID": "99A6641F-A8C2-4923-9BBB-0DA87F1E5187",
+	"label": "CFF-References",
+	"creator": "Sebastian Karcher, Dave Bunten",
+	"target": "cff",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 2,
+	"lastUpdated": "2024-03-15 12:21:10"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2023 Sebastian Karcher
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function writeKeywords(tags) {
+	if (!tags.length) return false;
+	let keywords = "\n";
+	for (let tag of tags) {
+		keywords += "  - " + tag.tag + "\n";
+	}
+	return keywords.replace(/\\n$/, "");
+}
+
+function writeDOI(itemDOI) {
+	if (!itemDOI) return false;
+	let doi = "\n  - type: doi\n    value: " + itemDOI + "\n";
+	return doi;
+}
+
+function writeAuthors(itemCreators) {
+	let itemAuthors = [];
+	for (let creator of itemCreators) {
+		if (creator.creatorType == "author" || creator.creatorType == "programmer") {
+			itemAuthors.push(creator);
+		}
+	}
+	if (!itemAuthors.length) return false;
+	let authors = "\n";
+	for (let author of itemAuthors) {
+		authors += "  - family-names: " + author.lastName + "\n";
+		if (author.firstName) {
+			authors += "    given-names: " + author.firstName + "\n";
+		}
+	}
+	return authors;
+}
+
+function doExport() {
+	var item;
+
+	Zotero.write('# This CITATION.cff reference content was generated from Zotero.\n');
+	Zotero.write('references:\n');
+
+	// eslint-disable-next-line no-cond-assign
+	while (item = Zotero.nextItem()) {
+
+		var cff = {};
+		cff.title = " >-\n  " + item.title;
+		cff.abstract = item.abstractNote;
+		cff.type = item.itemType;
+		cff.license = item.rights;
+		cff.version = item.versionNumber;
+		cff.url = item.url;
+		cff.keywords = writeKeywords(item.tags);
+		cff.authors = writeAuthors(item.creators);
+		if (item.date) {
+			cff["date-released"] = ZU.strToISO(item.date);
+		}
+		// get DOI from Extra for software; this will stop running automatically once software supports DOI
+		if (!ZU.fieldIsValidForType('DOI', item.itemType) && /^doi:/i.test(item.extra)) {
+			item.DOI = ZU.cleanDOI(item.extra);
+		}
+		cff.identifiers = writeDOI(item.DOI);
+
+		for (let field in cff) {
+			if (!cff[field]) continue;
+			if (field == "authors" || field == "keywords") {
+				Zotero.write(field + ": " + cff[field]);
+			}
+			else {
+				Zotero.write(field + ": " + cff[field] + "\n");
+			}
+		}
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/


### PR DESCRIPTION
This PR extends on the work originally provided by @adam3smith for the CFF translator as a new translator called "CFF-References". The purpose of this translator is to help translate Zotero resources into a [CITATION.cff](https://citation-file-format.github.io/) file's [`references` item](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#referencing-other-work).

Thank you in advance for any thoughts and feedback you may have! Please don't hesitate to let me know if I may change or improve this to help make it more useful to others.

Closes #3250 