### PR TITLE
Add ChatGPT translator

### DIFF
--- a/ChatGPT.js
+++ b/ChatGPT.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-10-15 19:39:38"
+	"lastUpdated": "2025-10-15 19:49:02"
 }
 
 /*
@@ -38,7 +38,7 @@
 /* Description
  **************
  *
- * The ChatGPT Translator can get a private conversation (standard), shared conversation, or conversations from a project. 
+ * The ChatGPT Translator can get a private conversation (standard), shared conversation, or conversations from a project.
  * As there is no specic "AI" source, instantMessages seemed to be the closest, but ChatGPT is set as the first "author" (Although, hesitantly, but this is done for transparency)
  *
  * For a private conversation, the translator attempts to use the internal API so data is cleanest, and some data such as date is only available via API
@@ -48,11 +48,11 @@
  *
  * Projects allow for multiple grabbing of conversations, utilizing the individual grabs for most of the code.
  *
- * Please note, much of this was vibe coded by OpenAi's Codex, so there is likely a lot of bloat that can be removed.  
+ * Please note, much of this was vibe coded by OpenAi's Codex, so there is likely a lot of bloat that can be removed.
  * I did several refactors to try and reduce Codex's bad habit of overengineering stuff, but I have run out of time to complete this, and in my tests it works well.
  *
  *
- * Only a single automated test is included, as most testing is on private conversations.  
+ * Only a single automated test is included, as most testing is on private conversations.
  * But to try and at least provide some info on my private testing, in the test share conversation, I included a log of getting that conversation when it was private.
  *
  */


### PR DESCRIPTION
/* Description
 **************
 * 
 * The ChatGPT Translator can get a private conversation (standard), shared conversation, or conversations from a project. 
 * As there is no specific "AI" source, instantMessages seemed to be the closest, but ChatGPT is set as the first "author" (Although, hesitantly, but this is done for transparency)
 * 
 * For a private conversation, the translator attempts to use the internal API so data is cleanest, and some data such as date is only available via API
 * Since a private conversation that is cited cannot be accessed, if the private conversation has had a public share created, it will put this URL in, and its date (I plan to make another translator so people have the option to get the private info only)
 * 
 * Shared conversations that have not yet been used by a new user have a share URL, but do not have API access to it and limited DOM information, so only a little metadata is filled in
 * 
 * Projects allow for multiple grabbing of conversations, utilizing the individual grabs for most of the code.
 * 
 * Please note, much of this was vibe coded by OpenAI's Codex, so there is likely a lot of bloat that can be removed.  
 * I did several refactors to try and reduce Codex's bad habit of overengineering stuff, but I have run out of time to complete this, and in my tests it works well.
 * 
 * 
 * Only a single automated test is included, as most testing is on private conversations.  
 * But to try and at least provide some info on my private testing, in the test share conversation, I included a log of getting that conversation when it was private.
 * 
 */


/* AI Chat Translator Pattern *
 ******************************
 *
 * The pattern for retrieving AI chats goes generally as follows:
 *
 * First is determined the source of the chats(s)
 *  - A private conversation ('private')
 *  - A shared conversation ('shared')
 *  - A project ('project')
 *
 * Depending on the source, the following will occur
 *
 * Private Conversation
 * --------------------
 * 1. While getting the initial API info for the chat, get the user info
 * 2. Get from the internal API endpoint for the conversation
 * 3. As a fallback, Get from the DOM for the conversation
 * 4. Get the shared version of the conversation if it exists from the Shared Conversation List
 * 5. Get the Snapshot from the private conversation
 *
 * Shared Conversation
 * -------------------
 * 1. Get from the DOM as much information as can be found.
 * 2. Attach a snapshot that points at the shared conversation URL
 *
 * Project of Conversations
 * ------------------------
 * 1. Scan the project dashboard DOM to build the selectable conversation list
 * 2. Resolve project and conversation identifiers for the selected entry
 * 3. Fetch each conversation via the private API pathway (same as a private save)
 * 4. Enrich with share metadata when available and note the project URL in the item
 *
 */