### PR TITLE
Research Square: fix publication date retrieval

### DIFF
--- a/Research Square.js
+++ b/Research Square.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-03-21 19:37:52"
+	"lastUpdated": "2024-04-01 19:07:11"
 }
 
 /*
@@ -114,6 +114,12 @@ async function scrape(doc, url = doc.location.href) {
 		}
 			
 		item.url = bareURL;
+
+		// RIS contains only the DY tag set to the retrieval date, not the publication one
+		let pubDate = attr(doc, "meta[name='citation_publication_date']", "content");
+		if (pubDate) {
+			item.date = pubDate;
+		}
 			
 		item.complete();
 	});
@@ -161,7 +167,7 @@ var testCases = [
 						"firstName": "Christoph"
 					}
 				],
-				"date": "2024-03-21",
+				"date": "2021-07-12",
 				"DOI": "10.21203/rs.3.rs-629724/v1",
 				"abstractNote": "The formation of peptide bonds is one of the most important biochemical reaction steps. Without the development of structurally and catalytically active polymers, there would be no life on our planet. Intensive research is being conducted on possible reaction pathways for the formation of complex peptides on the early Earth. Salt-induced peptide formation (SIPF) by metal catalysis is one possible pathway for abiotic peptide synthesis. The high salt concentration supports dehydration in this process. However, the formation of large, complex oligomer systems is prevented by the high thermodynamic barrier of peptide condensation in aqueous solution. Liquid sulphur dioxide proves to be a superior alternative for copper-catalysed peptide condensation. Compared to water, the amino acids are activated in sulphur dioxide, which leads to the incorporation of all 20 proteinogenic amino acids into the resulting proteins and thus to a large variety of products. Strikingly, even extremely low initial reactant concentrations of only 50 mM are sufficient for extensive peptide formation, leading to an overall yield of 2.9% for dialanine in 7 days. The reactions carried out at room temperature and the successful use of the Hadean mineral covellite as a catalyst, suggest a volcanic environment for the formation of the peptide world on early Earth as a likely scenario.",
 				"libraryCatalog": "Research Square",
@@ -303,7 +309,7 @@ var testCases = [
 						"firstName": "Adrien"
 					}
 				],
-				"date": "2024-03-21",
+				"date": "2021-07-19",
 				"DOI": "10.21203/rs.3.rs-624370/v1",
 				"abstractNote": "A worldwide effort is ongoing to discover drugs against the Severe Acute Respiratory Syndrome coronavirus type 2 (SARS-CoV-2), which has so far caused &gt;3.5 million fatalities (https://covid19.who.int/). The virus essential RNA-dependent RNA polymerase complex is targeted by several nucleoside/tide analogues whose mechanisms of action and clinical potential are currently evaluated. The guanosine analogue AT-527, a double prodrug of its 5&#039;-triphosphate AT-9010, is currently in phase III clinical trials as a COVID19 treatment. Here we report the cryo-EM structure at 2.98 Å resolution of the SARS-CoV-2 nsp12-nsp7-(nsp8)2 complex with RNA showing AT-9010 bound at three sites of nsp12. At the RdRp active-site, one AT-9010 is incorporated into the RNA product. Its 2&#039;-methyl group prevents correct alignment of a second AT-9010 occupying the incoming NTP pocket. The 2&#039;-F, 2&#039;-methyl 3&#039;-OH ribose scaffold explains the non-obligate RNA chain-termination potency of this NA series for both HCV NS5 and SARS-CoV RTCs. A third AT-9010 molecule 5&#039;-diphosphate binds to a coronavirus-specific pocket in the nsp12 N-terminus NiRAN domain, a SelO pseudo-kinase structural and functional homologue. This unique binding mode impedes NiRAN-mediated UMPylation of SARS-CoV-2 nsp8 and nsp9 proteins. Our results suggest a mechanism of action for AT-527 in line with a therapeutic use for COVID19.",
 				"libraryCatalog": "Research Square",


### PR DESCRIPTION
As discussed in https://github.com/zotero/translators/pull/3279#discussion_r1536904272, this fixes the publication date retrieval for Research Square translator. The RIS being returned only has the `DY` tag and it is set to the retrieval date, not the publication one. We'll pull the correct date from page metadata instead.

Together with #3279, this I think fully fixes #3232.