### PR TITLE
feat: Update IMDb.js to add URL to item

### DIFF
--- a/IMDb.js
+++ b/IMDb.js
@@ -45,7 +45,7 @@ function detectWeb(doc, url) {
 			return "film";
 		}
 	}
-	else if (url.includes('/find?') && getSearchResults(doc, true)) {
+	else if (url.includes('/find') && getSearchResults(doc, true)) {
 		return "multiple";
 	}
 	return false;

--- a/IMDb.js
+++ b/IMDb.js
@@ -54,7 +54,7 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//td[contains(@class, "result_text")]');
+	var rows = ZU.xpath(doc, '//li[contains(@class, "find-result-item")]');
 	for (let i = 0; i < rows.length; i++) {
 		var href = ZU.xpathText(rows[i], './a/@href');
 		var title = ZU.trimInternal(rows[i].textContent);

--- a/IMDb.js
+++ b/IMDb.js
@@ -471,7 +471,7 @@ var testCases = [
 					}
 				],
 				"date": "2006-09-07",
-				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
+				"abstractNote": "Newlyweds move in next door to a veteran married couple of 25 years.",
 				"distributor": "Impact Zone Productions, Sony Pictures Television",
 				"extra": "IMDb ID: tt0759475\nevent-location: United States",
 				"genre": "Comedy, Romance",
@@ -482,16 +482,16 @@ var testCases = [
 						"tag": "big breasts"
 					},
 					{
-						"tag": "breast"
-					},
-					{
 						"tag": "brother brother relationship"
 					},
 					{
-						"tag": "columbia tristar"
+						"tag": "death in title"
 					},
 					{
-						"tag": "death in title"
+						"tag": "principal"
+					},
+					{
+						"tag": "schoolteacher"
 					}
 				],
 				"notes": [],
@@ -535,7 +535,7 @@ var testCases = [
 					}
 				],
 				"date": "2006-09-07",
-				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
+				"abstractNote": "Newlyweds move in next door to a veteran married couple of 25 years.",
 				"distributor": "Impact Zone Productions, Sony Pictures Television",
 				"extra": "IMDb ID: tt0759475\nevent-location: United States",
 				"genre": "Comedy, Romance",
@@ -546,16 +546,16 @@ var testCases = [
 						"tag": "big breasts"
 					},
 					{
-						"tag": "breast"
-					},
-					{
 						"tag": "brother brother relationship"
 					},
 					{
-						"tag": "columbia tristar"
+						"tag": "death in title"
 					},
 					{
-						"tag": "death in title"
+						"tag": "principal"
+					},
+					{
+						"tag": "schoolteacher"
 					}
 				],
 				"notes": [],
@@ -610,7 +610,7 @@ var testCases = [
 				],
 				"date": "2023-03-02",
 				"abstractNote": "Picard grapples with a life-altering revelation as the crew of the Titan attempt to outmaneuver Vadic, while Raffi and Worf uncover a plot by a vengeful enemy.",
-				"extra": "IMDb ID: tt19402762\nevent-location:",
+				"extra": "IMDb ID: tt19402762\nevent-location: United States",
 				"libraryCatalog": "IMDb",
 				"programTitle": "Star Trek: Picard",
 				"runningTime": "56m",

--- a/IMDb.js
+++ b/IMDb.js
@@ -141,6 +141,7 @@ function scrape(doc, _url) {
 	addExtra(item, "event-location: "
 		+ [...locationLinks].map(a => a.innerText).join(', '));
 	item.tags = "keywords" in json ? json.keywords.split(",") : [];
+	item.url = json.url;
 	item.complete();
 }
 

--- a/IMDb.js
+++ b/IMDb.js
@@ -56,7 +56,7 @@ function getSearchResults(doc, checkOnly) {
 	var found = false;
 	var rows = ZU.xpath(doc, '//li[contains(@class, "find-result-item")]');
 	for (let i = 0; i < rows.length; i++) {
-		var href = ZU.xpathText(rows[i], './a/@href');
+		var href = ZU.xpathText(rows[i], '//a/@href');
 		var title = ZU.trimInternal(rows[i].textContent);
 		if (!href || !title) continue;
 		if (checkOnly) return true;

--- a/IMDb.js
+++ b/IMDb.js
@@ -164,6 +164,7 @@ var testCases = [
 			{
 				"itemType": "film",
 				"title": "La historia oficial",
+				"url": "https://www.imdb.com/title/tt0089276/",
 				"creators": [
 					{
 						"firstName": "Luis",
@@ -238,6 +239,7 @@ var testCases = [
 			{
 				"itemType": "film",
 				"title": "Käpy selän alla",
+				"url": "https://www.imdb.com/title/tt0060613/",
 				"creators": [
 					{
 						"firstName": "Mikko",
@@ -307,6 +309,7 @@ var testCases = [
 			{
 				"itemType": "tvBroadcast",
 				"title": "Islands",
+				"url": "https://www.imdb.com/title/tt6142646/",
 				"creators": [
 					{
 						"firstName": "Elizabeth",
@@ -365,6 +368,7 @@ var testCases = [
 			{
 				"itemType": "tvBroadcast",
 				"title": "That's a Wrap",
+				"url": "https://www.imdb.com/title/tt9060452/",
 				"creators": [
 					{
 						"firstName": "Alex",
@@ -438,6 +442,7 @@ var testCases = [
 			{
 				"itemType": "film",
 				"title": "'Til Death",
+				"url": "https://www.imdb.com/title/tt0759475/",
 				"creators": [
 					{
 						"firstName": "Josh",
@@ -501,6 +506,7 @@ var testCases = [
 			{
 				"itemType": "film",
 				"title": "'Til Death",
+				"url": "https://www.imdb.com/title/tt0759475/",
 				"creators": [
 					{
 						"firstName": "Josh",
@@ -564,6 +570,7 @@ var testCases = [
 			{
 				"itemType": "tvBroadcast",
 				"title": "Seventeen Seconds",
+				"url": "https://www.imdb.com/title/tt19402762/",
 				"creators": [
 					{
 						"firstName": "Jonathan",


### PR DESCRIPTION
## Changes
`IMDb.js`:
  - Adding URL to item in `scrape(...)` method

## Notes
- This changes populates the URL field when saving a IMDb page to Zotero using Zotero Connector.
- Populating the URL makes the Zotero item clickable
- Opens IMDb page on double-clicking the Zotoer item.

## Testing
- Tested on my local machine.
- Verified URL is getting populating on saving an IMDb link.