### PR TITLE
Fix: correctly source expandedTitle (the full title of the journal) in ACM Digital Library.

### DIFF
--- a/ACM Digital Library.js
+++ b/ACM Digital Library.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-01-07 17:48:30"
+	"lastUpdated": "2026-03-09 12:52:09"
 }
 
 /*
@@ -184,7 +184,7 @@ async function scrape(doc) {
 	
 	if (item.itemType == 'journalArticle') {
 		// Publication name in the CSL is shortened; scrape from page to get full title.
-		let expandedTitle = text(doc, 'span.epub-section__title');
+		let expandedTitle = attr(doc, 'meta[name="citation_journal_title"]', 'content');
 		if (expandedTitle) {
 			item.journalAbbreviation = item.publicationTitle;
 			item.publicationTitle = expandedTitle;


### PR DESCRIPTION
# Problem

When saving a paper from ACM Digital Library, the snippet to get the full title of the journal wrongly grabs `span.epub-section__title`, which points to the artifact of the paper:

```html
<span class="epub-section__title">{The title of the paper} (Artifact)</span>
```

which results in wrong journal field `{The title of the paper} (Artifact)`.

To reproduce the problem, one can try to save the example in [this link](https://dl.acm.org/doi/10.1145/3763081).

# Fix

The bug is caused by the wrong specification of the class. The correct class is `span.serial-title`:

```html
<span class="serial-title">Proceedings of the ACM on Programming Languages</span>
```