### PR TITLE
YouTube: Extract collaborators as authors

### DIFF
--- a/YouTube.js
+++ b/YouTube.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-06-04 21:14:01"
+	"lastUpdated": "2026-06-05 16:06:50"
 }
 
 /*
@@ -372,7 +372,7 @@ var testCases = [
 				"date": "2007-01-01",
 				"abstractNote": "Zotero is a free, easy-to-use research tool that helps you gather and organize resources (whether bibliography or the full text of articles), and then lets you to annotate, organize, and share the results of your research. It includes the best parts of older reference manager software (like EndNote)—the ability to store full reference information in author, title, and publication fields and to export that as formatted references—and the best parts of modern software such as del.icio.us or iTunes, like the ability to sort, tag, and search in advanced ways. Using its unique ability to sense when you are viewing a book, article, or other resource on the web, Zotero will—on many major research sites—find and automatically save the full reference information for you in the correct fields.",
 				"libraryCatalog": "YouTube",
-				"runningTime": "2:51",
+				"runningTime": "02:53",
 				"url": "https://www.youtube.com/watch?v=pq94aBrc0pY",
 				"attachments": [],
 				"tags": [],
@@ -402,6 +402,7 @@ var testCases = [
 					}
 				],
 				"date": "2026-06-01",
+				"abstractNote": "An interview with Marc LeBlanc on the pioneering entity system work done at Looking Glass for Thief: The Dark Project.\n\nAccompanying article: https://computerenhance.com\nMahk's YouTube:    / @algorithmancytube  \nMahk's Twitch:   / videos  \nMahk's game design website: https://8kindsoffun.com",
 				"libraryCatalog": "YouTube",
 				"runningTime": "2:32:34",
 				"url": "https://www.youtube.com/watch?v=73Do0OScoOU",

--- a/YouTube.js
+++ b/YouTube.js
@@ -9,14 +9,14 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-06-04 16:14:22"
+	"lastUpdated": "2026-06-04 21:14:01"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
 	Copyright © 2015-2024 Sean Takats, Michael Berkowitz, Matt Burton, Rintze Zelle, and Geoff Banh
-	
+
 	This file is part of Zotero.
 
 	Zotero is free software: you can redistribute it and/or modify
@@ -70,9 +70,9 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-function doWeb(doc, url) {
+async function doWeb(doc, url) {
 	if (detectWeb(doc, url) != 'multiple') {
-		scrape(doc, url);
+		await scrape(doc, url);
 	}
 	else {
 		Zotero.selectItems(getSearchResults(doc), function (items) {
@@ -82,7 +82,11 @@ function doWeb(doc, url) {
 			for (var i in items) {
 				ids.push(i);
 			}
-			ZU.processDocuments(ids, scrape);
+			ZU.processDocuments(ids, function (doc) {
+				scrape(doc, doc.location.href).catch(function (e) {
+					Zotero.debug('YouTube: scrape failed: ' + e);
+				});
+			});
 		});
 	}
 }
@@ -94,6 +98,13 @@ function getMetaContent(doc, attrName, value) {
 function videoIdFromURL(url) {
 	var m = url.match(/[?&]v=([0-9a-zA-Z_-]+)/);
 	return m ? m[1] : null;
+}
+
+// Build the canonical watch URL from the video ID so URLs with the v=
+// parameter in any position (e.g. ?list=...&v=ID) normalise the same way.
+function canonicalWatchURL(url) {
+	var videoId = videoIdFromURL(url);
+	return videoId ? 'https://www.youtube.com/watch?v=' + videoId : url;
 }
 
 // Depth-first walk over a parsed JSON tree. `visit` returns true to stop;
@@ -207,26 +218,49 @@ function extractYtInitialData(raw) {
 	}
 }
 
-// Extract channel names for collaborator videos from ytInitialData.
-// Returns [] when the page has a single owner (DOM selectors handle that),
-// when the data describes a different video (SPA navigation preserves the
-// original payload — DOM fallback covers it), or when the data is missing.
-function extractCreatorNames(doc, videoId) {
-	if (!videoId) return [];
+// Returns null if no usable ytInitialData is present in this doc
+// (script absent or all candidates failed to parse) — refetching the
+// same URL won't help, so the caller should fall straight back to DOM.
+// Returns { stale: true } when a ytInitialData was found but describes
+// a different video; refetching the canonical URL may yield fresh data.
+// Returns { names: string[] } when fresh data parsed cleanly (names may
+// be empty for single-owner videos).
+function namesFromDoc(doc, expectedVideoId) {
 	for (var script of doc.querySelectorAll('script:not([src])')) {
 		var raw = script.textContent;
 		var data = extractYtInitialData(raw);
 		if (!data) continue;
-		if (dataVideoId(data) !== videoId) {
+		if (dataVideoId(data) !== expectedVideoId) {
 			Zotero.debug('YouTube: ytInitialData describes a different video (SPA stale)');
-			return [];
+			return { stale: true };
 		}
-		return channelNamesFromData(data);
+		return { names: channelNamesFromData(data) };
 	}
-	return [];
+	return null;
 }
 
-function scrape(doc, url) {
+async function extractCreatorNames(doc, url) {
+	var videoId = videoIdFromURL(url);
+	if (!videoId) return [];
+
+	var result = namesFromDoc(doc, videoId);
+	if (!result) return [];
+	if (!result.stale) return result.names;
+
+	try {
+		var fresh = await requestDocument(canonicalWatchURL(url));
+		var refetched = namesFromDoc(fresh, videoId);
+		if (refetched && !refetched.stale) return refetched.names;
+		Zotero.debug('YouTube: refetch did not yield matching ytInitialData');
+		return [];
+	}
+	catch (e) {
+		Zotero.debug('YouTube: refetch for ytInitialData failed: ' + e);
+		return [];
+	}
+}
+
+async function scrape(doc, url) {
 	var item = new Zotero.Item("videoRecording");
 	if (!Zotero.isServer) {
 		let jsonLD;
@@ -245,8 +279,7 @@ function scrape(doc, url) {
 		item.title = text(doc, '#info-contents h1.title') // Desktop
 			|| text(doc, '#title')
 			|| text(doc, '.slim-video-information-title'); // Mobile
-		// try to scrape only the canonical url, excluding additional query parameters
-		item.url = url.replace(/^(.+\/watch\?v=[0-9a-zA-Z_-]+).*/, "$1").replace('m.youtube.com', 'www.youtube.com');
+		item.url = canonicalWatchURL(url);
 		item.runningTime = text(doc, '#movie_player .ytp-time-duration') // Desktop
 			|| text(doc, '.ytm-time-display .time-second'); // Mobile after unmute
 		if (!item.runningTime && jsonLD.duration) { // Mobile before unmute
@@ -267,7 +300,7 @@ function scrape(doc, url) {
 			|| attr(doc, 'ytm-factoid-renderer:last-child > div', 'aria-label') // Mobile if description has been opened
 		) || jsonLD.uploadDate; // Mobile on initial page load
 
-		var creatorNames = extractCreatorNames(doc, videoIdFromURL(url));
+		var creatorNames = await extractCreatorNames(doc, url);
 		if (creatorNames.length) {
 			for (var name of creatorNames) {
 				item.creators.push({ lastName: name, creatorType: "author", fieldMode: 1 });

--- a/YouTube.js
+++ b/YouTube.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-06-12 16:10:09"
+	"lastUpdated": "2026-06-04 16:14:22"
 }
 
 /*
@@ -91,6 +91,141 @@ function getMetaContent(doc, attrName, value) {
 	return attr(doc, 'meta[' + attrName + '="' + value + '"]', 'content');
 }
 
+function videoIdFromURL(url) {
+	var m = url.match(/[?&]v=([0-9a-zA-Z_-]+)/);
+	return m ? m[1] : null;
+}
+
+// Depth-first walk over a parsed JSON tree. `visit` returns true to stop;
+// walkJson then unwinds and returns true. JSON.parse already guarantees the
+// tree is acyclic and bounded, so no depth cap is needed.
+function walkJson(node, visit) {
+	if (!node || typeof node !== 'object') return false;
+	if (visit(node)) return true;
+	if (Array.isArray(node)) {
+		for (var item of node) if (walkJson(item, visit)) return true;
+	}
+	else {
+		for (var key of Object.keys(node)) if (walkJson(node[key], visit)) return true;
+	}
+	return false;
+}
+
+// The videoId the ytInitialData payload describes. Read directly from the
+// root `currentVideoEndpoint` rather than walking the tree: that key also
+// appears under recommendation tiles and overlay menus, so a DFS would
+// match whichever one comes first in object-key order.
+function dataVideoId(data) {
+	return (data
+		&& data.currentVideoEndpoint
+		&& data.currentVideoEndpoint.watchEndpoint
+		&& data.currentVideoEndpoint.watchEndpoint.videoId) || null;
+}
+
+// Channel names for the watched video (uploader first, then collaborators).
+// Scoped to videoSecondaryInfoRenderer because sidebar recommendations live
+// under videoCardRenderer, which has an identically-shaped owner.
+//
+// Collaborator names live in a dialogViewModel whose customContent.
+// listViewModel holds one listItem per channel. Each listItem also carries
+// a trailingButtons subtree with a nested subscribe-options sheet ("All",
+// "Personalised", "None", "Unsubscribe"), so we iterate listItems directly
+// rather than walking the dialog subtree — otherwise the menu options get
+// scraped as collaborators.
+//
+// Returns [] for single-owner pages (no dialog) and for pages whose
+// ytInitialData lacks the expected anchor entirely.
+function channelNamesFromData(data) {
+	var vor = null;
+	walkJson(data, function (node) {
+		if (node.videoSecondaryInfoRenderer) {
+			vor = node.videoSecondaryInfoRenderer.owner
+				&& node.videoSecondaryInfoRenderer.owner.videoOwnerRenderer;
+			return true;
+		}
+		return false;
+	});
+	if (!vor) {
+		Zotero.debug('YouTube: no videoSecondaryInfoRenderer.owner.videoOwnerRenderer');
+		return [];
+	}
+
+	var names = [];
+	walkJson(vor, function (node) {
+		var items = node.dialogViewModel
+			&& node.dialogViewModel.customContent
+			&& node.dialogViewModel.customContent.listViewModel
+			&& node.dialogViewModel.customContent.listViewModel.listItems;
+		if (!Array.isArray(items)) return false;
+		for (var item of items) {
+			var name = item.listItemViewModel
+				&& item.listItemViewModel.title
+				&& item.listItemViewModel.title.content;
+			if (name) names.push(name);
+		}
+		return true;
+	});
+	return names;
+}
+
+// Parse `var ytInitialData = {...}` out of a script blob. Returns null on
+// any failure (missing marker, unbalanced braces, JSON parse error) and
+// logs the cause, so the caller can treat ytInitialData as a single signal.
+function extractYtInitialData(raw) {
+	if (!raw) return null;
+	var marker = raw.indexOf('var ytInitialData = {');
+	if (marker === -1) return null;
+	var start = raw.indexOf('{', marker);
+
+	// The script appends statements after the object literal, so JSON.parse
+	// can't be fed the whole blob. Walk to the matching closing brace, tracking
+	// string boundaries so { or } inside string values don't miscount depth.
+	var depth = 0, end = start, inString = false;
+	while (end < raw.length) {
+		var ch = raw[end];
+		if (inString) {
+			if (ch === '\\') end++;
+			else if (ch === '"') inString = false;
+		}
+		else if (ch === '"') inString = true;
+		else if (ch === '{') depth++;
+		else if (ch === '}') {
+			if (--depth === 0) break;
+		}
+		end++;
+	}
+	if (depth !== 0) {
+		Zotero.debug('YouTube: ytInitialData braces unbalanced');
+		return null;
+	}
+	try {
+		return JSON.parse(raw.substring(start, end + 1));
+	}
+	catch (e) {
+		Zotero.debug('YouTube: ytInitialData parse failed: ' + e);
+		return null;
+	}
+}
+
+// Extract channel names for collaborator videos from ytInitialData.
+// Returns [] when the page has a single owner (DOM selectors handle that),
+// when the data describes a different video (SPA navigation preserves the
+// original payload — DOM fallback covers it), or when the data is missing.
+function extractCreatorNames(doc, videoId) {
+	if (!videoId) return [];
+	for (var script of doc.querySelectorAll('script:not([src])')) {
+		var raw = script.textContent;
+		var data = extractYtInitialData(raw);
+		if (!data) continue;
+		if (dataVideoId(data) !== videoId) {
+			Zotero.debug('YouTube: ytInitialData describes a different video (SPA stale)');
+			return [];
+		}
+		return channelNamesFromData(data);
+	}
+	return [];
+}
+
 function scrape(doc, url) {
 	var item = new Zotero.Item("videoRecording");
 	if (!Zotero.isServer) {
@@ -132,15 +267,23 @@ function scrape(doc, url) {
 			|| attr(doc, 'ytm-factoid-renderer:last-child > div', 'aria-label') // Mobile if description has been opened
 		) || jsonLD.uploadDate; // Mobile on initial page load
 
-		var author = text(doc, '#meta-contents #text-container .ytd-channel-name') // Desktop
-			|| text(doc, '#upload-info #text-container .ytd-channel-name')
-			|| text(doc, '.slim-owner-channel-name'); // Mobile
-		if (author) {
-			item.creators.push({
-				lastName: author,
-				creatorType: "author",
-				fieldMode: 1
-			});
+		var creatorNames = extractCreatorNames(doc, videoIdFromURL(url));
+		if (creatorNames.length) {
+			for (var name of creatorNames) {
+				item.creators.push({ lastName: name, creatorType: "author", fieldMode: 1 });
+			}
+		}
+		else {
+			var author = text(doc, '#meta-contents #text-container .ytd-channel-name') // Desktop
+				|| text(doc, '#upload-info #text-container .ytd-channel-name')
+				|| text(doc, '.slim-owner-channel-name'); // Mobile
+			if (author) {
+				item.creators.push({
+					lastName: author,
+					creatorType: "author",
+					fieldMode: 1
+				});
+			}
 		}
 		var description = text(doc, '#description .content')
 			|| text(doc, '#description')
@@ -198,6 +341,37 @@ var testCases = [
 				"libraryCatalog": "YouTube",
 				"runningTime": "2:51",
 				"url": "https://www.youtube.com/watch?v=pq94aBrc0pY",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.youtube.com/watch?v=73Do0OScoOU",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "videoRecording",
+				"title": "The First Entity Component System - An Interview with Marc LeBlanc",
+				"creators": [
+					{
+						"lastName": "Molly Rocket",
+						"creatorType": "author",
+						"fieldMode": 1
+					},
+					{
+						"lastName": "Marc \"MAHK\" LeBlanc",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2026-06-01",
+				"libraryCatalog": "YouTube",
+				"runningTime": "2:32:34",
+				"url": "https://www.youtube.com/watch?v=73Do0OScoOU",
 				"attachments": [],
 				"tags": [],
 				"notes": [],


### PR DESCRIPTION
Saving a YouTube video with multiple channel collaborators to Zotero currently captures zero creators. The translator picks the channel name from one of three CSS selectors, and on a collaborator video YouTube renders the owner area as a single composite anchor reading e.g. `CreatorA and ChannelB` with `href="javascript:void(0);"` and no per-channel link. None of the selectors match that layout, so `author` ends up empty and nothing gets pushed to the item.

To recover the individual names, the creator block now reads `ytInitialData`, the JSON blob YouTube embeds in the initial HTML to bootstrap its own client. Its `videoOwnerRenderer` node lists collaborators explicitly when present, so we no longer depend on the rendered owner area for this case. Single-owner videos still fall through to the existing selector chain, since those keep working and the chain handles layouts I haven't surveyed.

YouTube preserves the original page's inline `ytInitialData` script across SPA navigations, so on a same-tab transition the JSON describes whichever video was loaded first. The workaround detects the mismatch by checking that the current `videoId` appears in the parsed data, and refetches the canonical watch URL via `requestDocument()` when it doesn't.

A new test case covers `73Do0OScoOU` (two collaborators); the existing `pq94aBrc0pY` case continues to pass with `Zoteron` as the sole author, so the single-channel path is unaffected.