### PR TITLE
Add translators for Israel's national newspaper library, JTA news archive and Jerusalem Post

### DIFF
--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -12,6 +12,29 @@
 	"lastUpdated": "2025-06-08 07:51:10"
 }
 
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2015 Philipp Zumstein
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
 function detectWeb(doc, url) {
 	if (url.includes("/article/")) {
 		return "newspaperArticle";

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -1,0 +1,79 @@
+{
+	"translatorID": "af178ee7-0feb-485d-9cba-3312daf7ebad",
+	"label": "Israel National Newspaper Library",
+	"creator": "Anonymus",
+	"target": "^https:\\/\\/www\\.nli\\.org\\.il\\/(en|he|ar)\\/newspapers\\/[a-z]+\\/\\d{4}\\/\\d{2}\\/\\d{2}\\/\\d{2}\\/article\\/\\d{1,3}\\/?(\\?.*)?$/gm",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-06-08 07:51:10"
+}
+
+function detectWeb(doc, url) {
+	if (url.includes("/article/")) {
+		return "newspaperArticle";
+	}
+	return false;
+}
+
+async function doWeb(doc, url) {
+	await scrape(doc, url);
+}
+
+async function scrape(doc, url) {
+	try {
+		let item = new Zotero.Item("newspaperArticle");
+
+		item.url = url;
+		item.language = "en";
+
+		// Fallback values
+		item.title = "Untitled";
+		item.publicationTitle = "Unknown";
+		item.date = "Unknown";
+
+		// Extract from document title
+		let rawTitle = doc.title;
+		let parts = rawTitle.split("|").map(p => p.trim());
+		if (parts.length >= 3) {
+			item.title = parts[0].replace(/[\u200E\u2068\u2069]/g, "");
+			item.publicationTitle = parts[1].replace(/[\u200E\u2068\u2069]/g, "");
+			let parsed = Zotero.Utilities.strToDate(parts[2]);
+			item.date = parsed.date || parts[2];
+		} else {
+			Zotero.debug(" Unexpected title format: " + rawTitle);
+			item.title = rawTitle;
+		}
+
+		// Extract article body
+		let bodyElement = doc.querySelector("#pagesectionstextcontainer");
+		if (bodyElement) {
+			item.abstractNote = Zotero.Utilities.trimInternal(bodyElement.textContent);
+		}
+
+		// Page number (optional)
+		let scripts = doc.querySelectorAll("script");
+		for (let script of scripts) {
+			let text = script.textContent || "";
+			let match = text.match(/sectionPageBlockAreas\['\d+\.(\d+)'\]\s*=\s*\[\{pageID:'\d+\.(\d+)'/);
+			if (match) {
+				item.pages = match[2];
+				break;
+			}
+		}
+
+		Zotero.debug(" Finished scraping, calling item.complete()");
+		item.complete();
+	} catch (e) {
+		Zotero.debug(" Error in scrape(): " + e);
+		throw e;
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -27,8 +27,8 @@ async function scrape(doc, url) {
 	try {
 		let item = new Zotero.Item("newspaperArticle");
 
-		item.url = url;
-		item.language = "en";
+		let urlMatch = url.match(/^(https?:\/\/www\.nli\.org\.il\/(?:en|he|ar)\/newspapers\/[a-z]+\/\d{4}\/\d{2}\/\d{2}\/\d{2}\/article\/\d{1,3}\/)/);
+		item.url = urlMatch ? urlMatch[1] : url;
 
 		// Fallback values
 		item.title = "Untitled";

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -2,7 +2,7 @@
 	"translatorID": "af178ee7-0feb-485d-9cba-3312daf7ebad",
 	"label": "Israel National Newspaper Library",
 	"creator": "Anonymus",
-	"target": "^https:\\/\\/www\\.nli\\.org\\.il\\/(en|he|ar)\\/newspapers\\/[a-z]+\\/\\d{4}\\/\\d{2}\\/\\d{2}\\/\\d{2}\\/article\\/\\d{1,3}\\/?(\\?.*)?$/gm",
+	"target": "^https:\\/\\/www\\.nli\\.org\\.il\\/(en|he|ar)\\/newspapers\\/[a-z]+\\/\\d{4}\\/\\d{2}\\/\\d{2}\\/\\d{2}\\/article\\/\\d{1,3}\\/?(\\?.*)?$",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -9,7 +9,8 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-17 21:22:49"
+	"lastUpdated": "2025-07-17 21:22:49",
+	"skipTest": true
 }
 
 /*

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -9,31 +9,8 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-17 14:01:16"
+	"lastUpdated": "2025-07-17 21:11:44"
 }
-
-/*
-	***** BEGIN LICENSE BLOCK *****
-
-	Copyright © 2015 Philipp Zumstein
-
-	This file is part of Zotero.
-
-	Zotero is free software: you can redistribute it and/or modify
-	it under the terms of the GNU Affero General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
-
-	Zotero is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-	GNU Affero General Public License for more details.
-
-	You should have received a copy of the GNU Affero General Public License
-	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
-
-	***** END LICENSE BLOCK *****
-*/
 
 function detectWeb(doc, url) {
 	if (url.includes("/article/") || url.includes("/page/")) {
@@ -56,7 +33,7 @@ function detectLanguageFromText(text) {
 async function scrape(doc, url) {
 	const item = new Zotero.Item("newspaperArticle");
 
-	if (url.includes("/article/")){
+	if (url.includes("/article/")) {
 
 		// Title
 		const titleNode = doc.querySelector("#sectionleveltabtitlearea h2");
@@ -91,20 +68,18 @@ async function scrape(doc, url) {
 			if (json.publicationTitle) {
 				item.publicationTitle = json.publicationTitle;
 			}
-		} catch (e) {
+		} 
+		catch (e) {
 			Zotero.debug("Failed to parse data-nli-data-json: " + e);
 		}
 	}
-
-
 
 	if (url.includes("/page/")) {
 		const match = url.match(/\/page\/(\d+)(?:\/|$)/);
 		if (match) {
 			item.pages = match[1];
 		}
-		item.url = url //regular URL because the 
-		item.title = item.publicationTitle +  " newspaper";
+		item.title = item.publicationTitle + " newspaper";
 		item.url = url.trim(); // No persistent link, just the original URL
 	}
 

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -9,8 +9,25 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-17 21:11:44"
+	"lastUpdated": "2025-07-17 21:22:49"
 }
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+	Copyright © 2015 Philipp Zumstein
+	This file is part of Zotero.
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+	***** END LICENSE BLOCK *****
+*/
 
 function detectWeb(doc, url) {
 	if (url.includes("/article/") || url.includes("/page/")) {
@@ -34,7 +51,6 @@ async function scrape(doc, url) {
 	const item = new Zotero.Item("newspaperArticle");
 
 	if (url.includes("/article/")) {
-
 		// Title
 		const titleNode = doc.querySelector("#sectionleveltabtitlearea h2");
 		if (titleNode) item.title = titleNode.textContent.trim();
@@ -68,9 +84,9 @@ async function scrape(doc, url) {
 			if (json.publicationTitle) {
 				item.publicationTitle = json.publicationTitle;
 			}
-		} 
+		}
 		catch (e) {
-			Zotero.debug("Failed to parse data-nli-data-json: " + e);
+		    Zotero.debug("Failed to parse data-nli-data-json: " + e);
 		}
 	}
 

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -53,7 +53,7 @@ function detectLanguageFromText(text) {
 	return null;
 }
 
-function scrape(doc, url) {
+async function scrape(doc, url) {
 	const item = new Zotero.Item("newspaperArticle");
 
 	// Title
@@ -91,11 +91,6 @@ function scrape(doc, url) {
 
 /** BEGIN TEST CASES **/
 var testCases = [
-	{
-		"type": "web",
-		"url": "about:blank",
-		"detectedItemType": false,
-		"items": []
-	}
+	
 ]
 /** END TEST CASES **/

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -77,8 +77,8 @@ async function scrape(doc, url) {
 			item.abstractNote = Zotero.Utilities.trimInternal(bodyElement.textContent);
 		}
 
-		// Page number (optional)
-		let scripts = doc.querySelectorAll("script");
+		// Page number (broken)
+		/*let scripts = doc.querySelectorAll("script");
 		for (let script of scripts) {
 			let text = script.textContent || "";
 			let match = text.match(/sectionPageBlockAreas\['\d+\.(\d+)'\]\s*=\s*\[\{pageID:'\d+\.(\d+)'/);
@@ -86,7 +86,7 @@ async function scrape(doc, url) {
 				item.pages = match[2];
 				break;
 			}
-		}
+		}*/
 
 		Zotero.debug(" Finished scraping, calling item.complete()");
 		item.complete();

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -95,8 +95,8 @@ async function scrape(doc, url) {
 		if (match) {
 			item.pages = match[1];
 		}
-		item.title = item.publicationTitle + " newspaper";
-		item.url = url.trim(); // No persistent link, just the original URL
+		item.title = item.publicationTitle + ", " + item.date;
+		item.url = url.split('?')[0].split('#')[0]; // No persistent link, just the original URL
 	}
 
 	item.libraryCatalog = "National Library of Israel";

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -49,47 +49,41 @@ async function doWeb(doc, url) {
 function detectLanguageFromText(text) {
 	if (/[\u0590-\u05FF]/.test(text)) return "he"; // Hebrew range
 	if (/[\u0600-\u06FF]/.test(text)) return "ar"; // Arabic range
-	if (/[a-zA-Z]/.test(text)) return "en";         // Basic Latin letters
+	if (/[a-zA-Z]/.test(text)) return "en"; // Basic Latin letters
 	return null;
 }
 
 function scrape(doc, url) {
 	const item = new Zotero.Item("newspaperArticle");
 
-// Title
-const titleNode = doc.querySelector("#sectionleveltabtitlearea h2");
-if (titleNode) item.title = titleNode.textContent.trim();
+	// Title
+	const titleNode = doc.querySelector("#sectionleveltabtitlearea h2");
+	if (titleNode) item.title = titleNode.textContent.trim();
 
-// Persistent link
-const linkNode = doc.querySelector("#sectionleveltabpersistentlinkarea .persistentlinkurl");
-item.url = linkNode ? linkNode.textContent.trim() : url;
+	// Persistent link
+	const linkNode = doc.querySelector("#sectionleveltabpersistentlinkarea .persistentlinkurl");
+	item.url = linkNode ? linkNode.textContent.trim() : url;
 
-// Date from <title>
-const pubMatch = doc.title.match(/\|\s*(\d{1,2} (January|February|March|April|May|June|July|August|September|October|November|December) \d{4})\s*\|/);
-if (pubMatch) item.date = pubMatch[1];
+	// Date from <title>
+	const pubMatch = doc.title.match(/\|\s*(\d{1,2} (January|February|March|April|May|June|July|August|September|October|November|December) \d{4})\s*\|/);
+	if (pubMatch) item.date = pubMatch[1];
 
-// Abstract + Full Text
-const paragraphs = Array.from(doc.querySelectorAll("#pagesectionstextcontainer p"))
-	.map(p => p.textContent.trim())
-	.filter(Boolean);
-if (paragraphs.length) {
-	item.abstractNote = paragraphs[0];
-	item.extra = "Full Text:\n" + paragraphs.join("\n\n");
-}
+	// Abstract + Full Text
+	const paragraphs = Array.from(doc.querySelectorAll("#pagesectionstextcontainer p")).map(p => p.textContent.trim()).filter(Boolean);
+	if (paragraphs.length) {
+		item.abstractNote = paragraphs[0];
+		item.extra = "Full Text:\n" + paragraphs.join("\n\n");
+	}
 
-// Publication from <title>
-const parts = doc.title.split("|").map(part => part.trim());
-if (parts.length >= 4) {
-	item.publicationTitle = parts[parts.length - 4];
-}
+	// Publication from <title>
+	const parts = doc.title.split("|").map(part => part.trim());
+	if (parts.length >= 4) {
+		item.publicationTitle = parts[parts.length - 4];
+	}
 
-// Language detection
-const sampleText = paragraphs.join(" ").slice(0, 1000); // Analyze first 1000 characters
-item.language = detectLanguageFromText(sampleText);
-
-
-
-
+	// Language detection
+	const sampleText = paragraphs.join(" ").slice(0, 1000); // Analyze first 1000 characters
+	item.language = detectLanguageFromText(sampleText);
 	item.libraryCatalog = "National Library of Israel";
 
 	item.complete();
@@ -97,6 +91,11 @@ item.language = detectLanguageFromText(sampleText);
 
 /** BEGIN TEST CASES **/
 var testCases = [
-	
+	{
+		"type": "web",
+		"url": "about:blank",
+		"detectedItemType": false,
+		"items": []
+	}
 ]
 /** END TEST CASES **/

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -14,18 +14,22 @@
 
 /*
 	***** BEGIN LICENSE BLOCK *****
-	Copyright © 2015 Philipp Zumstein
+ 
 	This file is part of Zotero.
+ 
 	Zotero is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
+
 	Zotero is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 	GNU Affero General Public License for more details.
+
 	You should have received a copy of the GNU Affero General Public License
 	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
 	***** END LICENSE BLOCK *****
 */
 

--- a/Israel National Newspaper Library.js
+++ b/Israel National Newspaper Library.js
@@ -86,7 +86,7 @@ async function scrape(doc, url) {
 			}
 		}
 		catch (e) {
-		    Zotero.debug("Failed to parse data-nli-data-json: " + e);
+			Zotero.debug("Failed to parse data-nli-data-json: " + e);
 		}
 	}
 
@@ -99,9 +99,7 @@ async function scrape(doc, url) {
 		item.url = url.trim(); // No persistent link, just the original URL
 	}
 
-
 	item.libraryCatalog = "National Library of Israel";
-
 	item.complete();
 }
 

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -1,0 +1,88 @@
+{
+	"translatorID": "a3954ee5-ee4e-44d5-8a4e-d6662473e133",
+	"label": "Jewish Telegraph Agency News Archive",
+	"creator": "Anonymus",
+	"target": "^https:\\/\\/www\\.jta\\.org\\/archive\\/.*",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-07-18 10:59:49"
+}
+
+function detectWeb(doc, url) {
+	// This function determines if the translator should be active on the current page.
+	// It checks if the URL matches the JTA archive pattern and if a main article title
+	// element (h1 with class "entry-title") is present, indicating an article page.
+	if (url.match(/^https?:\/\/www\.jta\.org\/archive\//) && ZU.xpathText(doc, '//h1[@class="entry-title"]')) {
+		return "newspaperArticle"; // Returns the Zotero item type
+	}
+	return false; // Translator should not be active
+}
+
+async function doWeb(doc, url) {
+	await scrape(doc, url)
+}
+
+async function scrape(doc, url) {
+	// This function performs the actual scraping and creates a Zotero item.
+	const item = new Zotero.Item("newspaperArticle");
+
+	// 1. Extract Title: Scrapes the main headline of the article.
+	const titleNode = doc.querySelector('h1.entry-title');
+	if (titleNode) {
+		item.title = titleNode.textContent.trim();
+	}
+
+	// 2. Set Publication Title: The publication is consistently "Jewish Telegraphic Agency" for this archive.
+	item.publicationTitle = "Jewish Telegraphic Agency";
+
+	// 3. Set URL: Prefers the canonical URL found in the HTML head for consistency,
+	//    falling back to the current page URL if the canonical link is not found.
+	item.url = url.split('?')[0].split('#')[0];
+
+	// 4. Extract Date:
+	//    First, attempts to extract the date from the JSON-LD schema embedded in the HTML.
+	//    This is generally the most reliable method as it provides a standardized date format.
+	const dateElem = doc.querySelector('.post-pdf__date');
+	item.date = dateElem.textContent.trim();
+
+	item.attachments.push({
+	title: "Snapshot",
+	document: doc
+	})
+
+	item.libraryCatalog = "Jewish Telegraphic Agency Archive"; // Specific catalog for JTA
+	item.complete();
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.jta.org/archive/palestine-must-be-built-in-cooperation-with-arabs-and-christians-says-dr-weizmann",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Palestine Must Be Built in Cooperation with Arabs and Christians Says Dr. Weizmann",
+				"creators": [],
+				"date": "January 10, 1924",
+				"libraryCatalog": "Jewish Telegraphic Agency Archive",
+				"publicationTitle": "Jewish Telegraphic Agency",
+				"url": "https://www.jta.org/archive/palestine-must-be-built-in-cooperation-with-arabs-and-christians-says-dr-weizmann",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -98,3 +98,4 @@ var testCases = [
 	}
 ]
 /** END TEST CASES **/
+

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -96,5 +96,5 @@ var testCases = [
 			}
 		]
 	}
-];
+]
 /** END TEST CASES **/

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -9,17 +9,35 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-18 10:59:49"
+	"lastUpdated": "2025-07-18 11:18:17"
 }
 
+/*
+	***** BEGIN LICENSE BLOCK *****
+ 
+	This file is part of Zotero.
+ 
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
 function detectWeb(doc, url) {
-	// This function determines if the translator should be active on the current page.
-	// It checks if the URL matches the JTA archive pattern and if a main article title
-	// element (h1 with class "entry-title") is present, indicating an article page.
 	if (url.match(/^https?:\/\/www\.jta\.org\/archive\//) && ZU.xpathText(doc, '//h1[@class="entry-title"]')) {
-		return "newspaperArticle"; // Returns the Zotero item type
+		return "newspaperArticle";
 	}
-	return false; // Translator should not be active
+	return false;
 }
 
 async function doWeb(doc, url) {
@@ -27,7 +45,6 @@ async function doWeb(doc, url) {
 }
 
 async function scrape(doc, url) {
-	// This function performs the actual scraping and creates a Zotero item.
 	const item = new Zotero.Item("newspaperArticle");
 
 	// 1. Extract Title: Scrapes the main headline of the article.
@@ -36,16 +53,11 @@ async function scrape(doc, url) {
 		item.title = titleNode.textContent.trim();
 	}
 
-	// 2. Set Publication Title: The publication is consistently "Jewish Telegraphic Agency" for this archive.
 	item.publicationTitle = "Jewish Telegraphic Agency";
 
-	// 3. Set URL: Prefers the canonical URL found in the HTML head for consistency,
-	//    falling back to the current page URL if the canonical link is not found.
 	item.url = url.split('?')[0].split('#')[0];
 
-	// 4. Extract Date:
-	//    First, attempts to extract the date from the JSON-LD schema embedded in the HTML.
-	//    This is generally the most reliable method as it provides a standardized date format.
+	// Extract Date:
 	const dateElem = doc.querySelector('.post-pdf__date');
 	item.date = dateElem.textContent.trim();
 
@@ -54,7 +66,7 @@ async function scrape(doc, url) {
 	document: doc
 	})
 
-	item.libraryCatalog = "Jewish Telegraphic Agency Archive"; // Specific catalog for JTA
+	item.libraryCatalog = "Jewish Telegraphic Agency Archive";
 	item.complete();
 }
 

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -98,4 +98,3 @@ var testCases = [
 	}
 ];
 /** END TEST CASES **/
-

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -14,9 +14,9 @@
 
 /*
 	***** BEGIN LICENSE BLOCK *****
- 
+
 	This file is part of Zotero.
- 
+
 	Zotero is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
@@ -41,7 +41,7 @@ function detectWeb(doc, url) {
 }
 
 async function doWeb(doc, url) {
-	await scrape(doc, url)
+	await scrape(doc, url);
 }
 
 async function scrape(doc, url) {
@@ -62,9 +62,9 @@ async function scrape(doc, url) {
 	item.date = dateElem.textContent.trim();
 
 	item.attachments.push({
-	title: "Snapshot",
-	document: doc
-	})
+		title: "Snapshot",
+		document: doc
+	});
 
 	item.libraryCatalog = "Jewish Telegraphic Agency Archive";
 	item.complete();
@@ -96,6 +96,5 @@ var testCases = [
 			}
 		]
 	}
-]
+];
 /** END TEST CASES **/
-

--- a/Jewish Telegraph Agency News Archive.js
+++ b/Jewish Telegraph Agency News Archive.js
@@ -98,3 +98,4 @@ var testCases = [
 	}
 ];
 /** END TEST CASES **/
+

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -9,7 +9,8 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-18 14:31:18"
+	"lastUpdated": "2025-07-18 14:31:18",
+	"skipTest": true
 }
 
 /*
@@ -36,7 +37,7 @@
 function detectWeb(doc, url) {
 	if (url.match(/\/article-/i) || doc.querySelector('article')) {
 		return "newspaperArticle";
-	} 
+	}
 	return false;
 }
 
@@ -47,12 +48,12 @@ function doWeb(doc, url) {
 			ZU.processDocuments(Object.keys(items), scrape);
 		});
 	}
-    else {
+	else {
 		scrape(doc, url);
 	}
 }
 
-function getSearchResults(doc, url) {
+function getSearchResults(doc) {
 	var items = {};
 	var links = doc.querySelectorAll('a[href*="/article-"]');
 	for (let link of links) {
@@ -82,9 +83,7 @@ function scrape(doc, url) {
 	if (author) {
 		let authorName = author.textContent.trim();
 		// Convert to title case (e.g., "ELIAV BREUER" to "Eliav Breuer")
-		let normalizedName = authorName.toLowerCase().split(' ').map(word => 
-			word.charAt(0).toUpperCase() + word.slice(1)
-		).join(' ');
+		let normalizedName = authorName.toLowerCase().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 		let nameParts = normalizedName.split(' ').filter(part => part);
 		if (nameParts.length === 2) {
 			// Exactly two words: split into first and last name
@@ -145,13 +144,6 @@ function scrape(doc, url) {
 	// Extract ISSN
 	item.ISSN = "0792-822X";
 
-	// Extract full text
-	var articleText = "";
-	var paragraphs = doc.querySelectorAll('article p');
-	for (let p of paragraphs) {
-		articleText += p.textContent + "\n\n";
-	}
-
 	item.language = "en";
 
 	// Attach snapshot
@@ -166,7 +158,7 @@ function scrape(doc, url) {
 
 /** BEGIN TEST CASES **/
 var testCases = [
-		{
+	{
 		"type": "web",
 		"url": "https://www.jpost.com/middle-east/iran-news/article-861478#353653gsrdvydsfsdg",
 		"items": [

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -46,7 +46,8 @@ function doWeb(doc, url) {
 			if (!items) return;
 			ZU.processDocuments(Object.keys(items), scrape);
 		});
-	} else {
+	}
+    else {
 		scrape(doc, url);
 	}
 }
@@ -280,4 +281,3 @@ var testCases = [
 	}
 ]
 /** END TEST CASES **/
-

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -9,8 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-07-18 14:31:18",
-	"skipTest": true
+	"lastUpdated": "2025-07-18 14:31:18"
 }
 
 /*
@@ -83,7 +82,8 @@ function scrape(doc, url) {
 	if (author) {
 		let authorName = author.textContent.trim();
 		// Convert to title case (e.g., "ELIAV BREUER" to "Eliav Breuer")
-		let normalizedName = authorName.toLowerCase().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+		let normalizedName = authorName.toLowerCase().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
 		let nameParts = normalizedName.split(' ').filter(part => part);
 		if (nameParts.length === 2) {
 			// Exactly two words: split into first and last name

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -46,7 +46,8 @@ function doWeb(doc, url) {
 			if (!items) return;
 			ZU.processDocuments(Object.keys(items), scrape);
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
@@ -283,5 +284,6 @@ var testCases = [
 			}
 		]
 	}
+
 ]
 /** END TEST CASES **/

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -1,0 +1,287 @@
+{
+	"translatorID": "851bce89-f52d-4330-b737-8bd50615cf1f",
+	"label": "The Jerusalem Post",
+	"creator": "Anonymus",
+	"target": "^https?://(www\\.)?jpost\\.com/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-07-18 14:31:18"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+ 
+	This file is part of Zotero.
+ 
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	if (url.match(/\/article-/i) || doc.querySelector('article')) {
+		return "newspaperArticle";
+	} 
+	return false;
+}
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, url), function (items) {
+			if (!items) return;
+			ZU.processDocuments(Object.keys(items), scrape);
+		});
+	} else {
+		scrape(doc, url);
+	}
+}
+
+function getSearchResults(doc, url) {
+	var items = {};
+	var links = doc.querySelectorAll('a[href*="/article-"]');
+	for (let link of links) {
+		let title = ZU.trimInternal(link.textContent);
+		let href = link.href;
+		if (title && href) {
+			items[href] = title;
+		}
+	}
+	return items;
+}
+
+function scrape(doc, url) {
+	var item = new Zotero.Item("newspaperArticle");
+	item.publicationTitle = "The Jerusalem Post";
+
+	// Extract title
+	var title = doc.querySelector('h1') ? ZU.trimInternal(doc.querySelector('h1').textContent) : "";
+	item.title = title;
+
+	// Extract authors
+	var author = doc.querySelector('meta[name="author"]');
+	if (!author) {
+		// Fallback: scrape author from <span class="reporters">
+		author = doc.querySelector('span.reporters a.reporter-name-channel');
+	}
+	if (author) {
+		let authorName = author.textContent.trim();
+		// Convert to title case (e.g., "ELIAV BREUER" to "Eliav Breuer")
+		let normalizedName = authorName.toLowerCase().split(' ').map(word => 
+			word.charAt(0).toUpperCase() + word.slice(1)
+		).join(' ');
+		let nameParts = normalizedName.split(' ').filter(part => part);
+		if (nameParts.length === 2) {
+			// Exactly two words: split into first and last name
+			item.creators.push({
+				firstName: nameParts[0],
+				lastName: nameParts[1],
+				creatorType: "author"
+			});
+		}
+		else if (nameParts.length > 0) {
+			// Any other number of words: treat as single name field
+			item.creators.push({
+				lastName: normalizedName,
+				creatorType: "author",
+				fieldMode: 1 // Single name field
+			});
+		}
+	}
+	
+
+	// Extract date
+	var date = doc.querySelector('meta[property="article:published_time"]');
+	if (date) {
+		item.date = ZU.strToISO(date.content);
+	}
+	else {
+		// Fallback to text date in the article
+		let dateText = doc.querySelector('time');
+		if (dateText) {
+			item.date = ZU.strToISO(dateText.getAttribute('datetime') || dateText.textContent);
+		}
+	}
+
+	// Extract abstract/summary
+	var abstract = doc.querySelector('meta[name="description"]');
+	if (abstract) {
+		item.abstractNote = abstract.content;
+	}
+
+	// Extract tags
+	var tags = doc.querySelectorAll('meta[name="keywords"]');
+	if (tags.length) {
+		let keywords = tags[0].content.split(',').map(tag => tag.trim());
+		for (let tag of keywords) {
+			if (tag) item.tags.push(tag);
+		}
+	}
+
+	// Extract URL
+	item.url = url.split('?')[0].split('#')[0];
+
+	// Extract section
+	var section = doc.querySelector('meta[property="article:section"]');
+	if (section) {
+		item.section = section.content;
+	}
+
+	// Extract ISSN
+	item.ISSN = "0792-822X";
+
+	// Extract full text
+	var articleText = "";
+	var paragraphs = doc.querySelectorAll('article p');
+	for (let p of paragraphs) {
+		articleText += p.textContent + "\n\n";
+	}
+	if (articleText) {
+		item.notes.push({
+			note: "<h1>" + item.title + "</h1>\n" + articleText
+		});
+	}
+
+	item.language = "en";
+
+	// Attach snapshot
+	item.attachments.push({
+		title: "Snapshot",
+		document: doc,
+		mimeType: "text/html"
+	});
+
+	item.complete();
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.jpost.com/middle-east/iran-news/article-861478#353653gsrdvydsfsdg",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "Iran rushing to rearm Mideast terror proxies after IDF, US strikes on Tehran - WSJ",
+				"creators": [
+					{
+						"lastName": "Jerusalem Post Staff",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2025-07-18",
+				"ISSN": "0792-822X",
+				"abstractNote": "Despite the denials from Tehran, there is mounting evidence that Iran continues to send military aid to these groups, demonstrating its determination to retain influence over its militia allies.",
+				"language": "en",
+				"libraryCatalog": "The Jerusalem Post",
+				"publicationTitle": "The Jerusalem Post",
+				"url": "https://www.jpost.com/middle-east/iran-news/article-861478",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Hezbollah"
+					},
+					{
+						"tag": "Houthi"
+					},
+					{
+						"tag": "Iran"
+					},
+					{
+						"tag": "Iran nuclear"
+					},
+					{
+						"tag": "Lebanon"
+					},
+					{
+						"tag": "Operation Midnight Hammer"
+					},
+					{
+						"tag": "Operation Rising Lion"
+					},
+					{
+						"tag": "Syria Iran"
+					},
+					{
+						"tag": "Yemen"
+					},
+					{
+						"tag": "hezbollah iran"
+					},
+					{
+						"tag": "hezbollah syria"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.jpost.com/israel-news/article-861421?eagear345",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "I saw Israel’s attorney‑general bend the law for her favorites, and I paid the price - comment",
+				"creators": [
+					{
+						"firstName": "Zvika",
+						"lastName": "Klein",
+						"creatorType": "author"
+					}
+				],
+				"date": "2025-07-17",
+				"ISSN": "0792-822X",
+				"abstractNote": "Editor's Notes: I’ve been pretty quiet since I was released from house arrest and received tremendous support from Israelis. But on Friday, I almost lost it.",
+				"language": "en",
+				"libraryCatalog": "The Jerusalem Post",
+				"publicationTitle": "The Jerusalem Post",
+				"url": "https://www.jpost.com/israel-news/article-861421",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Attorney-General"
+					},
+					{
+						"tag": "Gali Baharav-Miara"
+					},
+					{
+						"tag": "Qatargate"
+					},
+					{
+						"tag": "The Jerusalem Post"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/The Jerusalem Post.js
+++ b/The Jerusalem Post.js
@@ -46,8 +46,7 @@ function doWeb(doc, url) {
 			if (!items) return;
 			ZU.processDocuments(Object.keys(items), scrape);
 		});
-	}
-	else {
+	} else {
 		scrape(doc, url);
 	}
 }
@@ -151,11 +150,6 @@ function scrape(doc, url) {
 	for (let p of paragraphs) {
 		articleText += p.textContent + "\n\n";
 	}
-	if (articleText) {
-		item.notes.push({
-			note: "<h1>" + item.title + "</h1>\n" + articleText
-		});
-	}
 
 	item.language = "en";
 
@@ -171,7 +165,7 @@ function scrape(doc, url) {
 
 /** BEGIN TEST CASES **/
 var testCases = [
-	{
+		{
 		"type": "web",
 		"url": "https://www.jpost.com/middle-east/iran-news/article-861478#353653gsrdvydsfsdg",
 		"items": [
@@ -284,6 +278,6 @@ var testCases = [
 			}
 		]
 	}
-
 ]
 /** END TEST CASES **/
+


### PR DESCRIPTION
Add translator for Israel's national newspaper library

Here are example articles:
https://www.nli.org.il/en/newspapers/israelsmessenger/1921/06/10/01/article/26/?e=-------en-20--1--img-txIN%7ctxTI--------------1
https://www.nli.org.il/en/newspapers/kentuckyjc/1938/08/19/01/article/14/?e=-------en-20--1--img-txIN%7ctxTI--------------1

