### PR TITLE
Adding a new option to get the callNumber

### DIFF
--- a/Primo 2018.js
+++ b/Primo 2018.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-05-11 21:32:37"
+	"lastUpdated": "2024-09-18 09:43:45"
 }
 
 /*
@@ -110,102 +110,6 @@ function getPnxElems(doc) {
 
 /** BEGIN TEST CASES **/
 var testCases = [
-	{
-		"type": "web",
-		"url": "http://virtuose.uqam.ca/primo-explore/fulldisplay?vid=UQAM&docid=UQAM_BIB000969205&context=L",
-		"defer": true,
-		"items": [
-			{
-				"itemType": "book",
-				"title": "War",
-				"creators": [
-					{
-						"lastName": "Baynes",
-						"firstName": "Ken",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Ken",
-						"lastName": "Baynes",
-						"creatorType": "author"
-					},
-					{
-						"lastName": "Welsh Arts Council",
-						"creatorType": "contributor",
-						"fieldMode": 1
-					},
-					{
-						"lastName": "Glynn Vivian Art Gallery",
-						"creatorType": "contributor",
-						"fieldMode": 1
-					}
-				],
-				"date": "1970",
-				"callNumber": "NX650G8B38",
-				"language": "eng",
-				"libraryCatalog": "virtuose.uqam.ca",
-				"place": "Boston",
-				"publisher": "Book and Art Chop",
-				"series": "Art and society 1",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "ART; GUERRE; WAR"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "http://bcujas-catalogue.univ-paris1.fr/primo-explore/fulldisplay?vid=CUJAS_V1&docid=33CUJAS_ALEPH000070200&context=L&search_scope=LSCOP_ALL",
-		"defer": true,
-		"items": [
-			{
-				"itemType": "book",
-				"title": "Test pattern for living",
-				"creators": [
-					{
-						"firstName": "Nicholas",
-						"lastName": "Johnson",
-						"creatorType": "author"
-					}
-				],
-				"date": "1972",
-				"callNumber": "203.206",
-				"language": "eng",
-				"libraryCatalog": "bcujas-catalogue.univ-paris1.fr",
-				"numPages": "xx+154",
-				"place": "Toronto New York",
-				"publisher": "Bantam Books",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "Mass media"
-					},
-					{
-						"tag": "Social aspects"
-					},
-					{
-						"tag": "United States"
-					},
-					{
-						"tag": "United States"
-					},
-					{
-						"tag": "Social conditions"
-					},
-					{
-						"tag": "1960-"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
 	{
 		"type": "web",
 		"url": "https://explore.lib.uliege.be/discovery/collectionDiscovery?vid=32ULG_INST:ULIEGE&collectionId=81129164700002321&lang=fr",

--- a/Primo Normalized XML.js
+++ b/Primo Normalized XML.js
@@ -11,7 +11,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2024-04-04 15:46:05"
+	"lastUpdated": "2024-09-18 09:58:45"
 }
 
 /*
@@ -307,14 +307,19 @@ function doImport() {
 			callArray.push(callNumber[i].textContent.match(/\$\$D(.+?)\$/)[1]);
 		}
 	}
+	/* 2024-09 : adding a test on p:delivery/p:bestlocation/p:callnumber to get Callnumber from Primo VE pages like https://bcujas-catalogue.univ-paris1.fr/discovery/fulldisplay?context=L&vid=33CUJAS_INST:33CUJAS_INST&search_scope=MyInstitution&tab=LibraryCatalog&docid=alma990004764520107621 for example */
 	if (!callArray.length) {
-		callNumber = ZU.xpath(doc, '//p:display/p:availlibrary', ns);
+		callNumber = ZU.xpath(doc, '//p:display/p:availlibrary|//p:delivery/p:bestlocation/p:callNumber', ns);
 		for (let i = 0; i < callNumber.length; i++) {
-			if (callNumber[i].textContent.search(/\$\$2.+\$/) != -1) {
-				callArray.push(callNumber[i].textContent.match(/\$\$2\(?(.+?)(?:\s*\))?\$/)[1]);
+			let testCallNumberWithSubfields = callNumber[i].textContent.match(/\$\$2\(?(.+?)(?:\s*\))?\$/);
+			if (testCallNumberWithSubfields) {
+				callArray.push(testCallNumberWithSubfields[1]);
+			} else {
+				callArray.push(callNumber[i].textContent);
 			}
 		}
 	}
+
 	if (callArray.length) {
 		// remove duplicate call numbers
 		callArray = dedupeArray(callArray);
@@ -791,6 +796,7 @@ var testCases = [
 				],
 				"date": "1971",
 				"abstractNote": "Includes bibliographical references.",
+				"callNumber": "TD174 .D95",
 				"language": "eng",
 				"place": "New York",
 				"publisher": "Chelsea House Publishers",
@@ -859,6 +865,76 @@ var testCases = [
 					},
 					{
 						"tag": "Wirtschaftsentwicklung"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "import",
+		"input": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><record xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\"><delivery><availabilityLinks>detailsgetit1</availabilityLinks><displayLocation>true</displayLocation><recordOwner>33CUJAS_INST</recordOwner><physicalServiceId>null</physicalServiceId><sharedDigitalCandidates>null</sharedDigitalCandidates><link><displayLabel>thumbnail</displayLabel><linkURL>https://proxy-euf.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:1107199956,OCLC:,LCCN:&amp;jscmd=viewapi&amp;callback=updateGBSCover</linkURL><linkType>thumbnail</linkType><id>:_0</id></link><availability>available_in_library</availability><additionalLocations>false</additionalLocations><digitalAuxiliaryMode>false</digitalAuxiliaryMode><holding><matchForHoldings><holdingRecord>852##b</holdingRecord><matchOn>MainLocation</matchOn></matchForHoldings><subLocationCode>MAG2</subLocationCode><volumeFilter>null</volumeFilter><ilsApiId>990004764520107621</ilsApiId><callNumberType>8</callNumberType><libraryCode>CUJ</libraryCode><yearFilter>null</yearFilter><boundWith>false</boundWith><stackMapUrl/><isValidUser>true</isValidUser><translateRelatedTitle>null</translateRelatedTitle><mainLocation>BIU Cujas</mainLocation><callNumber>567.067</callNumber><adaptorid>ALMA_01</adaptorid><organization>33CUJAS_INST</organization><holdingURL>OVP</holdingURL><availabilityStatus>available</availabilityStatus><id>_:0</id><subLocation>Magasin 2ème sous-sol</subLocation><holdId>2262944550007621</holdId><holKey>HoldingResultKey [mid=2262944550007621, libraryId=112237610007621, locationCode=MAG2, callNumber=567.067]</holKey><singleUnavailableItemProcessType>null</singleUnavailableItemProcessType><relatedTitle>null</relatedTitle></holding><bestlocation><matchForHoldings><holdingRecord>852##b</holdingRecord><matchOn>MainLocation</matchOn></matchForHoldings><subLocationCode>MAG2</subLocationCode><volumeFilter>null</volumeFilter><ilsApiId>990004764520107621</ilsApiId><callNumberType>8</callNumberType><libraryCode>CUJ</libraryCode><yearFilter>null</yearFilter><boundWith>false</boundWith><stackMapUrl/><isValidUser>true</isValidUser><translateRelatedTitle>null</translateRelatedTitle><mainLocation>BIU Cujas</mainLocation><callNumber>567.067</callNumber><adaptorid>ALMA_01</adaptorid><organization>33CUJAS_INST</organization><holdingURL>OVP</holdingURL><availabilityStatus>available</availabilityStatus><id>_:0</id><subLocation>Magasin 2ème sous-sol</subLocation><holdId>2262944550007621</holdId><holKey>HoldingResultKey [mid=2262944550007621, libraryId=112237610007621, locationCode=MAG2, callNumber=567.067]</holKey><singleUnavailableItemProcessType>null</singleUnavailableItemProcessType><relatedTitle>null</relatedTitle></bestlocation><electronicServices>null</electronicServices><feDisplayOtherLocations>false</feDisplayOtherLocations><hasD>null</hasD><hideResourceSharing>false</hideResourceSharing><hasFilteredServices>null</hasFilteredServices><physicalItemTextCodes>null</physicalItemTextCodes><quickAccessService>null</quickAccessService><recordInstitutionCode>null</recordInstitutionCode><displayedAvailability>null</displayedAvailability><consolidatedCoverage>null</consolidatedCoverage><additionalElectronicServices>null</additionalElectronicServices><deliveryCategory>Alma-P</deliveryCategory><serviceMode>ovp</serviceMode><filteredByGroupServices>null</filteredByGroupServices><electronicContextObjectId>null</electronicContextObjectId><GetIt1><links><isLinktoOnline>false</isLinktoOnline><displayText>null</displayText><inst4opac>33CUJAS_INST</inst4opac><getItTabText>service_getit</getItTabText><adaptorid>ALMA_01</adaptorid><ilsApiId>990004764520107621</ilsApiId><link>OVP</link><id>_:0</id></links><category>Alma-P</category></GetIt1></delivery><search><creator>Simone Daniela</creator><creationdate>2019</creationdate><sort_title>Copyright and collective authorship locating the authors of collaborative work</sort_title><sort_journal_title>Copyright and collective authorship locating the authors of collaborative work</sort_journal_title><sort_creationdate_full>2019</sort_creationdate_full><subject>Encyclopédies électroniques</subject><subject>Droit</subject><subject>Contenu généré par les utilisateurs</subject><subject>Qualité d&apos;auteur</subject><subject>Droit d&apos;auteur</subject><subject>Electronic encyclopedias</subject><subject>User-generated content Law and legislation</subject><subject>Copyright Art</subject><subject>Authorship</subject><subject>Copyright</subject><subject>Wikipedia</subject><isbn>9781107199958</isbn><isbn>1107199956</isbn><description>La 4e de couverture indique : &quot;As technology makes it easier for people to work together, large-scale collaboration is becoming increasingly prevalent. In this context, the question of how to determine authorship - and hence ownership - of copyright in collaborative works is an important question to which current copyright law fails to provide a coherent or consistent answer. In Copyright and Collective Authorship, Daniela Simone engages with the problem of how to determine the authorship of highly collaborative works. Employing insights from the ways in which collaborators understand and regulate issues of authorship, the book argues that a recalibration of copyright law is necessary, proposing an inclusive and contextual approach to joint authorship that is true to the legal concept of authorship but is also more aligned with creative reality.&quot;</description><language>eng</language><title>Copyright and collective authorship locating the authors of collaborative work</title><startdate>2019</startdate><unimarc_local_fields>990 20190827</unimarc_local_fields><unimarc_local_fields>980 BK</unimarc_local_fields><unimarc_local_fields>935 23749051X</unimarc_local_fields><unimarc_local_fields>930 751052119 567.067 b</unimarc_local_fields><addtitle>001(PPN)148977332 Cambridge intellectual property and information law</addtitle><addtitle>Cambridge intellectual property and information law</addtitle><general>Cambridge University Press</general><general>ALP000476452</general><general>UKMGB019402122</general><general>CHBIS011301756</general><general>CHVBK563491051</general><general>on1057238619</general><general>(OCoLC)1119538850</general><general>(ALP)000476452CUJ01</general><general>CUJ01(PPN)23749051X</general><general>(PPN)23749051X</general><rtype>books</rtype><enddate>2019</enddate><series>001(PPN)148977332 Cambridge intellectual property and information law</series><series>Cambridge intellectual property and information law</series><journal_title>Copyright and collective authorship locating the authors of collaborative work</journal_title><facet_creatorcontrib>Simone, Daniela</facet_creatorcontrib><sort_author>Simone Daniela</sort_author><sort_creationdate>2019</sort_creationdate></search><display><identifier>$$CISBN$$V978-1-107-19995-8;$$CISBN$$V1-107-19995-6;$$CPPN$$V23749051X;$$CMMSID$$V990004764520107621</identifier><creationdate>2019</creationdate><creator>Simone, Daniela$$QSimone Daniela</creator><lds18>&lt;a href=&quot;https://www.sudoc.fr/23749051X&quot; target=&quot;_blank&quot;&gt;Voir la notice&lt;/a&gt;</lds18><subject>Wikipedia</subject><subject>Copyright</subject><subject>Authorship</subject><subject>Copyright  -- Art</subject><subject>User-generated content  -- Law and legislation</subject><subject>Electronic encyclopedias</subject><subject>Droit d&apos;auteur</subject><subject>Qualité d&apos;auteur</subject><subject>Contenu généré par les utilisateurs  -- Droit</subject><subject>Encyclopédies électroniques</subject><format>1 vol. (xxi-300 p.) : couv. ill. en coul. ; 24 cm</format><language>eng</language><source>Alma</source><type>book</type><title>Copyright and collective authorship : locating the authors of collaborative work</title><version>1</version><relation>$$Cmain_series$$VCambridge intellectual property and information law$$QCambridge intellectual property and information law </relation><mms>990004764520107621</mms><series>Cambridge intellectual property and information law$$QCambridge intellectual property and information law</series><publisher>Cambridge etc. : Cambridge University Press</publisher><place>Cambridge [etc.]</place><lds02>CODE_PAYS_GB</lds02><lds01>23749051X</lds01><lds12>1. Copyright law and collective authorship 2. Authorship and joint authorship 3. Wikipedia 4. Australian indigenous art 5. Scientific collaborations 6. Film 7. Characteristics of collective authorship and the role of copyright law 8. An inclusive, contextual approach to the joint authorship test</lds12><lds03>TYPE_SUPPORT_BK</lds03></display><control><recordid>alma990004764520107621</recordid><sourceid>alma</sourceid><score>1.0</score><originalsourceid>000476452-CUJ01</originalsourceid><sourceformat>UNIMARC</sourceformat><sourcerecordid>990004764520107621</sourcerecordid><sourcesystem>ILS</sourcesystem><isDedup>false</isDedup></control><addata><date>2019</date><aulast>Simone</aulast><notes>Bibliogr. p. 273-293. Notes bibliogr. Index</notes><cop>Cambridge [etc</cop><isbn>978-1-107-19995-8</isbn><isbn>1-107-19995-6</isbn><format>book</format><ristype>BOOK</ristype><oclcid>(ocolc)1119538850</oclcid><abstract>La 4e de couverture indique : &quot;As technology makes it easier for people to work together, large-scale collaboration is becoming increasingly prevalent. In this context, the question of how to determine authorship - and hence ownership - of copyright in collaborative works is an important question to which current copyright law fails to provide a coherent or consistent answer. In Copyright and Collective Authorship, Daniela Simone engages with the problem of how to determine the authorship of highly collaborative works. Employing insights from the ways in which collaborators understand and regulate issues of authorship, the book argues that a recalibration of copyright law is necessary, proposing an inclusive and contextual approach to joint authorship that is true to the legal concept of authorship but is also more aligned with creative reality.&quot;</abstract><title>Copyright and collective authorship : locating the authors of collaborative work</title><aufirst>Daniela</aufirst><seriestitle>Cambridge intellectual property and information law</seriestitle><au>Simone Daniela</au><au>Simone,Daniela</au><genre>book</genre><btitle>Copyright and collective authorship : locating the authors of collaborative work</btitle><pub>Cambridge University Press</pub></addata><sort><creationdate>2019</creationdate><author>Simone Daniela</author><title>Copyright and collective authorship locating the authors of collaborative work</title></sort></record>",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Copyright and collective authorship: locating the authors of collaborative work",
+				"creators": [
+					{
+						"lastName": "Simone Daniela",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2019",
+				"ISBN": "9781107199958",
+				"abstractNote": "La 4e de couverture indique : \"As technology makes it easier for people to work together, large-scale collaboration is becoming increasingly prevalent. In this context, the question of how to determine authorship - and hence ownership - of copyright in collaborative works is an important question to which current copyright law fails to provide a coherent or consistent answer. In Copyright and Collective Authorship, Daniela Simone engages with the problem of how to determine the authorship of highly collaborative works. Employing insights from the ways in which collaborators understand and regulate issues of authorship, the book argues that a recalibration of copyright law is necessary, proposing an inclusive and contextual approach to joint authorship that is true to the legal concept of authorship but is also more aligned with creative reality.\"",
+				"callNumber": "567.067",
+				"language": "eng",
+				"numPages": "xxi+300",
+				"place": "Cambridge [etc",
+				"publisher": "Cambridge University Press",
+				"series": "Cambridge intellectual property and information law",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "Art"
+					},
+					{
+						"tag": "Authorship"
+					},
+					{
+						"tag": "Contenu généré par les utilisateurs"
+					},
+					{
+						"tag": "Copyright"
+					},
+					{
+						"tag": "Copyright"
+					},
+					{
+						"tag": "Droit"
+					},
+					{
+						"tag": "Droit d'auteur"
+					},
+					{
+						"tag": "Electronic encyclopedias"
+					},
+					{
+						"tag": "Encyclopédies électroniques"
+					},
+					{
+						"tag": "Law and legislation"
+					},
+					{
+						"tag": "Qualité d'auteur"
+					},
+					{
+						"tag": "User-generated content"
+					},
+					{
+						"tag": "Wikipedia"
 					}
 				],
 				"notes": [],


### PR DESCRIPTION
After discussions on #3075 this PR should fix what has been said : 

- two tests have been removed in Primo 2018.js : one for a site that has disappeared (uqam), one for a page that automatic test in Scaffold can not handle properly;
- a fix has been added to Primo normalized XML.js to get the information from a field that has been recently added to Primo and refactor the way xpath are treated. A test has been added to this translator to prove this is working fine, and a test has been updated that was previously missing the callnumber.