### PR TITLE
Add Gemini Chat translator (gemini.google.com → instantMessage)

### DIFF
--- a/Gemini Chat.js
+++ b/Gemini Chat.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-10-16 17:43:53"
+	"lastUpdated": "2025-10-16 17:50:44"
 }
 
 /*
@@ -2927,40 +2927,40 @@ async function callAPI(doc, apiOptions = {}) {
 
 /** BEGIN TEST CASES **/
 var testCases = [
-  {
-    "type": "web",
-    "url": "https://gemini.google.com/share/88994295fbe1",
-    "items": [
-      {
-        "itemType": "instantMessage",
-        "title": "Zotero Connector Test Case",
-        "creators": [
-          {
-            "creatorType": "author",
-            "lastName": "Google Gemini",
-            "fieldMode": 1
-          },
-          {
-            "creatorType": "author",
-            "lastName": "Anonymous",
-            "fieldMode": 1
-          }
-        ],
-        "date": "2025-10-16",
-        "extra": "Model: 2.5 Flash\nCreated: 2025-10-16",
-        "url": "https://gemini.google.com/share/88994295fbe1",
-        "attachments": [
-          {
-            "title": "Gemini Chat Conversation Snapshot",
-            "snapshot": true,
-            "mimeType": "text/html"
-          }
-        ],
-        "tags": [],
-        "notes": [],
-        "seeAlso": []
-      }
-    ]
-  }
+	{
+		"type": "web",
+		"url": "https://gemini.google.com/share/88994295fbe1",
+		"items": [
+			{
+				"itemType": "instantMessage",
+				"title": "Zotero Connector Test Case",
+				"creators": [
+					{
+						"creatorType": "author",
+						"lastName": "Google Gemini",
+						"fieldMode": 1
+					},
+					{
+						"creatorType": "author",
+						"lastName": "Anonymous",
+						"fieldMode": 1
+					}
+				],
+				"date": "2025-10-16",
+				"extra": "Model: 2.5 Flash\nCreated: 2025-10-16",
+				"url": "https://gemini.google.com/share/88994295fbe1",
+				"attachments": [
+					{
+						"title": "Gemini Chat Conversation Snapshot",
+						"snapshot": true,
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
* Description
 **************
 *
 * The Gemini translator handles single private or shared Gemini conversations.
 *
 * For private conversations, it signs the user in via the Gemini MaZiqc API, retrieves summaries for title and date,
 * and then backfills the human author and model details from the live DOM when needed. The saved item always keeps the
 * private conversation snapshot (share lookups are not yet wired up in this refactor).
 *
 * For shared conversations, it extracts the visible metadata from the published page, including publish timestamps,
 * and attaches a snapshot that points at the shared URL.
 *
 * Gemini project dashboards are not yet supported.
 *
 */

/* AI Chat Translator Pattern *
 ******************************
 *
 * The shared translator pattern handles AI conversations by first determining the source context:
 *  - A private conversation ('private')
 *  - A shared conversation ('share')
 *
 * Depending on the source, the Gemini-specific behavior is:
 *
 * Private Conversation
 * --------------------
 * 1. Gather auth tokens from the Gemini page context and call the MaZiqc summary API for title/date details.
 * 2. Record the resolved conversation identifier so later DOM fallbacks align to the same chat.
 * 3. Fill any missing human author or model metadata from the live DOM when the API does not expose it.
 * 4. Keep the private conversation URL and attach a snapshot based on the currently viewed page.
 *
 * Shared Conversation
 * -------------------
 * 1. Parse the published share DOM for title, owner, model, and publish timestamps.
 * 2. Save the share URL as both the item URL and the snapshot target.
 *
 * Project dashboards will hook into the private flow once Gemini exposes stable project APIs.
 *
 */