### PR TITLE
CiNii Articles has been integrated into CiNii Research.

### DIFF
--- a/CiNii Research.js
+++ b/CiNii Research.js
@@ -1,21 +1,22 @@
 {
 	"translatorID": "46291dc3-5cbd-47b7-8af4-d009078186f6",
-	"label": "CiNii",
-	"creator": "Michael Berkowitz and Mitsuo Yoshida",
-	"target": "^https?://ci\\.nii\\.ac\\.jp/",
+	"label": "CiNii Research",
+	"creator": "Michael Berkowitz, Mitsuo Yoshida and Satoshi Ando",
+	"target": "^https?://cir\\.nii\\.ac\\.jp/",
 	"minVersion": "1.0.0b4.r5",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2012-11-24 13:12:41"
+	"lastUpdated": "2024-09-25 04:32:17"
 }
 
 function detectWeb(doc, url) {
-	if (url.match(/naid/)) {
+//	if (url.match(/crid/)) {
+	if (url.includes("/crid/")) {
 		return "journalArticle";
-	} else if (doc.evaluate('//a[contains(@href, "/naid/")]', doc, null, XPathResult.ANY_TYPE, null).iterateNext()) {
+	} else if (doc.evaluate('//a[contains(@href, "/crid/")]', doc, null, XPathResult.ANY_TYPE, null).iterateNext()) {
 		return "multiple";
 	}
 }
@@ -24,7 +25,7 @@ function doWeb(doc, url) {
 	var arts = new Array();
 	if (detectWeb(doc, url) == "multiple") {
 		var items = new Object();
-		var links = doc.evaluate('//a[contains(@href, "/naid/")]', doc, null, XPathResult.ANY_TYPE, null);
+		var links = doc.evaluate('//a[contains(@href, "/crid/")]', doc, null, XPathResult.ANY_TYPE, null);
 		var link;
 		while (link = links.iterateNext()) {
 			items[link.href] = Zotero.Utilities.trimInternal(link.textContent);
@@ -74,55 +75,57 @@ function scrape(doc, url){
 			});
 			trans.translate();
 		});
-	}/** BEGIN TEST CASES **/
+	}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://ci.nii.ac.jp/search?q=test&range=0&count=20&sortorder=1&type=0",
+		"url": "https://cir.nii.ac.jp/all?q=test&range=0&count=20&sortorder=1&type=0",
 		"items": "multiple"
 	},
 	{
 		"type": "web",
-		"url": "http://ci.nii.ac.jp/naid/110000244188/ja/",
+		"url": "https://cir.nii.ac.jp/crid/1390001204062164736",
 		"items": [
 			{
 				"itemType": "journalArticle",
-				"title": "<研究速報>観測用既存鉄骨造モデル構造物を用いたオンライン応答実験=Pseudo-dynamic tests on existing steel model structure for seismic monitoring",
+				"title": "観測用既存鉄骨造モデル構造物を用いたオンライン応答実験",
 				"creators": [
 					{
-						"firstName": "謙一=Kenichi Ohi",
+						"firstName": "謙一",
 						"lastName": "大井",
 						"creatorType": "author"
 					},
 					{
-						"firstName": "輿助=Yosuke Shimawaki",
+						"firstName": "與助",
 						"lastName": "嶋脇",
 						"creatorType": "author"
 					},
 					{
-						"firstName": "拓海=Takumi Ito",
+						"firstName": "拓海",
 						"lastName": "伊藤",
 						"creatorType": "author"
 					},
 					{
-						"firstName": "Li",
-						"lastName": "Yushun",
+						"firstName": "玉順",
+						"lastName": "李",
 						"creatorType": "author"
 					}
 				],
-				"date": "November 2002",
+				"date": "2002",
 				"DOI": "10.11188/seisankenkyu.54.384",
-				"ISSN": "0037105X",
+				"ISSN": "1881-2058",
 				"issue": "6",
-				"itemID": "110000244188",
+				"itemID": "1390001204062164736",
 				"libraryCatalog": "CiNii",
 				"pages": "384-387",
 				"publicationTitle": "生産研究",
-				"url": "http://ci.nii.ac.jp/naid/110000244188/ja/",
+				"url": "https://cir.nii.ac.jp/crid/1390001204062164736",
 				"volume": "54",
 				"attachments": [
 					{
-						"title": "<研究速報>観測用既存鉄骨造モデル構造物を用いたオンライン応答実験=Pseudo-dynamic tests on existing steel model structure for seismic monitoring Snapshot",
+						"title": "観測用既存鉄骨造モデル構造物を用いたオンライン応答実験 Snapshot",
 						"mimeType": "text/html"
 					}
 				],

--- a/CiNii Research.js
+++ b/CiNii Research.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-09-25 04:32:17"
+	"lastUpdated": "2024-09-25 05:59:03"
 }
 
 function detectWeb(doc, url) {
@@ -58,9 +58,11 @@ function scrape(doc, url){
 				tags.push(Zotero.Utilities.trimInternal(kw.textContent));
 			}
 		}
+		//var abstractPath = '//div[@class="abstract"]/p[@class="entry-content"]';
+		var abstractPath = '//div[contains(@class, "abstract")]/p[contains(@class, "entry-content")]';
 		var abstractNote;
-		if (doc.evaluate('//div[@class="abstract"]', doc, null, XPathResult.ANY_TYPE, null).iterateNext()) {
-			abstractNote = doc.evaluate('//div[@class="abstract"]', doc, null, XPathResult.ANY_TYPE, null).iterateNext().textContent;
+		if (doc.evaluate(abstractPath, doc, null, XPathResult.ANY_TYPE, null).iterateNext()) {
+			abstractNote = doc.evaluate(abstractPath, doc, null, XPathResult.ANY_TYPE, null).iterateNext().textContent;
 		}
 		Zotero.Utilities.HTTP.doGet(biblink, function(text) {
 			var trans = Zotero.loadTranslator("import");
@@ -123,6 +125,7 @@ var testCases = [
 				"publicationTitle": "生産研究",
 				"url": "https://cir.nii.ac.jp/crid/1390001204062164736",
 				"volume": "54",
+				"abstractNote": "特集 ERS(耐震構造学)",
 				"attachments": [
 					{
 						"title": "観測用既存鉄骨造モデル構造物を用いたオンライン応答実験 Snapshot",


### PR DESCRIPTION
[The former CiNii has been integrated into CiNii Research](https://www.nii.ac.jp/en/news/release/2022/0418.html), with which the URL and some page structures have been changed.
I've revised the obsolete CiNii.js to adjust the brandnew CiNii Research.