### PR TITLE
DOI: Recover when one DOI fails to resolve

### DIFF
--- a/DOI.js
+++ b/DOI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-03-22 04:01:25"
+	"lastUpdated": "2024-06-04 14:34:03"
 }
 
 /*
@@ -214,7 +214,12 @@ async function retrieveDOIs(doiOrDOIs) {
 		// Don't throw on error
 		translate.setHandler("error", function () {});
 	
-		await translate.translate();
+		try {
+			await translate.translate();
+		}
+		catch (e) {
+			Zotero.debug(`Failed to resolve DOI '${doi}': ${e}`);
+		}
 	}
 }
 


### PR DESCRIPTION
We still need the `error` handler because the default child-translator `error` handler fails translation on the parent, no matter whether or not the error was caught. (Another result of our fake-async control flow... But I'm not sure there's anything we can do to fix it globally that won't break old translators.)

Addresses #3311