### PR TITLE
IMDb: Improve CSL specification adherence

### DIFF
--- a/IMDb.js
+++ b/IMDb.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-03-31 22:02:24"
+	"lastUpdated": "2025-07-29 17:25:50"
 }
 
 /*
@@ -45,7 +45,7 @@ function detectWeb(doc, url) {
 			return "film";
 		}
 	}
-	else if (url.includes('/find?') && getSearchResults(doc, true)) {
+	else if (url.includes('/find/?') && getSearchResults(doc, true)) {
 		return "multiple";
 	}
 	return false;
@@ -54,10 +54,10 @@ function detectWeb(doc, url) {
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
-	var rows = ZU.xpath(doc, '//td[contains(@class, "result_text")]');
-	for (let i = 0; i < rows.length; i++) {
-		var href = ZU.xpathText(rows[i], './a/@href');
-		var title = ZU.trimInternal(rows[i].textContent);
+	var rows = doc.querySelectorAll('.ipc-metadata-list-summary-item__t');
+	for (let row of rows) {
+		var href = row.href;
+		var title = ZU.trimInternal(row.textContent);
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -462,7 +462,7 @@ var testCases = [
 					}
 				],
 				"date": "2006-09-07",
-				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
+				"abstractNote": "Newlyweds move in next door to a veteran married couple of 25 years.",
 				"distributor": "Impact Zone Productions, Sony Pictures Television",
 				"extra": "IMDb ID: tt0759475\nevent-place: United States",
 				"libraryCatalog": "IMDb",
@@ -472,78 +472,16 @@ var testCases = [
 						"tag": "big breasts"
 					},
 					{
-						"tag": "breast"
-					},
-					{
 						"tag": "brother brother relationship"
 					},
 					{
-						"tag": "columbia tristar"
-					},
-					{
 						"tag": "death in title"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.imdb.com/title/tt0759475/?ref_=fn_al_tt_5",
-		"items": [
-			{
-				"itemType": "film",
-				"title": "'Til Death",
-				"creators": [
-					{
-						"firstName": "Josh",
-						"lastName": "Goldsmith",
-						"creatorType": "scriptwriter"
 					},
 					{
-						"firstName": "Cathy",
-						"lastName": "Yuspa",
-						"creatorType": "scriptwriter"
+						"tag": "principal"
 					},
 					{
-						"firstName": "Brad",
-						"lastName": "Garrett",
-						"creatorType": "contributor"
-					},
-					{
-						"firstName": "Joely",
-						"lastName": "Fisher",
-						"creatorType": "contributor"
-					},
-					{
-						"firstName": "Kat",
-						"lastName": "Foster",
-						"creatorType": "contributor"
-					}
-				],
-				"date": "2006-09-07",
-				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
-				"distributor": "Impact Zone Productions, Sony Pictures Television",
-				"extra": "IMDb ID: tt0759475\nevent-place: United States",
-				"libraryCatalog": "IMDb",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "big breasts"
-					},
-					{
-						"tag": "breast"
-					},
-					{
-						"tag": "brother brother relationship"
-					},
-					{
-						"tag": "columbia tristar"
-					},
-					{
-						"tag": "death in title"
+						"tag": "schoolteacher"
 					}
 				],
 				"notes": [],
@@ -597,7 +535,7 @@ var testCases = [
 				],
 				"date": "2023-03-02",
 				"abstractNote": "Picard grapples with a life-altering revelation as the crew of the Titan attempt to outmaneuver Vadic, while Raffi and Worf uncover a plot by a vengeful enemy.",
-				"extra": "IMDb ID: tt19402762\nevent-place:",
+				"extra": "IMDb ID: tt19402762\nevent-place: United States",
 				"libraryCatalog": "IMDb",
 				"programTitle": "Star Trek: Picard",
 				"runningTime": "56m",

--- a/IMDb.js
+++ b/IMDb.js
@@ -106,7 +106,6 @@ function scrape(doc, _url) {
 
 	item.date = json.datePublished;
 	item.runningTime = "duration" in json ? json.duration.replace("PT", "").toLowerCase() : "";
-	item.genre = Array.isArray(json.genre) ? json.genre.join(", ") : json.genre;
 	item.abstractNote = json.description;
 	var creatorsMapping = {
 		director: "director",
@@ -138,7 +137,7 @@ function scrape(doc, _url) {
 		addExtra(item, "IMDb ID: " + pageId);
 	}
 	let locationLinks = doc.querySelectorAll('a[href*="title/?country_of_origin"]');
-	addExtra(item, "event-location: "
+	addExtra(item, "event-place: "
 		+ [...locationLinks].map(a => a.innerText).join(', '));
 	item.tags = "keywords" in json ? json.keywords.split(",") : [];
 	item.complete();
@@ -198,8 +197,7 @@ var testCases = [
 				"date": "1985-11-08",
 				"abstractNote": "During the final months of Argentinian Military Dictatorship in 1983, a high school teacher sets out to find out who the mother of her adopted daughter is.",
 				"distributor": "Historias Cinematograficas, Progress Communications",
-				"extra": "Translated title: The Official Story\nIMDb ID: tt0089276\nevent-location: Argentina",
-				"genre": "Drama, History",
+				"extra": "Translated title: The Official Story\nIMDb ID: tt0089276\nevent-place: Argentina",
 				"libraryCatalog": "IMDb",
 				"runningTime": "1h52m",
 				"attachments": [],
@@ -272,8 +270,7 @@ var testCases = [
 				"date": "1966-10-21",
 				"abstractNote": "Two student couples go camping in the Finnish countryside; partner swapping and interpersonal dynamics - with a touch of their philosophy - between them all arise.",
 				"distributor": "FJ-Filmi",
-				"extra": "IMDb ID: tt0060613\nevent-location: Finland",
-				"genre": "Drama",
+				"extra": "IMDb ID: tt0060613\nevent-place: Finland",
 				"libraryCatalog": "IMDb",
 				"runningTime": "1h29m",
 				"attachments": [],
@@ -330,7 +327,7 @@ var testCases = [
 				],
 				"date": "2017-02-18",
 				"abstractNote": "Wildlife documentary series with David Attenborough, beginning with a look at the remote islands which offer sanctuary to some of the planet&apos;s rarest creatures.",
-				"extra": "IMDb ID: tt6142646\nevent-location: United Kingdom",
+				"extra": "IMDb ID: tt6142646\nevent-place: United Kingdom",
 				"libraryCatalog": "IMDb",
 				"programTitle": "Planet Earth II",
 				"runningTime": "51m",
@@ -403,7 +400,7 @@ var testCases = [
 				],
 				"date": "2019-10-21",
 				"abstractNote": "A struggling Lori turns to Candy for help before revisiting The Deuce; Candy makes a deal to secure funding for her film; Abby takes a stand against the latest phase of Midtown redevelopment; Tommy explains the new world order to ...",
-				"extra": "IMDb ID: tt9060452\nevent-location: United States",
+				"extra": "IMDb ID: tt9060452\nevent-place: United States",
 				"libraryCatalog": "IMDb",
 				"programTitle": "The Deuce",
 				"runningTime": "1h5m",
@@ -467,8 +464,7 @@ var testCases = [
 				"date": "2006-09-07",
 				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
 				"distributor": "Impact Zone Productions, Sony Pictures Television",
-				"extra": "IMDb ID: tt0759475\nevent-location: United States",
-				"genre": "Comedy, Romance",
+				"extra": "IMDb ID: tt0759475\nevent-place: United States",
 				"libraryCatalog": "IMDb",
 				"attachments": [],
 				"tags": [
@@ -530,8 +526,7 @@ var testCases = [
 				"date": "2006-09-07",
 				"abstractNote": "A pair of newlyweds move in next door to a veteran married couple of 25 years.",
 				"distributor": "Impact Zone Productions, Sony Pictures Television",
-				"extra": "IMDb ID: tt0759475\nevent-location: United States",
-				"genre": "Comedy, Romance",
+				"extra": "IMDb ID: tt0759475\nevent-place: United States",
 				"libraryCatalog": "IMDb",
 				"attachments": [],
 				"tags": [
@@ -602,7 +597,7 @@ var testCases = [
 				],
 				"date": "2023-03-02",
 				"abstractNote": "Picard grapples with a life-altering revelation as the crew of the Titan attempt to outmaneuver Vadic, while Raffi and Worf uncover a plot by a vengeful enemy.",
-				"extra": "IMDb ID: tt19402762\nevent-location:",
+				"extra": "IMDb ID: tt19402762\nevent-place:",
 				"libraryCatalog": "IMDb",
 				"programTitle": "Star Trek: Picard",
 				"runningTime": "56m",


### PR DESCRIPTION
Do not import text such as 'drama' to `genre`, which is a type/class/subtype rather than a style or category. Import the place to `event-place` rather than the nonexistent `event-location` variable.