### PR TITLE
Fix APA PsycNET `fulltext` match issue

### DIFF
--- a/APA PsycNET.js
+++ b/APA PsycNET.js
@@ -207,10 +207,10 @@ async function getIds(doc, url) {
 	}
 
 	// try to extract uid from the url
-	if (url.includes('/record/')) {
-		let m = url.match(/\/record\/([\d-]*)/);
-		if (m && m[1]) {
-			return m[1];
+	if (url.includes('/record/') || url.includes('/fulltext/')) {
+		let m = url.match(/\/(record|fulltext)\/([\d-]*)/);
+		if (m && m[2]) {
+			return m[2];
 		}
 	}
 


### PR DESCRIPTION
Fix the APA PsycNET save issue when URL containing `fulltext` (#1676, the `buy` issue has been fixed by others)
Example URL: https://psycnet.apa.org/fulltext/2022-40433-002.html
