### PR TITLE
Update arXiv translator to use recommended Atom API instead of OAI

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -1,15 +1,15 @@
 {
 	"translatorID": "ecddda2e-4fc6-4aea-9f17-ef3b56d7377a",
-	"label": "arXiv.org",
-	"creator": "Sean Takats and Michael Berkowitz",
-	"target": "^https?://([^\\.]+\\.)?(arxiv\\.org|xxx\\.lanl\\.gov)/(find|catchup|list/\\w|abs/|pdf/)",
-	"minVersion": "3.0",
-	"maxVersion": "",
-	"priority": 100,
-	"inRepository": true,
-	"translatorType": 12,
-	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-01-05 12:21:40"
+		"label": "arXiv.org",
+			"creator": "Sean Takats and Michael Berkowitz",
+				"target": "^https?://([^\\.]+\\.)?(arxiv\\.org|xxx\\.lanl\\.gov)/(find|catchup|list/\\w|abs/|pdf/)",
+					"minVersion": "3.0",
+						"maxVersion": "",
+							"priority": 100,
+								"inRepository": true,
+									"translatorType": 12,
+										"browserSupport": "gcsibv",
+											"lastUpdated": "2024-10-01 14:20:02"
 }
 
 /*
@@ -39,12 +39,202 @@ function detectSearch(item) {
 	return !!item.arXiv;
 }
 
-function doSearch(item) {
-	var url = 'https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
+async function doSearch(item) {
+	/*var url = 'https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
 		+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(item.arXiv);
-	ZU.doGet(url, parseXML);
+	ZU.doGet(url, parseXML);*/
+	const url = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(item.arXiv)}&max_results=1`;
+	const doc = await ZU.requestDocument(url);
+	parseAtom(doc);
 }
 
+const arXivCategories = {
+	"acc-phys": "Accelerator Physics",
+	"adap-org": "Adaptation, Noise, and Self-Organizing Systems",
+	"alg-geom": "Algebraic Geometry",
+	"ao-sci": "Atmospheric-Oceanic Sciences",
+	"astro-ph": "Astrophysics",
+	"astro-ph.CO": "Cosmology and Nongalactic Astrophysics",
+	"astro-ph.EP": "Earth and Planetary Astrophysics",
+	"astro-ph.GA": "Astrophysics of Galaxies",
+	"astro-ph.HE": "High Energy Astrophysical Phenomena",
+	"astro-ph.IM": "Instrumentation and Methods for Astrophysics",
+	"astro-ph.SR": "Solar and Stellar Astrophysics",
+	"atom-ph": "Atomic, Molecular and Optical Physics",
+	"bayes-an": "Bayesian Analysis",
+	"chao-dyn": "Chaotic Dynamics",
+	"chem-ph": "Chemical Physics",
+	"cmp-lg": "Computation and Language",
+	"comp-gas": "Cellular Automata and Lattice Gases",
+	"cond-mat": "Condensed Matter",
+	"cond-mat.dis-nn": "Disordered Systems and Neural Networks",
+	"cond-mat.mes-hall": "Mesoscale and Nanoscale Physics",
+	"cond-mat.mtrl-sci": "Materials Science",
+	"cond-mat.other": "Other Condensed Matter",
+	"cond-mat.quant-gas": "Quantum Gases",
+	"cond-mat.soft": "Soft Condensed Matter",
+	"cond-mat.stat-mech": "Statistical Mechanics",
+	"cond-mat.str-el": "Strongly Correlated Electrons",
+	"cond-mat.supr-con": "Superconductivity",
+	"cs.AI": "Artificial Intelligence",
+	"cs.AR": "Hardware Architecture",
+	"cs.CC": "Computational Complexity",
+	"cs.CE": "Computational Engineering, Finance, and Science",
+	"cs.CG": "Computational Geometry",
+	"cs.CL": "Computation and Language",
+	"cs.CR": "Cryptography and Security",
+	"cs.CV": "Computer Vision and Pattern Recognition",
+	"cs.CY": "Computers and Society",
+	"cs.DB": "Databases",
+	"cs.DC": "Distributed, Parallel, and Cluster Computing",
+	"cs.DL": "Digital Libraries",
+	"cs.DM": "Discrete Mathematics",
+	"cs.DS": "Data Structures and Algorithms",
+	"cs.ET": "Emerging Technologies",
+	"cs.FL": "Formal Languages and Automata Theory",
+	"cs.GL": "General Literature",
+	"cs.GR": "Graphics",
+	"cs.GT": "Computer Science and Game Theory",
+	"cs.HC": "Human-Computer Interaction",
+	"cs.IR": "Information Retrieval",
+	"cs.IT": "Information Theory",
+	"cs.LG": "Machine Learning",
+	"cs.LO": "Logic in Computer Science",
+	"cs.MA": "Multiagent Systems",
+	"cs.MM": "Multimedia",
+	"cs.MS": "Mathematical Software",
+	"cs.NA": "Numerical Analysis",
+	"cs.NE": "Neural and Evolutionary Computing",
+	"cs.NI": "Networking and Internet Architecture",
+	"cs.OH": "Other Computer Science",
+	"cs.OS": "Operating Systems",
+	"cs.PF": "Performance",
+	"cs.PL": "Programming Languages",
+	"cs.RO": "Robotics",
+	"cs.SC": "Symbolic Computation",
+	"cs.SD": "Sound",
+	"cs.SE": "Software Engineering",
+	"cs.SI": "Social and Information Networks",
+	"cs.SY": "Systems and Control",
+	"dg-ga": "Differential Geometry",
+	"econ.EM": "Econometrics",
+	"econ.GN": "General Economics",
+	"econ.TH": "Theoretical Economics",
+	"eess.AS": "Audio and Speech Processing",
+	"eess.IV": "Image and Video Processing",
+	"eess.SP": "Signal Processing",
+	"eess.SY": "Systems and Control",
+	"funct-an": "Functional Analysis",
+	"gr-qc": "General Relativity and Quantum Cosmology",
+	"hep-ex": "High Energy Physics - Experiment",
+	"hep-lat": "High Energy Physics - Lattice",
+	"hep-ph": "High Energy Physics - Phenomenology",
+	"hep-th": "High Energy Physics - Theory",
+	"math-ph": "Mathematical Physics",
+	"math.AC": "Commutative Algebra",
+	"math.AG": "Algebraic Geometry",
+	"math.AP": "Analysis of PDEs",
+	"math.AT": "Algebraic Topology",
+	"math.CA": "Classical Analysis and ODEs",
+	"math.CO": "Combinatorics",
+	"math.CT": "Category Theory",
+	"math.CV": "Complex Variables",
+	"math.DG": "Differential Geometry",
+	"math.DS": "Dynamical Systems",
+	"math.FA": "Functional Analysis",
+	"math.GM": "General Mathematics",
+	"math.GN": "General Topology",
+	"math.GR": "Group Theory",
+	"math.GT": "Geometric Topology",
+	"math.HO": "History and Overview",
+	"math.IT": "Information Theory",
+	"math.KT": "K-Theory and Homology",
+	"math.LO": "Logic",
+	"math.MG": "Metric Geometry",
+	"math.MP": "Mathematical Physics",
+	"math.NA": "Numerical Analysis",
+	"math.NT": "Number Theory",
+	"math.OA": "Operator Algebras",
+	"math.OC": "Optimization and Control",
+	"math.PR": "Probability",
+	"math.QA": "Quantum Algebra",
+	"math.RA": "Rings and Algebras",
+	"math.RT": "Representation Theory",
+	"math.SG": "Symplectic Geometry",
+	"math.SP": "Spectral Theory",
+	"math.ST": "Statistics Theory",
+	"mtrl-th": "Materials Theory",
+	"nlin.AO": "Adaptation and Self-Organizing Systems",
+	"nlin.CD": "Chaotic Dynamics",
+	"nlin.CG": "Cellular Automata and Lattice Gases",
+	"nlin.PS": "Pattern Formation and Solitons",
+	"nlin.SI": "Exactly Solvable and Integrable Systems",
+	"nucl-ex": "Nuclear Experiment",
+	"nucl-th": "Nuclear Theory",
+	"patt-sol": "Pattern Formation and Solitons",
+	"physics.acc-ph": "Accelerator Physics",
+	"physics.ao-ph": "Atmospheric and Oceanic Physics",
+	"physics.app-ph": "Applied Physics",
+	"physics.atm-clus": "Atomic and Molecular Clusters",
+	"physics.atom-ph": "Atomic Physics",
+	"physics.bio-ph": "Biological Physics",
+	"physics.chem-ph": "Chemical Physics",
+	"physics.class-ph": "Classical Physics",
+	"physics.comp-ph": "Computational Physics",
+	"physics.data-an": "Data Analysis, Statistics and Probability",
+	"physics.ed-ph": "Physics Education",
+	"physics.flu-dyn": "Fluid Dynamics",
+	"physics.gen-ph": "General Physics",
+	"physics.geo-ph": "Geophysics",
+	"physics.hist-ph": "History and Philosophy of Physics",
+	"physics.ins-det": "Instrumentation and Detectors",
+	"physics.med-ph": "Medical Physics",
+	"physics.optics": "Optics",
+	"physics.plasm-ph": "Plasma Physics",
+	"physics.pop-ph": "Popular Physics",
+	"physics.soc-ph": "Physics and Society",
+	"physics.space-ph": "Space Physics",
+	"plasm-ph": "Plasma Physics",
+	"q-alg": "Quantum Algebra and Topology",
+	"q-bio": "Quantitative Biology",
+	"q-bio.BM": "Biomolecules",
+	"q-bio.CB": "Cell Behavior",
+	"q-bio.GN": "Genomics",
+	"q-bio.MN": "Molecular Networks",
+	"q-bio.NC": "Neurons and Cognition",
+	"q-bio.OT": "Other Quantitative Biology",
+	"q-bio.PE": "Populations and Evolution",
+	"q-bio.QM": "Quantitative Methods",
+	"q-bio.SC": "Subcellular Processes",
+	"q-bio.TO": "Tissues and Organs",
+	"q-fin.CP": "Computational Finance",
+	"q-fin.EC": "Economics",
+	"q-fin.GN": "General Finance",
+	"q-fin.MF": "Mathematical Finance",
+	"q-fin.PM": "Portfolio Management",
+	"q-fin.PR": "Pricing of Securities",
+	"q-fin.RM": "Risk Management",
+	"q-fin.ST": "Statistical Finance",
+	"q-fin.TR": "Trading and Market Microstructure",
+	"quant-ph": "Quantum Physics",
+	"solv-int": "Exactly Solvable and Integrable Systems",
+	"stat.AP": "Applications",
+	"stat.CO": "Computation",
+	"stat.ME": "Methodology",
+	"stat.ML": "Machine Learning",
+	"stat.OT": "Other Statistics",
+	"stat.TH": "Statistics Theory",
+	"supr-con": "Superconductivity",
+	"test": "Test",
+	"test.dis-nn": "Test Disruptive Networks",
+	"test.mes-hall": "Test Hall",
+	"test.mtrl-sci": "Test Mtrl-Sci",
+	"test.soft": "Test Soft",
+	"test.stat-mech": "Test Mechanics",
+	"test.str-el": "Test Electrons",
+	"test.supr-con": "Test Superconductivity",
+	"bad-arch.bad-cat": "Invalid Category"
+}
 
 var version;
 var arxivDOI;
@@ -69,7 +259,7 @@ function detectWeb(doc, url) {
 	}
 }
 
-function doWeb(doc, url) {
+async function doWeb(doc, url) {
 	if (detectWeb(doc, url) == 'multiple') {
 		var rows = ZU.xpath(doc, '//div[@id="dlpage"]/dl/dt');
 		var getTitleId;
@@ -99,26 +289,20 @@ function doWeb(doc, url) {
 		else {
 			throw new Error("Unrecognized multiples format");
 		}
-		
+
 		var items = {};
 		for (let i = 0; i < rows.length; i++) {
 			var row = getTitleId(rows[i]);
 			items[row.id] = row.title;
 		}
-		
-		Z.selectItems(items, function (items) {
-			if (!items) return;
-			
-			var urls = [];
-			for (var id in items) {
-				urls.push('https://export.arxiv.org/oai2'
-					+ '?verb=GetRecord&metadataPrefix=oai_dc'
-					+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(id)
-				);
-			}
-			
-			ZU.doGet(urls, parseXML);
-		});
+
+		const selectedItems = await Z.selectItems(items);
+		if (selectedItems) {
+			const apiURL = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(Object.keys(selectedItems).join(','))}`;
+			Z.debug(apiURL);
+			const document = await requestDocument(apiURL);
+			parseAtom(document);
+		}
 	}
 	else {
 		var id;
@@ -127,9 +311,9 @@ function doWeb(doc, url) {
 			version = versionMatch[1];
 		}
 		arxivDOI = text(doc, '.arxivdoi>a');
-		var p = url.indexOf("/pdf/");
-		if (p > -1) {
-			id = url.substring(p + 5, url.length - 4);
+		Z.debug(url);
+		if (url.includes("/pdf/")) {
+			id = url.match(/pdf\/(.+)(?:\.pdf)?/)[1];
 		}
 		else {
 			id = ZU.xpathText(doc, '(//span[@class="arxivid"]/a)[1]')
@@ -137,15 +321,129 @@ function doWeb(doc, url) {
 		}
 		if (!id) throw new Error('Could not find arXiv ID on page.');
 		id = id.trim().replace(/^arxiv:\s*|v\d+|\s+.*$/ig, '');
-		var apiurl = 'https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
+		const apiURL = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(id)}&max_results=1`;
+		Z.debug(id);
+		Z.debug(apiURL);
+		await ZU.requestDocument(apiURL).then(parseAtom);
+		/*var apiurl = 'https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=oai_dc'
 			+ '&identifier=oai%3AarXiv.org%3A' + encodeURIComponent(id);
-		ZU.doGet(apiurl, parseXML);
+		ZU.doGet(apiurl, parseXML);*/
 	}
 }
 
+function parseAtom(doc) {
+	const entries = doc.querySelectorAll("feed > entry");
+	entries.forEach(parseSingleEntry);
+}
+
+function parseSingleEntry(entry) {
+	var hasPreprint;
+	if (ZU.fieldIsValidForType('title', 'preprint')) {
+		hasPreprint = true;
+	}
+	var newItem;
+	if (hasPreprint) {
+		newItem = new Zotero.Item("preprint");
+	}
+	else {
+		newItem = new Zotero.Item("report");
+	}
+
+	newItem.title = ZU.trimInternal(text(entry, "title"));
+	Z.debug(newItem.title);
+	newItem.date = text(entry, "updated");
+	_getCreatorNodes(entry, "author", newItem, "author");
+
+	newItem.abstractNote = ZU.trimInternal(text(entry, "summary"));
+
+	const comments = entry.querySelectorAll("comment");
+
+	for (const comment of comments) {
+		const noteStr = ZU.trimInternal(comment.textContent);
+		newItem.notes.push({ note: `Comment: ${noteStr}` });
+	}
+
+	const categories = Array.from(entry.querySelectorAll("category")).map((el) => el.getAttribute("term")).map(sub => arXivCategories[sub] ?? false).filter(Boolean);
+	if (categories && categories.length) newItem.tags.push(...categories);
+
+	const arxivURL = text(entry, "id").replace(/v\d+/, '');
+	const doi = text(entry, "doi");
+	if (doi) newItem.DOI = doi;
+	else newItem.url = arxivURL;
+
+	const articleID = arxivURL.replace(/https?:\/\/arxiv.org\/abs\//, ''); // Trim off http://arxiv.org/abs/
+
+	let articleField = attr(entry, "primary_category", "term").replace(/^.+?:/, "").replace(/\..+?$/, "");
+	if (articleField) articleField = "[" + articleField + "]";
+
+	if (articleID && articleID.includes("/")) {
+		newItem.extra = "arXiv:" + articleID;
+	}
+	else {
+		newItem.extra = "arXiv:" + articleID + " " + articleField;
+	}
+
+	const pdfURL = attr(entry, "link[title='pdf']", "href");
+
+	newItem.attachments.push({
+		title: "arXiv Fulltext PDF",
+		url: pdfURL,
+		mimeType: "application/pdf"
+	});
+	newItem.attachments.push({
+		title: "arXiv.org Snapshot",
+		url: newItem.url,
+		mimeType: "text/html"
+	});
+
+	Z.debug(newItem);
+
+	// retrieve and supplement publication data for published articles via DOI
+	if (newItem.DOI) {
+		var translate = Zotero.loadTranslator("search");
+		// CrossRef
+		translate.setTranslator("b28d0d42-8549-4c6d-83fc-8382874a5cb9");
+
+		var item = { itemType: "journalArticle", DOI: newItem.DOI };
+		translate.setSearch(item);
+		translate.setHandler("itemDone", function (obj, item) {
+			// Z.debug(item)
+			newItem.itemType = item.itemType;
+			newItem.volume = item.volume;
+			newItem.issue = item.issue;
+			newItem.pages = item.pages;
+			newItem.date = item.date;
+			newItem.ISSN = item.ISSN;
+			if (item.publicationTitle) {
+				newItem.publicationTitle = item.publicationTitle;
+				newItem.journalAbbreviation = item.journalAbbreviation;
+			}
+			newItem.date = item.date;
+		});
+		translate.setHandler("done", function () {
+			newItem.complete();
+		});
+		translate.setHandler("error", function () { });
+		translate.translate();
+	}
+	else {
+		newItem.publisher = "arXiv";
+		newItem.number = "arXiv:" + articleID;
+		if (version) {
+			newItem.extra += '\nversion: ' + version;
+		}
+		if (arxivDOI) newItem.DOI = ZU.cleanDOI(arxivDOI);
+		// only for Zotero versions without preprint
+		if (!hasPreprint) {
+			newItem.extra += '\ntype: article';
+		}
+		else newItem.archiveID = "arXiv:" + articleID;
+		newItem.complete();
+	}
+}
 
 function parseXML(text) {
-	// Z.debug(text);
+	Z.debug(text);
 	/* eslint camelcase: ["error", { allow: ["oai_dc"] }] */
 	var ns = {
 		oai_dc: 'http://www.openarchives.org/OAI/2.0/oai_dc/',
@@ -181,10 +479,10 @@ function parseXML(text) {
 			newItem.date = dates[dates.length - 1];
 		}
 	}
-	
-	
+
+
 	var descriptions = ZU.xpath(dcMeta, "./dc:description", ns);
-	
+
 	// Put the first description into abstract, all other into notes.
 	if (descriptions.length > 0) {
 		newItem.abstractNote = ZU.trimInternal(descriptions[0].textContent);
@@ -198,7 +496,7 @@ function parseXML(text) {
 		var subject = ZU.trimInternal(subjects[j].textContent);
 		newItem.tags.push(subject);
 	}
-					
+
 	var identifiers = ZU.xpath(dcMeta, "./dc:identifier", ns);
 	for (let j = 0; j < identifiers.length; j++) {
 		var identifier = ZU.trimInternal(identifiers[j].textContent);
@@ -212,17 +510,16 @@ function parseXML(text) {
 
 	var articleID = ZU.xpath(xml, "//n:GetRecord/n:record/n:header/n:identifier", ns)[0];
 	if (articleID) articleID = ZU.trimInternal(articleID.textContent).substr(14); // Trim off oai:arXiv.org:
-	
+
 	var articleField = ZU.xpathText(xml, '//n:GetRecord/n:record/n:header/n:setSpec', ns);
 	if (articleField) articleField = "[" + articleField.replace(/^.+?:/, "") + "]";
-	
+
 	if (articleID && articleID.includes("/")) {
 		newItem.extra = "arXiv:" + articleID;
 	}
 	else {
 		newItem.extra = "arXiv:" + articleID + " " + articleField;
 	}
-	
 
 	var pdfUrl = "https://arxiv.org/pdf/" + articleID + (version ? "v" + version : "") + ".pdf";
 	newItem.attachments.push({
@@ -235,13 +532,13 @@ function parseXML(text) {
 		url: newItem.url,
 		mimeType: "text/html"
 	});
-	
+
 	// retrieve and supplement publication data for published articles via DOI
 	if (newItem.DOI) {
 		var translate = Zotero.loadTranslator("search");
 		// CrossRef
 		translate.setTranslator("b28d0d42-8549-4c6d-83fc-8382874a5cb9");
-		
+
 		var item = { itemType: "journalArticle", DOI: newItem.DOI };
 		translate.setSearch(item);
 		translate.setHandler("itemDone", function (obj, item) {
@@ -261,7 +558,7 @@ function parseXML(text) {
 		translate.setHandler("done", function () {
 			newItem.complete();
 		});
-		translate.setHandler("error", function () {});
+		translate.setHandler("error", function () { });
 		translate.translate();
 	}
 	else {
@@ -296,7 +593,18 @@ function getCreatorNodes(dcMeta, name, newItem, creatorType, ns) {
 			ZU.cleanAuthor(nodes[i].textContent, creatorType, true)
 		);
 	}
-}/** BEGIN TEST CASES **/
+}
+
+function _getCreatorNodes(entry, name, newItem, creatorType) {
+	var nodes = entry.querySelectorAll(`${name} > name`);
+	for (var i = 0; i < nodes.length; i++) {
+		newItem.creators.push(
+			ZU.cleanAuthor(nodes[i].textContent, creatorType, false)
+		);
+	}
+}
+
+/** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
@@ -540,10 +848,10 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://arxiv.org/pdf/1402.1516.pdf",
+		"url": "https://arxiv.org/pdf/1402.1516",
 		"items": [
 			{
-				"itemType": "journalArticle",
+				"itemType": "preprint",
 				"title": "A dual pair for free boundary fluids",
 				"creators": [
 					{
@@ -557,15 +865,16 @@ var testCases = [
 						"creatorType": "author"
 					}
 				],
-				"date": "2014-02-06",
+				"date": "2014-02-06T22:20:30Z",
 				"abstractNote": "We construct a dual pair associated to the Hamiltonian geometric formulation of perfect fluids with free boundaries. This dual pair is defined on the cotangent bundle of the space of volume preserving embeddings of a manifold with boundary into a boundaryless manifold of the same dimension. The dual pair properties are rigorously verified in the infinite dimensional Fr\\'echet manifold setting. It provides an example of a dual pair associated to actions that are not completely mutually orthogonal.",
-				"extra": "arXiv: 1402.1516",
+				"archiveID": "arXiv:1402.1516",
+				"extra": "arXiv:1402.1516 [math]",
 				"libraryCatalog": "arXiv.org",
-				"publicationTitle": "arXiv:1402.1516 [math-ph]",
+				"repository": "arXiv",
 				"url": "http://arxiv.org/abs/1402.1516",
 				"attachments": [
 					{
-						"title": "arXiv:1402.1516 PDF",
+						"title": "arXiv Fulltext PDF",
 						"mimeType": "application/pdf"
 					},
 					{
@@ -574,8 +883,15 @@ var testCases = [
 					}
 				],
 				"tags": [
-					"Mathematical Physics",
-					"Mathematics - Symplectic Geometry"
+					{
+						"tag": "Mathematical Physics"
+					},
+					{
+						"tag": "Mathematical Physics"
+					},
+					{
+						"tag": "Symplectic Geometry"
+					}
 				],
 				"notes": [
 					{


### PR DESCRIPTION
Based on various tests, the currently used `oai2` endpoint is very slow (up to 20s for a single query). Conversely, the endpoint documented by arXiv is much faster. This is currently a WIP.