### PR TITLE
eLibrary.ru: name parsing logic fixes for the recent update, test updates

### DIFF
--- a/eLibrary.ru.js
+++ b/eLibrary.ru.js
@@ -204,7 +204,7 @@ async function scrape(doc, url = doc.location.href) {
 		
 		if (cleaned.firstName === undefined) {
 			// Unable to parse. Restore punctuation.
-			cleaned.fieldMode = true;
+			cleaned.fieldMode = 1;
 			cleaned.lastName = dirty;
 		}
 		
@@ -683,7 +683,7 @@ var testCases = [
 					{
 						"lastName": "Де Щулф А.",
 						"creatorType": "author",
-						"fieldMode": true
+						"fieldMode": 1
 					},
 					{
 						"firstName": "Эдуард Павлович",
@@ -698,7 +698,7 @@ var testCases = [
 					{
 						"lastName": "Ван Хооф Л.",
 						"creatorType": "author",
-						"fieldMode": true
+						"fieldMode": 1
 					},
 					{
 						"firstName": "С.",
@@ -708,7 +708,7 @@ var testCases = [
 					{
 						"lastName": "Де Лангхе К.",
 						"creatorType": "author",
-						"fieldMode": true
+						"fieldMode": 1
 					},
 					{
 						"firstName": "А.",
@@ -718,7 +718,7 @@ var testCases = [
 					{
 						"lastName": "Ван Де Керчове Р.",
 						"creatorType": "author",
-						"fieldMode": true
+						"fieldMode": 1
 					},
 					{
 						"firstName": "Р.",
@@ -728,7 +728,7 @@ var testCases = [
 					{
 						"lastName": "Те Киефте Д.",
 						"creatorType": "author",
-						"fieldMode": true
+						"fieldMode": 1
 					}
 				],
 				"date": "2009",


### PR DESCRIPTION
This is a follow up to #3289. Main goal was to update tests as mentioned by Abe in [this comment](https://github.com/zotero/translators/pull/3289#issuecomment-2187272698), but along the way I've noticed that the last name parsing logic needs fixing after the scraping logic update in that PR.

The main reason is that it looks like the tooltips, that are now being used to pull names, contain names directly from author's eLibrary.ru profile and that includes maiden names in parenthesis, where exists. See e.g., the test for https://www.elibrary.ru/item.asp?id=17339044.

There is also an additional peculiarity in view of that, namely that names in tooltips are in Russian even if the ones on the page are in English. An example of that is https://elibrary.ru/item.asp?id=30694319, included in one of the tests. I haven't updated that test yet, as I'd like to discuss it first. Saving names in one language when the paper info is in a different one looks incorrect to me, but (a) I'm open to other opinions and (b) if you also think so, that would probably require some further tweaking of the name-scraping logic first.

Also fixed a couple of minor items in separate commits.