### PR TITLE
Update Primo Normalized XML.js

### DIFF
--- a/Primo Normalized XML.js
+++ b/Primo Normalized XML.js
@@ -131,7 +131,7 @@ function doImport() {
 	item.title = ZU.xpathText(doc, '//p:display/p:title', ns);
 	if (item.title) {
 		item.title = ZU.unescapeHTML(item.title);
-		item.title = item.title.replace(/\s*:/, ":");
+		item.title = item.title.replace(/\s*:/, ":").replace(/(.+).{2}\s\/\s.*/, '$1');
 	}
 	var creators = ZU.xpath(doc, '//p:display/p:creator', ns);
 	var contributors = ZU.xpath(doc, '//p:display/p:contributor', ns);


### PR DESCRIPTION
Trying to fix a problem with the title in Italy: the title field is catalogued as follows "`Title words / Author's name and surname`", so I added a regex to keep only what's before the bar (and the space before the bar).
This should be the one fix that should address the issue?