### PR TITLE
Update Primo 2018.js

### DIFF
--- a/Primo 2018.js
+++ b/Primo 2018.js
@@ -57,7 +57,7 @@ function getSearchResults(doc, checkOnly) {
 		let title = text(row.parentNode, '.item-title')
 			|| row.parentNode.textContent;
 		if (!href || !title) continue;
-		title = title.replace(/^;/, '');
+		title = title.replace(/^;/, '').replace(/(.+).{2}\s\/\s.*/, '$1');
 		if (checkOnly) return true;
 		found = true;
 		items[href] = title;


### PR DESCRIPTION
Trying to fix a problem with the title in Italy: the title field is catalogued as follows "`Title words / Author's name and surname`", so I added a regex to keep only what's before the bar (and the space before the bar)