### PR TITLE
Embedded Metadata: do not add duplicates bylines when getting authors

### DIFF
--- a/Embedded Metadata.js
+++ b/Embedded Metadata.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-06-10 14:42:15"
+	"lastUpdated": "2025-09-25 08:28:33"
 }
 
 /*
@@ -761,7 +761,9 @@ function getAuthorFromByline(doc, newItem) {
 			Z.debug(`Found ${byline.length} elements with '${bylineClass}' class (strict: ${isStrict})`);
 			for (let bylineElement of byline) {
 				if (!bylineElement.innerText?.trim()) continue;
-				bylines.push(bylineElement);
+				if (!bylines.includes(bylineElement)) {
+					bylines.push(bylineElement);
+				}
 			}
 
 			if (isStrict && bylines.length) {
@@ -1935,6 +1937,40 @@ var testCases = [
 				"shortTitle": "Infographic",
 				"url": "https://www.statista.com/chart/13139/estimated-worldwide-mobile-e-commerce-sales",
 				"websiteTitle": "Statista Daily Data",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://optimization-online.org/2023/05/maximum-likelihood-probability-measures-over-sets-and-applications-to-data-driven-optimization/",
+		"items": [
+			{
+				"itemType": "blogPost",
+				"title": "Maximum Likelihood Probability Measures over Sets and Applications to Data-Driven Optimization – Optimization Online",
+				"creators": [
+					{
+						"firstName": "Juan",
+						"lastName": "Borrero",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Denis",
+						"lastName": "Saure",
+						"creatorType": "author"
+					}
+				],
+				"date": "2023-05-15",
+				"language": "en-US",
+				"url": "https://optimization-online.org/2023/05/maximum-likelihood-probability-measures-over-sets-and-applications-to-data-driven-optimization/",
 				"attachments": [
 					{
 						"title": "Snapshot",


### PR DESCRIPTION
This fixes an issue when duplicate bylines (strict true/false) are added to the list that leads to empty creators, cf. new webtest.

I ran the other webtests and they are working properly for creators. 2 links changed, but in other fields.