### PR TITLE
The Met: all-round refresh incl. asyncify and new website adjustments

### DIFF
--- a/The Met.js
+++ b/The Met.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "72dbad15-cd1a-4d52-b2ed-7d67f909cada",
 	"label": "The Met",
-	"creator": "Aurimas Vinckevicius, Philipp Zumstein",
-	"target": "^https?://metmuseum\\.org/art/collection",
-	"minVersion": "3.0",
+	"creator": "Aurimas Vinckevicius, Philipp Zumstein and contributors",
+	"target": "^https?://(?:www\\.)?metmuseum\\.org/art/collection",
+	"minVersion": "6.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2017-07-01 11:39:10"
+	"lastUpdated": "2024-07-21 18:22:01"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017 Philipp Zumstein
+	Copyright © 2017-2024 Philipp Zumstein and contributors
 	
 	This file is part of Zotero.
 
@@ -35,25 +35,25 @@
 	***** END LICENSE BLOCK *****
 */
 
-
+// eslint-disable-next-line no-unused-vars
 function detectWeb(doc, url) {
-	if (ZU.xpathText(doc, '//div[contains(@class, "collection-details__tombstone")]')) {
+	if (doc.querySelector('.artwork-details')) {
 		return 'artwork';
 	}
-	//multiples are working when waiting for the website to load completely,
-	//but automatic testing seems difficult, try manually e.g.
-	//http://metmuseum.org/art/collection?ft=albrecht+d%C3%BCrer&noqs=true
-	if (getSearchResults(doc, true)) return 'multiple';
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
 }
 
 
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
-	var rows = ZU.xpath(doc, '//h2[contains(@class, "card__title")]/a');
-	for (var i=0; i<rows.length; i++) {
-		var href = rows[i].href;
-		var title = ZU.trimInternal(rows[i].textContent);
+	let items = {};
+	let found = false;
+	let rows = doc.querySelectorAll('[class*="collection-object_caption"] a');
+	for (let row of rows) {
+		var href = row.href;
+		var title = ZU.trimInternal(row.textContent);
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -63,34 +63,31 @@ function getSearchResults(doc, checkOnly) {
 }
 
 
-function doWeb(doc, url) {
+async function doWeb(doc, url) {
 	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) {
-				return true;
-			}
-			var articles = [];
-			for (var i in items) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
-		});
-	} else {
-		scrape(doc, url);
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
 	}
 }
 
 
-function scrape(doc, url) {
-	var item = new Zotero.Item('artwork');
-	item.title = ZU.xpathText(doc, '//h1');
+// eslint-disable-next-line no-unused-vars
+async function scrape(doc, url = doc.location.href) {
+	let item = new Zotero.Item('artwork');
+	item.title = text(doc, '.artwork__title--text');
 	
-	var meta = ZU.xpath(doc, '//div[contains(@class, "collection-details__tombstone")]/dl')
-	for (var i=0; i<meta.length; i++) {
-		var heading = ZU.xpathText(meta[i], './dt[contains(@class, "label")]');
-		heading = heading.toLowerCase().substr(0, heading.length-1);
-		var content = ZU.xpathText(meta[i], './dd[contains(@class, "value")]');
-		//Z.debug(heading + content)
+	let meta = doc.querySelectorAll('.artwork-tombstone--item');
+	for (let elem of meta) {
+		let heading = text(elem, '.artwork-tombstone--label');
+		heading = heading.toLowerCase().substr(0, heading.length - 1);
+		let content = text(elem, '.artwork-tombstone--value');
+		// Z.debug(heading + content);
 
 		switch (heading) {
 			case 'date':
@@ -108,22 +105,26 @@ function scrape(doc, url) {
 			case 'culture':
 				item.tags.push(content);
 				break;
-			case 'artist':
-				var cleaned = content.replace(/\(.*\)$/, '').trim();
-				if (cleaned.split(' ').length>2) {
-					item.creators.push({'lastName': content, 'creatorType': 'artist', 'fieldMode': 1})
-				} else {
+			case 'artist': {
+				let cleaned = content.replace(/\(.*\)$/, '').trim();
+				if (cleaned.split(' ').length > 2) {
+					item.creators.push({ lastName: content, creatorType: 'artist', fieldMode: 1 });
+				}
+				else {
 					item.creators.push(ZU.cleanAuthor(cleaned, "artist"));
 				}
 				break;
+			}
 		}
-	} 
-	
-	item.abstractNote = ZU.xpathText(doc, '//div[contains(@class, "collection-details__label")]');
+	}
+
+	item.abstractNote = text(doc, '.artwork__intro__desc');
 	item.libraryCatalog = 'The Metropolitan Museum of Art';
-	item.url = ZU.xpathText(doc, '//link[@rel="canonical"]/@href');
-	
-	var download = ZU.xpathText(doc, '//li[contains(@class, "utility-menu__item--download")]/a/@href');
+	item.url = attr(doc, 'link[rel="canonical"]', 'href');
+
+	// Non-open-access items still have the (invisible) download button with seemingly valid, but 404-ing, URL.
+	// Filter those out via the "not-openaccess" class set on the <section/> containing the button.
+	let download = attr(doc, 'section:not(.artwork--not-openaccess) .artwork__interaction--download a', 'href');
 	if (download) {
 		item.attachments.push({
 			title: 'Met Image',
@@ -134,7 +135,7 @@ function scrape(doc, url) {
 		title: 'Snapshot',
 		document: doc
 	});
-	
+
 	item.complete();
 }
 
@@ -142,31 +143,35 @@ function scrape(doc, url) {
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://metmuseum.org/art/collection/search/328877?rpp=30&pg=1&rndkey=20140708&ft=*&who=Babylonian&pos=4",
+		"url": "https://www.metmuseum.org/art/collection/search/328877?rpp=30&pg=1&rndkey=20140708&ft=*&who=Babylonian&pos=4",
 		"items": [
 			{
 				"itemType": "artwork",
 				"title": "Cuneiform tablet case impressed with four cylinder seals, for cuneiform tablet 86.11.214a: field rental",
 				"creators": [],
-				"date": "ca. 1749–1712 B.C.",
+				"date": "ca. 1749–1712 BCE",
 				"artworkMedium": "Clay",
 				"artworkSize": "2.1 x 4.4 x 2.9 cm (7/8 x 1 3/4 x 1 1/8 in.)",
 				"callNumber": "86.11.214b",
 				"libraryCatalog": "The Metropolitan Museum of Art",
 				"shortTitle": "Cuneiform tablet case impressed with four cylinder seals, for cuneiform tablet 86.11.214a",
-				"url": "http://metmuseum.org/art/collection/search/328877",
+				"url": "https://www.metmuseum.org/art/collection/search/328877",
 				"attachments": [
 					{
 						"title": "Met Image"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"Babylonian",
-					"Clay-Tablets-Inscribed-Seal Impressions",
-					"Old Babylonian"
+					{
+						"tag": "Babylonian"
+					},
+					{
+						"tag": "Old Babylonian"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -175,31 +180,35 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://metmuseum.org/art/collection/search/328877",
+		"url": "https://www.metmuseum.org/art/collection/search/328877",
 		"items": [
 			{
 				"itemType": "artwork",
 				"title": "Cuneiform tablet case impressed with four cylinder seals, for cuneiform tablet 86.11.214a: field rental",
 				"creators": [],
-				"date": "ca. 1749–1712 B.C.",
+				"date": "ca. 1749–1712 BCE",
 				"artworkMedium": "Clay",
 				"artworkSize": "2.1 x 4.4 x 2.9 cm (7/8 x 1 3/4 x 1 1/8 in.)",
 				"callNumber": "86.11.214b",
 				"libraryCatalog": "The Metropolitan Museum of Art",
 				"shortTitle": "Cuneiform tablet case impressed with four cylinder seals, for cuneiform tablet 86.11.214a",
-				"url": "http://metmuseum.org/art/collection/search/328877",
+				"url": "https://www.metmuseum.org/art/collection/search/328877",
 				"attachments": [
 					{
 						"title": "Met Image"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"Babylonian",
-					"Clay-Tablets-Inscribed-Seal Impressions",
-					"Old Babylonian"
+					{
+						"tag": "Babylonian"
+					},
+					{
+						"tag": "Old Babylonian"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
@@ -208,7 +217,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://metmuseum.org/art/collection/search/436243?rpp=30&pg=1&ft=albrecht+d%c3%bcrer&pos=1",
+		"url": "https://www.metmuseum.org/art/collection/search/436243?rpp=30&pg=1&ft=albrecht+d%c3%bcrer&pos=1",
 		"items": [
 			{
 				"itemType": "artwork",
@@ -221,27 +230,71 @@ var testCases = [
 					}
 				],
 				"date": "ca. 1505",
-				"abstractNote": "This picture of Christ as Salvator Mundi, Savior of the World, who raises his right hand in blessing and in his left holds a globe representing the earth, can be appreciated both as a painting and as a drawing. Albrecht Dürer, the premier artist of the German Renaissance, probably began this work shortly before he departed for Italy in 1505, but completed only the drapery. His unusually extensive and meticulous preparatory drawing on the panel is visible in the unfinished portions of Christ's face and hands.",
+				"abstractNote": "This picture of Christ as Savior of the World, who raises his right hand in blessing and in his left holds an orb representing the Earth, can be appreciated both as a painting and a drawing. Dürer, the premier artist of the German Renaissance, probably began this work shortly before he departed for Italy in 1505 but completed only the drapery. His unusually extensive and meticulous preparatory drawing on the panel is visible in the unfinished portions of Christ’s face and hands.",
 				"artworkMedium": "Oil on linden",
 				"artworkSize": "22 7/8 x 18 1/2in. (58.1 x 47cm)",
 				"callNumber": "32.100.64",
 				"libraryCatalog": "The Metropolitan Museum of Art",
-				"url": "http://metmuseum.org/art/collection/search/436243",
+				"url": "https://www.metmuseum.org/art/collection/search/436243",
 				"attachments": [
 					{
 						"title": "Met Image"
 					},
 					{
-						"title": "Snapshot"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [
-					"Paintings"
+					{
+						"tag": "Paintings"
+					}
 				],
 				"notes": [],
 				"seeAlso": []
 			}
 		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.metmuseum.org/art/collection/search/371722",
+		"items": [
+			{
+				"itemType": "artwork",
+				"title": "Rotoreliefs (Optical Discs)",
+				"creators": [
+					{
+						"firstName": "Marcel",
+						"lastName": "Duchamp",
+						"creatorType": "artist"
+					}
+				],
+				"date": "1935/1953",
+				"artworkMedium": "Offset lithograph",
+				"artworkSize": "Each:  7 7/8 inches (20 cm) diameter",
+				"callNumber": "1972.597.1–.6",
+				"libraryCatalog": "The Metropolitan Museum of Art",
+				"url": "https://www.metmuseum.org/art/collection/search/371722",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Prints"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.metmuseum.org/art/collection/search?q=albrecht%20d%C3%BCrer",
+		"items": "multiple"
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
* Adjust logic for the new webpage formatting, use only CSS selectors.
* Asyncify & lint.
* Update existing tests, add a "multiple" one.

Fixes #3309.