### PR TITLE
minor fix for Queensland State Archives

### DIFF
--- a/Queensland State Archives.js
+++ b/Queensland State Archives.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-08-21 19:41:51"
+	"lastUpdated": "2024-08-26 01:32:21"
 }
 
 /*
@@ -88,7 +88,10 @@ async function scrape(url) {
 	let item = new Zotero.Item("manuscript");
 	item.title = data.title;
 	if ("record_type" in data.subject_terms) {
-		item.type = data.subject_terms.record_type.join("; ");
+		let recordTypes = data.subject_terms.record_type.map(
+			term => term.term
+		);
+		item.type = recordTypes.join("; ");
 	}
 	item.archive = "Queensland State Archives";
 	item.archiveLocation = data.qsa_id_prefixed;


### PR DESCRIPTION
The data structure of the API has changed slightly – there's a list of objects where there used to be a list of strings. I've changed the translator to extract the strings from the objects.