### PR TITLE
New translators for Miroslav Krleža Institute of Lexicography publications

### DIFF
--- a/Hrvatska enciklopedija.js
+++ b/Hrvatska enciklopedija.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-11-06 14:16:30"
+	"lastUpdated": "2025-11-06 14:58:36"
 }
 
 /*
@@ -44,7 +44,7 @@ function detectWeb(doc, url) {
 
 function doWeb(doc, url) {
 	let item = new Zotero.Item("encyclopediaArticle");
-	item.attachments.push( {title: "Snapshot", document: doc} );
+	item.attachments.push({ title: "Snapshot", document: doc });
 	
 	item.encyclopediaTitle = "Hrvatska enciklopedija";
 	item.publisher = "Leksikografski zavod Miroslav Krleža";

--- a/Hrvatska tehnicka enciklopedija.js
+++ b/Hrvatska tehnicka enciklopedija.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-11-06 14:19:43"
+	"lastUpdated": "2025-11-06 15:01:36"
 }
 
 /*
@@ -35,8 +35,8 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(doc, url) {
-	if ( doc.querySelector("div.content") ) {
+function detectWeb(doc, _) {
+	if (doc.querySelector("div.content")) {
 		return "encyclopediaArticle";
 	}
 	return false;
@@ -44,7 +44,7 @@ function detectWeb(doc, url) {
 
 function doWeb(doc, url) {
 	let item = new Zotero.Item("encyclopediaArticle");
-	item.attachments.push( {title: "Snapshot", document: doc} );
+	item.attachments.push({ title: "Snapshot", document: doc });
 	
 	item.encyclopediaTitle = "Hrvatska tehnička enciklopedija";
 	item.publisher = "Leksikografski zavod Miroslav Krleža";
@@ -53,7 +53,7 @@ function doWeb(doc, url) {
 	item.url = url.replace(/[?#].*/, "");
 	
 	item.title = doc.title.replace(" | Hrvatska tehnička enciklopedija", "");
-	item.date = ZU.strToISO( attr(doc, "time.published", "datetime") );
+	item.date = ZU.strToISO(attr(doc, "time.published", "datetime"));
 
 	item.complete();
 }

--- a/Hrvatski biografski leksikon.js
+++ b/Hrvatski biografski leksikon.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-11-06 14:15:43"
+	"lastUpdated": "2025-11-06 15:03:24"
 }
 
 /*
@@ -35,8 +35,8 @@
 	***** END LICENSE BLOCK *****
 */
 
-function detectWeb(doc, url) {
-	if ( doc.querySelector("div.clanak") ) {
+function detectWeb(doc, _) {
+	if (doc.querySelector("div.clanak")) {
 		return "encyclopediaArticle";
 	}
 	return false;
@@ -44,7 +44,7 @@ function detectWeb(doc, url) {
 
 function doWeb(doc, url) {
 	let item = new Zotero.Item("encyclopediaArticle");
-	item.attachments.push( {title: "Snapshot", document: doc} );
+	item.attachments.push({ title: "Snapshot", document: doc });
 	
 	item.encyclopediaTitle = "Hrvatski biografski leksikon";
 	item.publisher = "Leksikografski zavod Miroslav Krleža";
@@ -53,7 +53,7 @@ function doWeb(doc, url) {
 	item.url = url.replace(/[?#].*/, "");
 	
 	item.title = doc.title.replace(" - Hrvatski biografski leksikon", "");
-	item.date = ZU.strToISO( attr(doc, "time.published", "datetime") );
+	item.date = ZU.strToISO(attr(doc, "time.published", "datetime"));
 
 	item.complete();
 }


### PR DESCRIPTION
New translators for tehnika.lzmk.hr and hbl.lzmk.hr. Cosmetic changes to enciklopedija.hr translator to keep them in sync.