### PR TITLE
RDF: Move issue to number (don't copy) if issue isn't valid

### DIFF
--- a/RDF.js
+++ b/RDF.js
@@ -12,7 +12,7 @@
 	},
 	"inRepository": true,
 	"translatorType": 1,
-	"lastUpdated": "2023-04-24 15:51:01"
+	"lastUpdated": "2025-08-06 22:48:30"
 }
 
 /*
@@ -1012,10 +1012,13 @@ function importItem(newItem, node) {
 		n.so + "issueNumber"], true);
 
 
-	// number means the same thing as issue
-	// and will automatically then also map
-	// to patentNumber or reportNumber
-	newItem.number = newItem.issue;
+	// Move issue to number if issue isn't valid for this type,
+	// because number will automatically then also map to
+	// patentNumber or reportNumber
+	if (!ZU.fieldIsValidForType("issue", newItem.itemType)) {
+		newItem.number = newItem.issue;
+		delete newItem.issue;
+	}
 
 	// edition
 	newItem.edition = getFirstResults(node, [n.prism + "edition", n.prism2_0 + "edition", n.prism2_1 + "edition", n.bibo + "edition", n.so + "bookEdition", n.so + "version"], true);


### PR DESCRIPTION
Fixes the bug reported here: https://forums.zotero.org/discussion/comment/496947/#Comment_496947

It makes sense to put issue info in `number` for item types that don't support `issue`, since `number` is a more general field with more mappings, but it doesn't seem right to put the data in both fields, or to apply the transformation in cases where `issue` is perfectly valid.

Instead, we now move `issue` to `number`, only on item types that don't support `issue`.