### PR TITLE
ScienceDirect: Asyncify, don't save snapshots on search results

### DIFF
--- a/ScienceDirect.js
+++ b/ScienceDirect.js
@@ -169,7 +169,7 @@ async function getPDFLink(doc) {
 	if (intermediateURL) {
 		return parseIntermediatePDFPage(intermediateURL);
 	}
-	return;
+	return false;
 }
 
 


### PR DESCRIPTION
Closes #3315, closes #3316. I haven't been able to test the latter change because ScienceDirect blocked me. (I only ran through the tests once and saved a couple search results...)