### PR TITLE
Update Wikidata QuickStatements.js

### DIFF
--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -1,14 +1,14 @@
 {
-	"translatorID": "51e5355d-9974-484f-80b9-f84d2b55782e",
+	"translatorID": "51e5355d-9974-484f-80b9-f84d2b55782e-pascal",
 	"label": "Wikidata QuickStatements",
-	"creator": "Philipp Zumstein",
+	"creator": "Philipp Zumstein (with minor edits by Pascal Martinolli)",
 	"target": "txt",
-	"minVersion": "3.0",
+	"minVersion": "3.1",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 2,
-	"lastUpdated": "2022-12-08 23:00:00"
+	"lastUpdated": "2025-05-21 00:00:00"
 }
 
 
@@ -33,6 +33,28 @@
 	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
 
 	***** END LICENSE BLOCK *****
+*/
+
+/*
+	***** BEGIN REVISION BLOCK *****
+
+	In 2025, Pascal Martinolli made some revisions to the original code.
+	
+	They modify the Description of :
+	   - encyclopedia entries (which encyclopedia),
+	   - book sections (which book),
+	   - thesis (which university),
+	   - conference papers (which conference).
+	   
+	They add a "default for all languages" Label.
+	
+	They manage the permanent identifiers from :
+	   - OpenAlex: P10283
+	   - Semantic Scholar CorpusID: P8299
+	   - Web of Science WOS: P8372
+	   - Microsoft Academic Graph MAG: P6366
+
+	***** END REVISION BLOCK *****
 */
 
 
@@ -148,7 +170,11 @@ var identifierMapping = {
 	"Open Library ID": "P648",
 	OCLC: "P243",
 	"IMDb ID": "P345",
-	"Google-Books-ID": "P675"
+	"Google-Books-ID": "P675",
+	OpenAlex: "P10283",
+	CorpusID: "P8299",
+	WOS: "P8372",
+	MAG: "P6366"
 };
 
 
@@ -191,6 +217,18 @@ function zoteroItemToQuickStatements(item) {
 	});
 	if (item.publicationTitle && (itemType == "journalArticle" || itemType == "magazineArticle" || itemType == "newspaperArticle")) {
 		description = description + ' from \'' + item.publicationTitle + '\'';
+	}
+	if (item.proceedingsTitle && (itemType == "conferencePaper")) {
+		description = description + ' from \'' + item.proceedingsTitle + '\'';
+	}
+	if (item.bookTitle && (itemType == "bookSection")) {
+		description = description + ' from \'' + item.bookTitle + '\'';
+	}
+	if (item.encyclopediaTitle && (itemType == "encyclopediaArticle")) {
+		description = description + ' from \'' + item.encyclopediaTitle + '\'';
+	}
+	if (item.university && (itemType == "thesis")) {
+		description = description + ' from \'' + item.university + '\'';
 	}
 	if (item.date) {
 		var year = ZU.strToDate(item.date).year;
@@ -260,6 +298,7 @@ function zoteroItemToQuickStatements(item) {
 	if (item.language && (item.language.toLowerCase() in languageMapping)) {
 		let lang = item.language.toLowerCase();
 		addStatement('L' + lang, '"' + item.title + '"');
+		addStatement('Lmul', '"' + item.title + '"');
 		addStatement('P1476', lang + ':"' + item.title + '"');
 		addStatement('P407', languageMapping[lang]);
 	}


### PR DESCRIPTION
	They modify the Description of :
	   - encyclopedia entries (which encyclopedia),
	   - book sections (which book),
	   - thesis (which university),
	   - conference papers (which conference).
	   
	They add a "default for all languages" Label.
	
	They manage the permanent identifiers from :
	   - OpenAlex: P10283
	   - Semantic Scholar CorpusID: P8299
	   - Web of Science WOS: P8372
	   - Microsoft Academic Graph MAG: P6366