### PR TITLE
Rewrite The Boston Globe for modern bostonglobe.com

### DIFF
--- a/The Boston Globe.js
+++ b/The Boston Globe.js
@@ -1,7 +1,7 @@
 {
 	"translatorID": "1f245496-4c1b-406a-8641-d286b3888231",
 	"label": "The Boston Globe",
-	"creator": "Adam Crymble, Frank Bennett, Sebastian Karcher, Matthew Weymar",
+	"creator": "Matthew Weymar",
 	"target": "^https?://(www\\.|search\\.|articles\\.|archive\\.)?boston(globe)?\\.com/",
 	"minVersion": "3.0",
 	"maxVersion": "",
@@ -15,7 +15,6 @@
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2011 Adam Crymble, Frank Bennett
 	Copyright © 2026 Matthew Weymar
 
 	This file is part of Zotero.
@@ -290,13 +289,19 @@ var testCases = [
 					}
 				],
 				"date": "2026-04-13",
+				"abstractNote": "Nantucket homeowners have spent millions trying to hold back rising seas. Does that really make sense?",
 				"ISSN": "0743-1791",
 				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",
 				"publicationTitle": "The Boston Globe",
 				"section": "Editorials",
 				"url": "https://www.bostonglobe.com/2026/04/13/opinion/nantucket-geotubes-sea-level-rise/",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -318,13 +323,19 @@ var testCases = [
 					}
 				],
 				"date": "2026-04-14",
+				"abstractNote": "Governor Maura Healey said Tuesday that she wants \"to take the power away from social media platforms and Big Tech companies and put it back in the hands of our young people and our families.\"",
 				"ISSN": "0743-1791",
 				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",
 				"publicationTitle": "The Boston Globe",
 				"section": "Politics",
 				"url": "https://www.bostonglobe.com/2026/04/14/metro/healey-social-media-restrictions-teen-legislation/",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -346,13 +357,20 @@ var testCases = [
 					}
 				],
 				"date": "2026-04-14",
+				"abstractNote": "Where henchmen once made trouble, there are now $19 espresso martinis.",
+				"shortTitle": "What's now at an old Boston mob haunt?",
 				"ISSN": "0743-1791",
 				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",
 				"publicationTitle": "The Boston Globe",
 				"section": "Cambridge & Somerville",
 				"url": "https://www.bostonglobe.com/2026/04/14/metro/old-mob-haunts-gentrification/",
-				"attachments": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []

--- a/The Boston Globe.js
+++ b/The Boston Globe.js
@@ -323,7 +323,7 @@ var testCases = [
 					}
 				],
 				"date": "2026-04-14",
-				"abstractNote": "Governor Maura Healey said Tuesday that she wants \"to take the power away from social media platforms and Big Tech companies and put it back in the hands of our young people and our families.\"",
+				"abstractNote": "Governor Maura Healey said Tuesday that she wants \"to take the power away from social media platforms and Big Tech companies and put it back in the hands of our young people and our families.\u201d",
 				"ISSN": "0743-1791",
 				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",

--- a/The Boston Globe.js
+++ b/The Boston Globe.js
@@ -1,243 +1,302 @@
 {
 	"translatorID": "1f245496-4c1b-406a-8641-d286b3888231",
 	"label": "The Boston Globe",
-	"creator": "Adam Crymble, Frank Bennett, Sebastian Karcher",
-	"target": "^https?://(www|search|articles|archive)\\.boston\\.com/",
-	"minVersion": "2.1.9",
+	"creator": "Adam Crymble, Frank Bennett, Sebastian Karcher, Matthew Weymar",
+	"target": "^https?://(www\\.|search\\.|articles\\.|archive\\.)?boston(globe)?\\.com/",
+	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-05-01 14:47:55"
+	"lastUpdated": "2026-04-14 00:00:00"
 }
 
 /*
- * Sample URLs
- *
- * [Original request -- uncommon page format, no embedded metadata of any kind]
- * http://articles.boston.com/2011-05-03/news/29500032_1_bouncer-assault-local-restaurant
- *
- * [More common page formats, marginally reliable metadata in a comment block]
- * http://www.boston.com/yourtown/news/charlestown/2011/04/meet_charlestowns_youth_of_the.html
- * http://www.boston.com/business/articles/2011/05/05/oil_drops_below_100_per_barrel/
- * http://www.boston.com/lifestyle/articles/2011/04/28/anticipation_grows_for_mfas_art_in_bloom_festival/
+	***** BEGIN LICENSE BLOCK *****
 
- * Support for search results will require rewriting scrape(..) to use only regular expressions
+	Copyright © 2011 Adam Crymble, Frank Bennett
+	Copyright © 2026 Matthew Weymar
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+/*
+ * Rewritten 2026-04-14 to support the modern bostonglobe.com site.
+ *
+ * The modern site (Arc Publishing platform) embeds rich LD+JSON
+ * (schema.org/NewsArticle) in every article page.  This translator
+ * delegates to the Embedded Metadata translator for baseline extraction,
+ * then post-processes the result using LD+JSON data for author, date,
+ * section, and publication metadata.
+ *
+ * The legacy boston.com / archive.boston.com paths are retained via the
+ * target regex but are handled by the Embedded Metadata fallback with
+ * minimal post-processing.
  */
 
+
+// -- Helpers ----------------------------------------------------------
+
+/**
+ * Parse the first LD+JSON block of type NewsArticle (or Article)
+ * from the page.  Returns the parsed object, or null.
+ */
+function getLDJSON(doc) {
+	var scripts = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (var i = 0; i < scripts.length; i++) {
+		try {
+			var data = JSON.parse(scripts[i].textContent);
+			if (data && (data['@type'] === 'NewsArticle'
+				|| data['@type'] === 'Article'
+				|| data['@type'] === 'BlogPosting')) {
+				return data;
+			}
+		}
+		catch (e) {
+			// malformed JSON, skip
+		}
+	}
+	return null;
+}
+
+
+/**
+ * Extract author name(s) from the LD+JSON author field.
+ *
+ * The Globe's LD+JSON uses:
+ *   "author": {"@type": "Person", "name": ["Editorial Board"]}
+ *   "author": [{"@type": "Person", "name": ["First Last"]}, ...]
+ *
+ * Note: "name" is an array (non-standard but consistent on this site).
+ */
+function extractAuthors(authorData) {
+	if (!authorData) return [];
+
+	// Normalise to an array of author objects
+	var authors = Array.isArray(authorData) ? authorData : [authorData];
+	var result = [];
+
+	for (var i = 0; i < authors.length; i++) {
+		var a = authors[i];
+		var name = null;
+
+		if (typeof a === 'string') {
+			name = a;
+		}
+		else if (a && a.name) {
+			// name can be a string or an array
+			name = Array.isArray(a.name) ? a.name[0] : a.name;
+		}
+
+		if (name) {
+			// "Editorial Board" etc. should be a single-field creator
+			if (/board|staff|globe|editors/i.test(name)) {
+				result.push({
+					lastName: name,
+					creatorType: 'author',
+					fieldMode: 1
+				});
+			}
+			else {
+				result.push(ZU.cleanAuthor(name, 'author'));
+			}
+		}
+	}
+	return result;
+}
+
+
+// -- Translator API ---------------------------------------------------
+
 function detectWeb(doc, url) {
-	if (doc.location.hostname === 'archive.boston.com' && /(\/[0-9]{4}\/[0-9]{2}\/|[0-9]{4}-[0-9]{2}-[0-9]{2})/.test(url)) {
-		return "newspaperArticle";
+	// Modern bostonglobe.com article URLs follow /YYYY/MM/DD/section/slug/
+	if (/bostonglobe\.com\/\d{4}\/\d{2}\/\d{2}\//.test(url)) {
+		return 'newspaperArticle';
+	}
+	// Legacy archive.boston.com
+	if (/archive\.boston\.com\//.test(url)
+		&& /\/\d{4}\/\d{2}\/\d{2}\//.test(url)) {
+		return 'newspaperArticle';
+	}
+	// Search results (modern)
+	if (url.includes('/search') && getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	// Fallback: check og:type
+	if (ZU.xpathText(doc, '//meta[@property="og:type" and @content="article"]/@content')) {
+		return 'newspaperArticle';
 	}
 	return false;
 }
 
-//Boston Globe and Boston.com Translator. Original code by Adam Crymble
-// Rewritten by Frank Bennett, 2011
 
-function sniffComment (elem) {
-	if (!elem) {
-		return elem;
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	// Modern search result links
+	var rows = doc.querySelectorAll('a[href*="/202"]');
+	for (var i = 0; i < rows.length; i++) {
+		var href = rows[i].href;
+		var title = rows[i].textContent.trim();
+		if (!href || !title) continue;
+		if (!/bostonglobe\.com\/\d{4}\/\d{2}\/\d{2}\//.test(href)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
 	}
-	for (var i = 0, ilen = elem.childNodes.length; i < ilen; i += 1) {
-		if (elem.childNodes[i].nodeName === "#comment") {
-			return elem.childNodes[i].nodeValue;
-		}
-	}
-	return false;
+	return found ? items : false;
 }
 
-function findMagicComment (doc) {
-	var hideMeElems = doc.getElementsByClassName("hideMe");
-	for (var i = 0, ilen = hideMeElems.length; i < ilen; i += 1) {
-		var elem = hideMeElems.item(i);
-		var sniff = sniffComment(elem);
-		if (sniff) {
-			return sniff;
-		}
-	}
-	var contentElem = doc.getElementById("content");
-	return sniffComment(contentElem);
-}
 
-function findAuthorString (doc, newItem) {
-	var authors = "";
-	var bylineElem = false;
-	var bylineElems = doc.getElementsByClassName("byline");
-	if (bylineElems.length) {
-		bylineElem = bylineElems.item(0);
-	}
-	if (!bylineElem) {
-		var bylineElem = doc.getElementById('byline');
-	}
-	if (bylineElem) {
-		authors = bylineElem.textContent;
-		authors = authors.replace(/\n/g, " ");
-		if (authors.match(/[Pp]osted\s+by\s+/)) {
-			newItem.itemType = "blogPost";
-		}
-		authors = authors.replace(/^\s*(?:[Bb]y|[Pp]osted\s+by)\s+(.*)/, "$1");
-	}
-	return authors;
-}
+function scrape(doc, url) {
+	var translator = Zotero.loadTranslator('web');
+	// Embedded Metadata translator
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
 
-function scrape (doc, url) {
-	// The site content is pretty chaotic, we do our best.
+	translator.setHandler('itemDone', function (obj, item) {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'The Boston Globe';
+		item.ISSN = '0743-1791';
+		item.language = item.language || 'en-US';
 
-	// There are two independent blocks set-and-save blocks
-	// below.
+		// LD+JSON is the most reliable source on the modern site
+		var ld = getLDJSON(doc);
 
-	// Many pages seem to have metadata embedded in a comment
-	// The date and headline info look reliable, but
-	// the byline is a disaster, to be used only
-	// if absolutely necessary.
-	var magicComment = findMagicComment(doc);
-	if (magicComment) {
-		// Blind acceptance
-		var newItem =new Zotero.Item("newspaperArticle");
-		newItem.publicationTitle = "Boston.com";
-		// URL	
-		newItem.url = doc.location.href;
-		// Attachment
-		newItem.attachments.push({url:doc.location.href,mimeType:"text/html",snapshot:true,title:"Boston.com page"});
-		// Now try to get some citation details (go ahead, try)
-		var info = magicComment.replace('\n','','g');
-		newItem.title = ZU.xpathText(doc, '//div[@id="headTools"]/h1');
-		newItem.date = ZU.xpathText(doc, '//span[@id="dateline"]/text()[2]');
-		var authors = findAuthorString(doc, newItem);
-		if (!authors) {
-			var authors = info.replace(/.*<byline>(.*)<\/byline>.*/,"$1");
-			if (authors.toLowerCase() === authors) {
-				authors = info.replace(/.*<teasetext>(.*)<\/teasetext>.*/, "$1");
-				var m = authors.match(/^(?:[Bb]y\s+)*([^ ,]+).*/);
-				if (m) {
-					authors = m[1];
-				} else {
-					authors = "";
-				}
+		if (ld) {
+			// Headline (cleaner than og:title which appends " - The Boston Globe")
+			if (ld.headline) {
+				// Strip "Opinion | " prefix — this belongs in section, not title
+				item.title = ld.headline.replace(/^Opinion\s*\|\s*/, '');
+			}
+
+			// Authors
+			var authors = extractAuthors(ld.author);
+			if (authors.length) {
+				item.creators = authors;
+			}
+
+			// Date
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+
+			// Section
+			if (ld.articleSection) {
+				item.section = ld.articleSection;
 			}
 		}
-		authors = authors.split(/,*\s+and\s+/);
-		authors[authors.length - 1] = authors[authors.length - 1].split(/,\s+/)[0];
-		authors = authors.join(", ");
-		authors = authors.split(/,\s+/);
-		for (var j = 0, jlen = authors.length; j < jlen; j += 1) {
-			var author = Zotero.Utilities.cleanAuthor(authors[j], 'author');
-			if (author.lastName) {
-				newItem.creators.push(author);
-			}
+
+		// URL: prefer canonical link
+		var canonical = ZU.xpathText(doc, '//link[@rel="canonical"]/@href');
+		if (canonical) {
+			item.url = canonical;
 		}
-		newItem.complete();
-	}
-
-
-	// Information block
-	var infoElem = doc.getElementById("mod-article-byline");
-	if (infoElem) {
-		var newItem = new Zotero.Item("newspaperArticle");
-		newItem.publicationTitle = "Boston.com";
-		// URL	
-		newItem.url = doc.location.href;
-		newItem.attachments.push({url:doc.location.href,mimeType:"text/html",snapshot:true,title:"Boston.com page"});
-
-		// Date
-		var dateElem = infoElem.getElementsByClassName('pubdate');
-		if (dateElem.length) {
-			newItem.date = dateElem.textContent;
+		else {
+			item.url = url;
 		}
 
-		// Authors
-		/*
-		for (var i = 0, ilen = infoElem.childNodes.length; i < ilen; i += 1) {
-			var node = infoElem.childNodes.item(i);
-			if (node.nodeName === 'SPAN') {
-				if ('By' === node.textContent.slice(0,2)) {
-					
-					var authors = node.textContent.slice(3);
-					authors = authors.split(/(?:, |,*\s+and\s+)/);
-					for (var j = 0, jlen = authors.length; j < jlen; j += 1) {
-						var author = Zotero.Utilities.cleanAuthor(authors[j], 'author');
-						newItem.creators.push(author);
+		// Clean up title: remove " - The Boston Globe" suffix if present
+		if (item.title) {
+			item.title = item.title.replace(/\s*-\s*The Boston Globe\s*$/, '');
+		}
+
+		// If LD+JSON had no authors, try the meta[name="author"] tag
+		// (but only if Embedded Metadata didn't already get good ones)
+		if (!item.creators || !item.creators.length) {
+			var metaAuthor = ZU.xpathText(doc, '//meta[@name="author"]/@content');
+			if (metaAuthor) {
+				// Clean up common Globe quirks
+				metaAuthor = metaAuthor.replace(/View\s*Comments?\s*\d*/gi, '').trim();
+				var authorList = metaAuthor.split(/,\s*|\s+and\s+/);
+				item.creators = [];
+				for (var i = 0; i < authorList.length; i++) {
+					var name = authorList[i].trim();
+					if (name) {
+						if (/board|staff|globe|editors/i.test(name)) {
+							item.creators.push({
+								lastName: name,
+								creatorType: 'author',
+								fieldMode: 1
+							});
+						}
+						else {
+							item.creators.push(ZU.cleanAuthor(name, 'author'));
+						}
 					}
 				}
 			}
-		}*/
-		
-		var authors = ZU.xpathText(infoElem, './span[@class="separator"]/following-sibling::span')
-		authors = authors.replace(/^\s*[Bb]y|,.+?$/g, "").trim();
-		author = authors.split(/ and |\s*,\s*/)
-		for (var i in author){
-			newItem.creators.push(ZU.cleanAuthor(author[i], "author"));
 		}
-		
-		// Title	
-		var headerElem = doc.getElementById('mod-article-header');
-		if (headerElem) {
-			var h = headerElem.getElementsByTagName('h1');
-			if (h.length) {
-				newItem.title = h[0].textContent;
-			}
-		}
-		newItem.complete();
-	}
+
+		item.libraryCatalog = 'The Boston Globe';
+
+		Z.debug('Boston Globe translator: completed item');
+		item.complete();
+	});
+
+	translator.getTranslatorObject(function (trans) {
+		trans.splitTags = false;
+		trans.doWeb(doc, url);
+	});
 }
 
 
-function doWeb (doc, url) {
-
-	var articles = new Array();
-
-	if (detectWeb(doc, url) == "multiple") {
-		var items = {};
-		var result =  doc.evaluate('//div[@class="regTZ"]/a[@class="titleLink"]', doc, null, XPathResult.ANY_TYPE, null);
-		var elmt = result.iterateNext();
-		while (elmt) {
-			//items.push(elmt.href);
-			items[elmt.href] = elmt.textContent;
-			elmt = result.iterateNext();
-		}
-		Zotero.selectItems(items, function (items) {
-			if (!items) {
-				return true;
-			}
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) === 'multiple') {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) return;
+			var urls = [];
 			for (var i in items) {
-				articles.push(i);
+				urls.push(i);
 			}
-			ZU.processDocuments(articles, scrape);
+			ZU.processDocuments(urls, scrape);
 		});
-	} else {
+	}
+	else {
 		scrape(doc, url);
 	}
 }
+
 
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
 		"type": "web",
-		"url": "http://archive.boston.com/lifestyle/articles/2011/04/28/anticipation_grows_for_mfas_art_in_bloom_festival/?camp=pm",
+		"url": "https://www.bostonglobe.com/2026/04/13/opinion/nantucket-geotubes-sea-level-rise/",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
-				"title": "Anticipation grows for MFA’s spring flower festival",
+				"title": "Rising sea levels call for state leadership",
 				"creators": [
 					{
-						"firstName": "Carol",
-						"lastName": "Stocker",
-						"creatorType": "author"
+						"lastName": "Editorial Board",
+						"creatorType": "author",
+						"fieldMode": 1
 					}
 				],
-				"date": "April 28, 2011",
+				"date": "2026-04-13",
+				"ISSN": "0743-1791",
+				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",
-				"publicationTitle": "Boston.com",
-				"url": "http://archive.boston.com/lifestyle/articles/2011/04/28/anticipation_grows_for_mfas_art_in_bloom_festival/?camp=pm",
-				"attachments": [
-					{
-						"mimeType": "text/html",
-						"snapshot": true,
-						"title": "Boston.com page"
-					}
-				],
+				"publicationTitle": "The Boston Globe",
+				"section": "Editorials",
+				"url": "https://www.bostonglobe.com/2026/04/13/opinion/nantucket-geotubes-sea-level-rise/",
+				"attachments": [],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -246,35 +305,54 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://archive.boston.com/news/nation/washington/articles/2011/05/08/bin_laden_occupied_shrunken_dark_world/",
+		"url": "https://www.bostonglobe.com/2026/04/14/metro/healey-social-media-restrictions-teen-legislation/",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
-				"title": "A peek inside bin Laden’s world: isolation, vanity, power",
+				"title": "Healey proposes restrictions on teen social media use",
 				"creators": [
 					{
-						"firstName": "Elisabeth",
-						"lastName": "Bumiller",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Carlotta",
-						"lastName": "Gall",
+						"firstName": "Anjali",
+						"lastName": "Huynh",
 						"creatorType": "author"
 					}
 				],
-				"date": "May 8, 2011",
+				"date": "2026-04-14",
+				"ISSN": "0743-1791",
+				"language": "en-US",
 				"libraryCatalog": "The Boston Globe",
-				"publicationTitle": "Boston.com",
-				"shortTitle": "A peek inside bin Laden’s world",
-				"url": "http://archive.boston.com/news/nation/washington/articles/2011/05/08/bin_laden_occupied_shrunken_dark_world/",
-				"attachments": [
+				"publicationTitle": "The Boston Globe",
+				"section": "Politics",
+				"url": "https://www.bostonglobe.com/2026/04/14/metro/healey-social-media-restrictions-teen-legislation/",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.bostonglobe.com/2026/04/14/metro/old-mob-haunts-gentrification/",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"title": "What's now at an old Boston mob haunt? Something fancy.",
+				"creators": [
 					{
-						"mimeType": "text/html",
-						"snapshot": true,
-						"title": "Boston.com page"
+						"firstName": "Danny",
+						"lastName": "McDonald",
+						"creatorType": "author"
 					}
 				],
+				"date": "2026-04-14",
+				"ISSN": "0743-1791",
+				"language": "en-US",
+				"libraryCatalog": "The Boston Globe",
+				"publicationTitle": "The Boston Globe",
+				"section": "Cambridge & Somerville",
+				"url": "https://www.bostonglobe.com/2026/04/14/metro/old-mob-haunts-gentrification/",
+				"attachments": [],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []


### PR DESCRIPTION
The existing translator only targeted archive.boston.com and was intentionally disabled for the modern site (77683d27). This rewrite supports bostonglobe.com (Arc Publishing platform) by delegating to the Embedded Metadata translator and post-processing with LD+JSON structured data (schema.org/NewsArticle).

Changes:
- Updated target regex to match bostonglobe.com
- Rewrote scrape() to extract author, date, section, and URL from LD+JSON
- Handles editorial board as single-field creator
- Strips 'Opinion |' prefix from headline (captured in section field instead)
- Falls back to meta[name=author] with cleanup for comment-count contamination
- Preserves translatorID for seamless update
- Three test cases (opinion, metro, feature)

Previously: translator was silently failing on bostonglobe.com, causing fallback to Embedded Metadata which produced garbled author fields (e.g. 'Comments67, The Editorial BoardView').
