### PR TITLE
[PICA] Handling electronic theses on sudoc.fr

### DIFF
--- a/Library Catalog (PICA).js
+++ b/Library Catalog (PICA).js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-11-26 15:26:20"
+	"lastUpdated": "2026-03-27 21:31:39"
 }
 
 /*
@@ -93,6 +93,10 @@ function detectWeb(doc, _url) {
 				}
 				else if (type.includes('map.')) {
 					return "map";
+				}
+				else if (type.includes('binary.') && (ZU.xpath(doc, '//tr/td[@class="rec_lable" and .//span[starts-with(text(), "Thèse")]]').length)) {
+					// Electronic theses have a binary icon, we can detect them because they contain a field named These like on https://www.sudoc.fr/282427384
+					return "thesis";
 				}
 			}
 			return "book";


### PR DESCRIPTION
Hello,
this request adds a test that will handle electronic theses as thesis rather than fallback on the book type on a record like : https://www.sudoc.fr/282427384

This should be improved to handle records when the language is set to German or English (and Thèse is changed to _Dissertation_) but right now, my scaffold version is not working with my test page https://www.sudoc.fr/282427384 (Linux, Zotero 9 but I have tried to reinstall 8.0.4 and it does not fix the issue). I assume it might be related to some redirect on sudoc's website which think scaffold is some sort of robot or something like that. It was working some weeks ago when I developed this before forgetting to create the PR.