### PR TITLE
Note HTML & Note Markdown: Add annotation key to all reader links

### DIFF
--- a/Note HTML.js
+++ b/Note HTML.js
@@ -14,7 +14,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 2,
-	"lastUpdated": "2024-04-10 19:44:00"
+	"lastUpdated": "2024-04-24 14:50:00"
 }
 
 /*

--- a/Note Markdown.js
+++ b/Note Markdown.js
@@ -14,7 +14,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 2,
-	"lastUpdated": "2024-03-19 15:35:00"
+	"lastUpdated": "2024-04-24 14:50:00"
 }
 
 /*
@@ -1534,9 +1534,11 @@ function convert(doc) {
 					linkText = 'snapshot';
 				}
 				else {
-					openURI += '?page=' + (position.pageIndex + 1)
-						+ (annotation.annotationKey ? '&annotation=' + annotation.annotationKey : '');
+					openURI += '?page=' + (position.pageIndex + 1);
 					linkText = 'pdf';
+				}
+				if (annotation.annotationKey) {
+					openURI += '&annotation=' + annotation.annotationKey;
 				}
 
 				let a = doc.createElement('a');


### PR DESCRIPTION
Not sure why I didn't do this in #3253 - no good reason not to add the key to EPUB/snapshot links.

@mrtcode: Let me know if this looks OK to apply to Note Markdown as well.