### PR TITLE
Remove format=json from Anne Frank API requests

### DIFF
--- a/Anne Frank Knowledge Base.js
+++ b/Anne Frank Knowledge Base.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-06-01 15:40:31"
+	"lastUpdated": "2026-06-05 12:00:00"
 }
 
 /*
@@ -128,17 +128,13 @@ function parseAnneFrankURL(url) {
 }
 
 function buildAPIURL(lang, endpoint, uuid) {
-	var apiURL = "https://research.annefrank.org/" + lang + "/api/" + endpoint;
-	if (uuid) {
-		apiURL += "/" + uuid;
-	}
-	return apiURL + "?format=json";
+	return "https://research.annefrank.org/" + lang + "/api/" + endpoint + "/" + uuid;
 }
 
 function buildSearchAPIURL(lang, query) {
-	var apiURL = "https://research.annefrank.org/" + lang + "/api/search?format=json";
+	var apiURL = "https://research.annefrank.org/" + lang + "/api/search";
 	if (query) {
-		apiURL += "&q=" + encodeURIComponent(query);
+		apiURL += "?q=" + encodeURIComponent(query);
 	}
 	return apiURL;
 }
@@ -159,7 +155,7 @@ function translateRecord(type, data, lang, doc) {
 	var item = new Zotero.Item("encyclopediaArticle");
 	item.title = getItemTitle(type, data, lang);
 	item.abstractNote = getLocalized(data, "summary", lang);
-	item.url = data.url || "";
+	item.url = getCanonicalURL(type, data, lang);
 	item.encyclopediaTitle = getPublicationTitle(lang);
 	item.publisher = getPublisher(lang);
 	item.place = "Amsterdam";
@@ -212,6 +208,29 @@ function getDisplayTitle(type, data, lang) {
 
 function getLocalized(data, base, lang) {
 	return data[base + "_" + lang] || data[base] || data[base + "_en"] || data[base + "_nl"] || "";
+}
+
+function getCanonicalURL(type, data, lang) {
+	var slug = typeToSlug(type);
+	if (data.uuid && slug) {
+		return "https://research.annefrank.org/" + lang + "/" + slug + "/" + data.uuid + "/";
+	}
+	return data.url || "";
+}
+
+function typeToSlug(type) {
+	switch (type) {
+		case "person":
+			return "personen";
+		case "event":
+		case "aw_event":
+			return "gebeurtenissen";
+		case "location":
+			return "locaties";
+		case "subject":
+			return "onderwerpen";
+	}
+	return "";
 }
 
 function getPublicationTitle(lang) {


### PR DESCRIPTION
I figured out what was going wrong with the API requests: for individual subjects, locations, events, and people, the data can be retrieved directly from the API by using the identifier in the URL. Passing that identifier as a search query triggers a redirect, which appears to be blocked in some Zotero configurations, notably Citoid. I’ve submitted this follow-up patch to request the direct API URLs instead.