### PR TITLE
Add French plural definite article to cite key banned title words

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -371,7 +371,7 @@ var numberRe = /^[0-9]+/;
 // it includes the indefinite articles of English, German, French and Spanish, as well as a small set of English prepositions whose
 // force is more grammatical than lexical, i.e. which are likely to strike many as 'insignificant'.
 // The assumption is that most who want a title word in their key would prefer the first word of significance.
-var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l'|el|las|los|al|uno|una|unos|unas|de|des|del|d')(\s+|\b)|(<\/?(i|b|sup|sub|sc|span style="small-caps"|span)>)/g;
+var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l'|les|el|las|los|al|uno|una|unos|unas|de|des|del|d')(\s+|\b)|(<\/?(i|b|sup|sub|sc|span style="small-caps"|span)>)/g;
 var citeKeyConversionsRe = /%([a-zA-Z])/;
 
 var citeKeyConversions = {


### PR DESCRIPTION
Not sure if this was excluded on purpose, but if not 'les' was missing from the list. E.g. in

```bibtex
@article{vandel_les_1958,
	title = {Les activités du Laboratoire souterrain du C.N.R.S. à Moulis},
	issn = {0369-3392},
	url = {https://cnum.cnam.fr/pgi/fpage.php?4KY28.153/284/100/527/5/513},
	pages = {280--282},
	number = {3279},
	journaltitle = {La Nature},
	author = {Vandel, Albert},
	date = {1958},
	langid = {french},
}
```

I would rather have

```bibtex
@article{vandel_activites_1958,
...
```