### PR TITLE
Update EUR-Lex.js

### DIFF
--- a/EUR-Lex.js
+++ b/EUR-Lex.js
@@ -205,7 +205,12 @@ function scrape(doc, url) {
 		for (let i = 0; i < passedBy.length; i++) {
 			passedByArray.push(passedBy[i].getAttribute("resource").split("/").pop());
 		}
-		item.legislativeBody = passedByArray.join(", ");
+		
+		if (type == "statute") {
+			item.authority = passedByArray.join(", ");
+		} else {
+			item.legislativeBody = passedByArray.join(", ");
+		}
 		
 		item.url = attr(doc, 'meta[typeOf="eli:LegalResource"]', "about") + "/" + language.toLowerCase();
 	}


### PR DESCRIPTION
This commit improves the import of files as statutes, i.e. EU regulations. The "bill" file type in Zotero already has a field named "Legislative Body". The file type 'statute' does not. When importing a file of this type, the translator writes the file type in the 'Extra' field. You cannot have unofficial variables in the extra field if you want your style to be registered in the official Zotero style repository. The solution is to use the recognised file variables. The correct CSL field mapping for 'Legislative Body' is 'authority', so 'authority' must be imported into the 'Extra' field for statutes.