### PR TITLE
arXiv: Always add DOI

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 12,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-10-22 16:12:31"
+	"lastUpdated": "2024-11-20 15:37:18"
 }
 
 /*
@@ -234,8 +234,7 @@ const arXivCategories = {
 };
 
 var version;
-var arxivDOI;
-// these variables will be set in doWeb and
+// this variable will be set in doWeb and
 // can be used then afterwards in the parseXML
 
 function detectSearch(item) {
@@ -334,7 +333,6 @@ async function doWeb(doc, url) {
 		if (versionMatch) {
 			version = versionMatch[1];
 		}
-		arxivDOI = text(doc, '.arxivdoi > a');
 
 		if (!id) { // Honestly not sure where this might still be needed
 			id = text(doc, 'span.arxivid > a');
@@ -419,7 +417,7 @@ function parseSingleEntry(entry) {
 	// retrieve and supplement publication data for published articles via DOI
 	if (newItem.DOI) {
 		var translate = Zotero.loadTranslator("search");
-		// CrossRef
+		// DOI Content Negotiation
 		translate.setTranslator("b28d0d42-8549-4c6d-83fc-8382874a5cb9");
 
 		var item = { itemType: "journalArticle", DOI: newItem.DOI };
@@ -449,7 +447,8 @@ function parseSingleEntry(entry) {
 		if (version) {
 			newItem.extra += '\nversion: ' + version;
 		}
-		if (arxivDOI) newItem.DOI = ZU.cleanDOI(arxivDOI);
+		// https://blog.arxiv.org/2022/02/17/new-arxiv-articles-are-now-automatically-assigned-dois/
+		newItem.DOI = "10.48550/arXiv." + articleID;
 		newItem.archiveID = "arXiv:" + articleID;
 		newItem.complete();
 	}
@@ -717,6 +716,7 @@ var testCases = [
 					}
 				],
 				"date": "2014-02-06",
+				"DOI": "10.48550/arXiv.1402.1516",
 				"abstractNote": "We construct a dual pair associated to the Hamiltonian geometric formulation of perfect fluids with free boundaries. This dual pair is defined on the cotangent bundle of the space of volume preserving embeddings of a manifold with boundary into a boundaryless manifold of the same dimension. The dual pair properties are rigorously verified in the infinite dimensional Fr\\'echet manifold setting. It provides an example of a dual pair associated to actions that are not completely mutually orthogonal.",
 				"archiveID": "arXiv:1402.1516",
 				"extra": "arXiv:1402.1516 [math]",
@@ -984,6 +984,7 @@ var testCases = [
 					}
 				],
 				"date": "2002-11-11",
+				"DOI": "10.48550/arXiv.math/0211159",
 				"abstractNote": "We present a monotonic expression for the Ricci flow, valid in all dimensions and without curvature assumptions. It is interpreted as an entropy for a certain canonical ensemble. Several geometric applications are given. In particular, (1) Ricci flow, considered on the space of riemannian metrics modulo diffeomorphism and scaling, has no nontrivial periodic orbits (that is, other than fixed points); (2) In a region, where singularity is forming in finite time, the injectivity radius is controlled by the curvature; (3) Ricci flow can not quickly turn an almost euclidean region into a very curved one, no matter what happens far away. We also verify several assertions related to Richard Hamilton's program for the proof of Thurston geometrization conjecture for closed three-manifolds, and give a sketch of an eclectic proof of this conjecture, making use of earlier results on collapsing with local lower curvature bound.",
 				"archiveID": "arXiv:math/0211159",
 				"extra": "arXiv:math/0211159",


### PR DESCRIPTION
From the [blog post](https://blog.arxiv.org/2022/02/17/new-arxiv-articles-are-now-automatically-assigned-dois/):

> An author can determine their article’s DOI by using the DOI prefix https://doi.org/10.48550/ followed by the arXiv ID (replacing the colon with a period). For example, the arXiv ID [arXiv:2202.01037](https://arxiv.org/abs/2202.01037) will translate to the DOI link https://doi.org/10.48550/arXiv.2202.01037