### PR TITLE
fix(arXiv): omit empty category brackets from Extra field

### DIFF
--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 12,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-05-11 18:35:08"
+	"lastUpdated": "2026-05-19 15:28:10"
 }
 
 /*

--- a/arXiv.org.js
+++ b/arXiv.org.js
@@ -404,8 +404,11 @@ function parseSingleEntry(entry) {
 	if (articleID && articleID.includes("/")) {
 		newItem.extra = "arXiv:" + articleID;
 	}
-	else {
+	else if (articleField) {
 		newItem.extra = "arXiv:" + articleID + " " + articleField;
+	}
+	else {
+		newItem.extra = "arXiv:" + articleID;
 	}
 
 	let pdfURL = versionedArXivURL.replace("/abs/", "/pdf/");


### PR DESCRIPTION
When the arXiv API doesn't return a primary_category (articleField is empty), the Extra field was being set to 'arXiv:XXXX []' — the empty brackets were still included. The fix adds a conditional so the space and category brackets are only added when articleField has an actual value.