### PR TITLE
Cambridge Core: Don't prefix abstracts of articles with a graphical abstract

### DIFF
--- a/Cambridge Core.js
+++ b/Cambridge Core.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-11-20 15:43:05"
+	"lastUpdated": "2026-08-05 17:31:25"
 }
 
 /*
@@ -146,10 +146,15 @@ async function scrape(doc, url = doc.location.href) {
 		
 		translator.setHandler('itemDone', (_obj, item) => {
 			item.url = url;
-			var abstract = ZU.xpathText(doc,
-				'//div[@class="abstract"]');
-			if (abstract) {
-				item.abstractNote = abstract;
+			// Articles with a graphical abstract have TWO div.abstract nodes:
+			// the first holds only the figure and has no text. xpathText()
+			// joined both with its default ", " delimiter, so those abstracts
+			// began with a stray comma. Use the first node that has text.
+			for (let node of doc.querySelectorAll('div.abstract')) {
+				if (node.textContent.trim()) {
+					item.abstractNote = ZU.trimInternal(node.textContent);
+					break;
+				}
 			}
 			item.title = ZU.unescapeHTML(item.title);
 			item.publisher = ""; // don't grab the publisher
@@ -573,6 +578,87 @@ var testCases = [
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/impact-of-droplets-onto-surfactantladen-thin-liquid-films/03C213289D24A7074987081D659E1DB3",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"creators": [
+					{
+						"firstName": "C. R.",
+						"lastName": "Constante-Amores",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "L.",
+						"lastName": "Kahouadji",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "S.",
+						"lastName": "Shin",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "J.",
+						"lastName": "Chergui",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "D.",
+						"lastName": "Juric",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "J. R.",
+						"lastName": "Castrejón-Pita",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "O. K.",
+						"lastName": "Matar",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "A. A.",
+						"lastName": "Castrejón-Pita",
+						"creatorType": "author"
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "capillary flows"
+					},
+					{
+						"tag": "drops"
+					},
+					{
+						"tag": "multiphase flow"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"title": "Impact of droplets onto surfactant-laden thin liquid films",
+				"DOI": "10.1017/jfm.2023.224",
+				"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/impact-of-droplets-onto-surfactantladen-thin-liquid-films/03C213289D24A7074987081D659E1DB3",
+				"abstractNote": "We study the effect of insoluble surfactants on the impact of surfactant-free droplets onto surfactant-laden thin liquid films via a fully three-dimensional direct numerical simulation approach that employs a hybrid interface-tracking/level-set method, and by taking into account surfactant-induced Marangoni stresses due to gradients in interfacial surfactant concentration. Our numerical predictions for the temporal evolution of the surfactant-free crown are validated against the experimental work by Che & Matar (Langmuir, vol. 33, 2017, pp. 12140–12148). We focus on the ‘crown-splash regime’, and we observe that the crown dynamics evolves through various stages: from the growth of linear modes (through a Rayleigh–Plateau instability) to the development of nonlinearities leading to primary and secondary breakup events (through droplet shedding modulated by an end-pinching mechanism). We show that the addition of surfactants does not affect the wave selection via the Rayleigh–Plateau instability. However, the presence of surfactants plays a key role in the late stages of the dynamics as soon as the ligaments are driven out from the rim. Surfactant-induced Marangoni stresses delay the end-pinching mechanisms to result in longer ligaments prior to their capillary singularity. Our results indicate that Marangoni stresses bridge the gap between adjacent protrusions promoting the adjacent protrusions' collision and the merging of ligaments. Finally, we demonstrate that the addition of surfactants leads to surface rigidification and consequently to the retardation of the flow dynamics.",
+				"date": "2023/04",
+				"publicationTitle": "Journal of Fluid Mechanics",
+				"volume": "961",
+				"pages": "A8",
+				"ISSN": "0022-1120, 1469-7645",
+				"language": "en",
+				"libraryCatalog": "Cambridge University Press"
 			}
 		]
 	}

--- a/Cambridge Core.js
+++ b/Cambridge Core.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-08-05 18:02:48"
+	"lastUpdated": "2026-08-05 17:31:25"
 }
 
 /*
@@ -208,7 +208,7 @@ var testCases = [
 				"pages": "227-243",
 				"publicationTitle": "Journal of American Studies",
 				"shortTitle": "“SAMO© as an Escape Clause”",
-				"url": "https://www.cambridge.org/core/journals/journal-of-american-studies/article/samo-as-an-escape-clause-jean-michel-basquiats-engagement-with-a-commodified-american-africanism/1E4368D610A957B84F6DA3A58B8BF164",
+				"url": "https://www.cambridge.org/core/journals/journal-of-american-studies/article/abs/samo-as-an-escape-clause-jean-michel-basquiats-engagement-with-a-commodified-american-africanism/1E4368D610A957B84F6DA3A58B8BF164",
 				"volume": "45",
 				"attachments": [
 					{
@@ -254,7 +254,7 @@ var testCases = [
 				"libraryCatalog": "Cambridge University Press",
 				"pages": "437-469",
 				"publicationTitle": "Journal of Fluid Mechanics",
-				"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/high-resolution-simulations-of-cylindrical-density-currents/30D62864BDED84A6CC81F5823950767B",
+				"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/abs/high-resolution-simulations-of-cylindrical-density-currents/30D62864BDED84A6CC81F5823950767B",
 				"volume": "590",
 				"attachments": [
 					{
@@ -476,7 +476,7 @@ var testCases = [
 				"pages": "340-347",
 				"publicationTitle": "American Political Science Review",
 				"shortTitle": "Violence in Pre-Modern Societies",
-				"url": "https://www.cambridge.org/core/journals/american-political-science-review/article/violence-in-premodern-societies-rural-colombia/A14B0BB4130A2BA6BE79E2853597526E",
+				"url": "https://www.cambridge.org/core/journals/american-political-science-review/article/abs/violence-in-premodern-societies-rural-colombia/A14B0BB4130A2BA6BE79E2853597526E",
 				"volume": "60",
 				"attachments": [
 					{
@@ -514,7 +514,7 @@ var testCases = [
 				"pages": "449-470",
 				"publicationTitle": "Journal of Public Policy",
 				"shortTitle": "When Consumers Oppose Consumer Protection",
-				"url": "https://www.cambridge.org/core/journals/journal-of-public-policy/article/when-consumers-oppose-consumer-protection-the-politics-of-regulatory-backlash/2C8E6B9BB6881A233B8936D9AD2C6305",
+				"url": "https://www.cambridge.org/core/journals/journal-of-public-policy/article/abs/when-consumers-oppose-consumer-protection-the-politics-of-regulatory-backlash/2C8E6B9BB6881A233B8936D9AD2C6305",
 				"volume": "10",
 				"attachments": [
 					{

--- a/Cambridge Core.js
+++ b/Cambridge Core.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-08-05 17:31:25"
+	"lastUpdated": "2026-08-05 18:02:48"
 }
 
 /*
@@ -208,7 +208,7 @@ var testCases = [
 				"pages": "227-243",
 				"publicationTitle": "Journal of American Studies",
 				"shortTitle": "“SAMO© as an Escape Clause”",
-				"url": "https://www.cambridge.org/core/journals/journal-of-american-studies/article/abs/samo-as-an-escape-clause-jean-michel-basquiats-engagement-with-a-commodified-american-africanism/1E4368D610A957B84F6DA3A58B8BF164",
+				"url": "https://www.cambridge.org/core/journals/journal-of-american-studies/article/samo-as-an-escape-clause-jean-michel-basquiats-engagement-with-a-commodified-american-africanism/1E4368D610A957B84F6DA3A58B8BF164",
 				"volume": "45",
 				"attachments": [
 					{
@@ -254,7 +254,7 @@ var testCases = [
 				"libraryCatalog": "Cambridge University Press",
 				"pages": "437-469",
 				"publicationTitle": "Journal of Fluid Mechanics",
-				"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/abs/high-resolution-simulations-of-cylindrical-density-currents/30D62864BDED84A6CC81F5823950767B",
+				"url": "https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/high-resolution-simulations-of-cylindrical-density-currents/30D62864BDED84A6CC81F5823950767B",
 				"volume": "590",
 				"attachments": [
 					{
@@ -476,7 +476,7 @@ var testCases = [
 				"pages": "340-347",
 				"publicationTitle": "American Political Science Review",
 				"shortTitle": "Violence in Pre-Modern Societies",
-				"url": "https://www.cambridge.org/core/journals/american-political-science-review/article/abs/violence-in-premodern-societies-rural-colombia/A14B0BB4130A2BA6BE79E2853597526E",
+				"url": "https://www.cambridge.org/core/journals/american-political-science-review/article/violence-in-premodern-societies-rural-colombia/A14B0BB4130A2BA6BE79E2853597526E",
 				"volume": "60",
 				"attachments": [
 					{
@@ -514,7 +514,7 @@ var testCases = [
 				"pages": "449-470",
 				"publicationTitle": "Journal of Public Policy",
 				"shortTitle": "When Consumers Oppose Consumer Protection",
-				"url": "https://www.cambridge.org/core/journals/journal-of-public-policy/article/abs/when-consumers-oppose-consumer-protection-the-politics-of-regulatory-backlash/2C8E6B9BB6881A233B8936D9AD2C6305",
+				"url": "https://www.cambridge.org/core/journals/journal-of-public-policy/article/when-consumers-oppose-consumer-protection-the-politics-of-regulatory-backlash/2C8E6B9BB6881A233B8936D9AD2C6305",
 				"volume": "10",
 				"attachments": [
 					{

--- a/Cambridge Core.js
+++ b/Cambridge Core.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-08-05 17:31:25"
+	"lastUpdated": "2026-08-06 17:19:45"
 }
 
 /*
@@ -146,10 +146,8 @@ async function scrape(doc, url = doc.location.href) {
 		
 		translator.setHandler('itemDone', (_obj, item) => {
 			item.url = url;
-			// Articles with a graphical abstract have TWO div.abstract nodes:
-			// the first holds only the figure and has no text. xpathText()
-			// joined both with its default ", " delimiter, so those abstracts
-			// began with a stray comma. Use the first node that has text.
+			// There may be more than one .abstract element if the paper
+			// has a graphical abstract, so use the first one with text
 			for (let node of doc.querySelectorAll('div.abstract')) {
 				if (node.textContent.trim()) {
 					item.abstractNote = ZU.trimInternal(node.textContent);


### PR DESCRIPTION
Abstracts of Cambridge Core articles that have a **graphical abstract** are saved with a stray `, ` in front:

> `, We study the effect of insoluble surfactants on the impact of...`

Such articles have **two** `div.abstract` nodes — the first holds only the figure and has no text. `ZU.xpathText()` joins all matched nodes with its default `", "` delimiter, so the empty first node contributed the separator. This affects a lot of Journal of Fluid Mechanics articles; 188 of the 1367 JFM items in my own library are affected.

The fix takes the first `div.abstract` that actually has text. It deliberately does not pass `delimiter: ''` to `xpathText()`, which would silently concatenate genuinely multi-node abstracts instead.

The text now also goes through `ZU.trimInternal()`. `xpathText()` does no trimming, so abstracts could pick up a trailing space as well — e.g. the abstract of [Micro-bubble morphologies following drop impacts onto a pool surface](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/microbubble-morphologies-following-drop-impacts-onto-a-pool-surface/ED77B4E99987ED9B17A3CAD627492504) is saved 869 characters long, one trailing space more than its text. All seven existing test cases with abstracts are already `trimInternal`-identical, so nothing there changes.

### Verification

The new test case (`10.1017/jfm.2023.224`) **fails on master's code and passes with this change** — I ran the harness on master's code with the new test case added to confirm the guard actually catches the bug. No other case changes state:

| run (local, subscribed network) | failing cases |
|---|---|
| master, as-is (12 cases) | 1, 2, 5, 6, 9, 10, 12 |
| master's code + new test case | 1, 2, 5, 6, 9, 10, 12, **13** |
| this branch (13 cases) | 1, 2, 5, 6, 9, 10, 12 |

Case 13 is the only one whose state changes. Cases 1, 2, 9 and 10 fail locally for an
unrelated, environment-dependent reason described below; on CI they pass, so this branch's
CI shows only 5, 6 and 12 — the same three as master.

### A note on four other cases

I initially also refreshed the `url` of cases 1, 2, 9 and 10, having seen them fail locally: Cambridge redirects `/article/abs/<slug>/<id>` to `/article/<slug>/<id>`, so the saved url didn't match. That was wrong and I've reverted it — the redirect only happens for readers **with access** to the article, so an institutional network gets the canonical form while CI gets the `/abs/` form the test cases already record. The existing URLs are correct; those four only fail on a subscribed network.

### Left alone: the three book/bookSection cases

Cases 5, 6 and 12 fail on master too, for a reason unrelated to this PR, and I'd rather flag it than record it as expected output.

Cambridge's RIS export now emits the DOI with the value itself prefixed:

```
DO  - DOI: 10.1017/9781108770750
```

The connector's bundled schema (version 28) doesn't allow `DOI` on `book` or `bookSection`, so the value is dropped instead of falling back to `Extra` — which is where these test cases expect it (`"extra": "DOI: 10.1017/9781108638210"`). A current desktop client keeps it as a proper `DOI` field (I checked: it imports as `10.1017/9781108770750` either way, so `cleanDOI` copes with the prefix), so saved items are unaffected.

So this looks like a test-environment artifact rather than a user-facing regression, and refreshing those fixtures would bake "no DOI" into the repo. Happy to include a fix if you'd prefer one here — stripping the prefix in this translator would be a one-liner — but it seemed better not to guess at how you'd want the schema pinning handled.
