### PR TITLE
InvenioRDM: Add CDS to target

### DIFF
--- a/InvenioRDM.js
+++ b/InvenioRDM.js
@@ -2,14 +2,14 @@
 	"translatorID": "a714cb93-6595-482f-b371-a4ca0be14449",
 	"label": "InvenioRDM",
 	"creator": "Philipp Zumstein, Sebastian Karcher and contributors",
-	"target": "^https?://(zenodo\\.org|repository\\.cern|data\\.caltech\\.edu|repository\\.tugraz\\.at|researchdata\\.tuwien\\.at|ultraviolet\\.library\\.nyu\\.edu|adc\\.ei-basel\\.hasdai\\.org|fdat\\.uni-tuebingen\\.de|www\\.fdr\\.uni-hamburg\\.de|rodare\\.hzdr\\.de|aperta\\.ulakbim.gov\\.tr|www\\.openaccessrepository\\.it|eic-zenodo\\.sdcc\\.bnl\\.gov)",
+	"target": "^https?://(zenodo\\.org|sandbox\\.zenodo\\.org|repository\\.cern|data\\.caltech\\.edu|repository\\.tugraz\\.at|researchdata\\.tuwien\\.at|ultraviolet\\.library\\.nyu\\.edu|adc\\.ei-basel\\.hasdai\\.org|fdat\\.uni-tuebingen\\.de|www\\.fdr\\.uni-hamburg\\.de|rodare\\.hzdr\\.de|aperta\\.ulakbim.gov\\.tr|www\\.openaccessrepository\\.it|eic-zenodo\\.sdcc\\.bnl\\.gov)",
 	"minVersion": "6.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-09-18 15:10:52"
+	"lastUpdated": "2026-05-19 15:16:47"
 }
 
 /*

--- a/InvenioRDM.js
+++ b/InvenioRDM.js
@@ -1182,7 +1182,6 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "https://aperta.ulakbim.gov.tr/record/252039",
-		"detectedItemType": "dataset",
 		"items": [
 			{
 				"itemType": "dataset",
@@ -1245,6 +1244,51 @@ var testCases = [
 		"url": "https://zenodo.org/communities/oat23/records?q=&l=list&p=1&s=10&sort=newest",
 		"defer": true,
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://repository.cern/records/yskdj-44858",
+		"items": [
+			{
+				"itemType": "thesis",
+				"title": "Design study of a low-energy extension of the H8 beam-line at the CERN Super Proton Synchrotron",
+				"creators": [
+					{
+						"lastName": "Turner",
+						"firstName": "M",
+						"creatorType": "author"
+					},
+					{
+						"lastName": "Turner",
+						"firstName": "M",
+						"creatorType": "author"
+					}
+				],
+				"date": "2014-05-15",
+				"abstractNote": "Design study of a new low-energy beam in the H8 beam-line of CERN SPS to\nprovide 1 to 9 GeV/c electrons, pion and muons. Two layout congurations\nare considered. Layout 1 brings the beam back to the central line after the\nparticle selection. In layout 2 the beam at the experiment is o-axis. Studies\nof particle rates with optimized magnet settings and optics studies for beam\ntransmission and focusing to experiment were performed. Fluka simulations\nof all beam-line options were made to estimate the spot-sizes, the particle\nrates and the backgrounds at the experiments. The results showed that the\nbackground is signicantly lower in layout 2.",
+				"language": "eng",
+				"libraryCatalog": "InvenioRDM",
+				"place": "Graz",
+				"university": "Graz, Tech. U.",
+				"url": "https://repository.cern/records/yskdj-44858",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Detectors and Experimental Techniques"
+					},
+					{
+						"tag": "collection:AIDA"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/

--- a/InvenioRDM.js
+++ b/InvenioRDM.js
@@ -2,7 +2,7 @@
 	"translatorID": "a714cb93-6595-482f-b371-a4ca0be14449",
 	"label": "InvenioRDM",
 	"creator": "Philipp Zumstein, Sebastian Karcher and contributors",
-	"target": "^https?://(zenodo\\.org|sandbox\\.zenodo\\.org|data\\.caltech\\.edu|repository\\.tugraz\\.at|researchdata\\.tuwien\\.at|ultraviolet\\.library\\.nyu\\.edu|adc\\.ei-basel\\.hasdai\\.org|fdat\\.uni-tuebingen\\.de|www\\.fdr\\.uni-hamburg\\.de|rodare\\.hzdr\\.de|aperta\\.ulakbim.gov\\.tr|www\\.openaccessrepository\\.it|eic-zenodo\\.sdcc\\.bnl\\.gov)",
+	"target": "^https?://(zenodo\\.org|repository\\.cern|data\\.caltech\\.edu|repository\\.tugraz\\.at|researchdata\\.tuwien\\.at|ultraviolet\\.library\\.nyu\\.edu|adc\\.ei-basel\\.hasdai\\.org|fdat\\.uni-tuebingen\\.de|www\\.fdr\\.uni-hamburg\\.de|rodare\\.hzdr\\.de|aperta\\.ulakbim.gov\\.tr|www\\.openaccessrepository\\.it|eic-zenodo\\.sdcc\\.bnl\\.gov)",
 	"minVersion": "6.0",
 	"maxVersion": "",
 	"priority": 100,


### PR DESCRIPTION
- the new CERN Document Server is InvenioRDM based (repository.cern)
- the Zenodo Sandbox environment should not be used to cite articles on wikipedia (if there is another use case for still including it, happy to add it back) as it is used only for testing purposes