### PR TITLE
Add translators for Vietnamese news sites

### DIFF
--- a/Bao Chinh Phu.js
+++ b/Bao Chinh Phu.js
@@ -1,0 +1,188 @@
+{
+	"translatorID": "dd6a9009-cfd0-430f-90b3-61db962a1c4b",
+	"label": "Bao Chinh Phu",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?baochinhphu\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:28"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/\d{10,}\.htm/i.test(url)
+			|| attr(doc, 'meta[property="article:published_time"]', 'content')) {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*=".htm"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 20) continue;
+		if (!/baochinhphu\.vn\/.+\.htm/i.test(href)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Báo Điện tử Chính phủ';
+		item.language = 'vi';
+
+		// Prefer h1 / og:title over HTML-entity-encoded JSON-LD headline
+		let title = text(doc, 'h1')
+			|| attr(doc, 'meta[property="og:title"]', 'content');
+		if (title) {
+			item.title = title;
+		}
+
+		let ld = getJSONLD(doc);
+		let published = (ld && ld.datePublished)
+			|| attr(doc, 'meta[property="article:published_time"]', 'content');
+		if (published) {
+			item.date = ZU.strToISO(published);
+		}
+
+		item.creators = [];
+		let authorName = null;
+		if (ld && ld.author && ld.author.name
+				&& !/^baochinhphu\.vn$/i.test(ld.author.name)) {
+			authorName = ld.author.name;
+		}
+		if (authorName) {
+			item.creators.push({
+				lastName: authorName,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+
+		if (item.abstractNote) {
+			item.abstractNote = item.abstractNote.replace(/^\(Chinhphu\.vn\)\s*-\s*/i, '');
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://baochinhphu.vn/pho-thu-tuong-nguyen-van-thang-xu-ly-den-cung-cac-vuong-mac-khong-day-doanh-nghiep-di-vong-10226080815310734.htm",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "Ban biên tập",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Phó Thủ tướng Nguyễn Văn Thắng: Xử lý đến cùng các vướng mắc, không đẩy doanh nghiệp đi vòng",
+				"publicationTitle": "Báo Điện tử Chính phủ",
+				"date": "2026-08-08",
+				"url": "https://baochinhphu.vn/pho-thu-tuong-nguyen-van-thang-xu-ly-den-cung-cac-vuong-mac-khong-day-doanh-nghiep-di-vong-10226080815310734.htm",
+				"abstractNote": "Hôm nay, 8/8, tại trụ sở Chính phủ, Phó Thủ tướng Nguyễn Văn Thắng đã có buổi làm việc với các bộ, ngành, địa phương và doanh nghiệp để giải quyết khó khăn, vướng mắc trong lĩnh vực thuế và hải quan.",
+				"language": "vi",
+				"libraryCatalog": "baochinhphu.vn",
+				"shortTitle": "Phó Thủ tướng Nguyễn Văn Thắng"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Cong an Nhan dan.js
+++ b/Cong an Nhan dan.js
@@ -1,0 +1,212 @@
+{
+	"translatorID": "a4de917b-ac4b-4251-9fc0-b3e1b153b232",
+	"label": "Cong an Nhan dan",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?cand\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:31"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/post\d+\.html/i.test(url)
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="post"][href$=".html"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 10) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Công an Nhân dân';
+		item.language = 'vi';
+
+		let ld = getJSONLD(doc);
+		if (ld) {
+			if (ld.headline) {
+				item.title = ld.headline;
+			}
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+			if (ld.description) {
+				item.abstractNote = ld.description;
+			}
+			if (ld.author && ld.author['@type'] === 'Person' && ld.author.name) {
+				item.creators = [{
+					lastName: ld.author.name,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+		else {
+			let published = attr(doc, 'meta[property="article:published_time"]', 'content');
+			if (published) {
+				item.date = ZU.strToISO(published);
+			}
+			let author = text(doc, '.article__author');
+			if (author) {
+				item.creators = [{
+					lastName: author,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+
+		item.creators = item.creators.filter(
+			c => !/Công an Nhân dân/i.test(c.lastName)
+		);
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://cand.vn/canh-sat-kinh-te-phai-chu-dong-phong-ngua-rui-ro-tu-som-tu-xa-post818972.html",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "Khổng Hà",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Cảnh sát kinh tế"
+					},
+					{
+						"tag": "an ninh kinh tế"
+					},
+					{
+						"tag": "bảo vệ tài sản"
+					},
+					{
+						"tag": "phòng ngừa"
+					},
+					{
+						"tag": "tội phạm kinh tế"
+					},
+					{
+						"tag": "đấu tranh chống tham nhũng"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Cảnh sát kinh tế phải chủ động phòng ngừa rủi ro từ sớm, từ xa",
+				"publicationTitle": "Công an Nhân dân",
+				"section": "Lãnh đạo Bộ Công an,Tin hoạt động,Công an trong lòng dân,Thời sự,Bộ trưởng Bộ Công an",
+				"date": "2026-08-08",
+				"url": "https://cand.vn/canh-sat-kinh-te-phai-chu-dong-phong-ngua-rui-ro-tu-som-tu-xa-post818972.html",
+				"abstractNote": "Chủ tịch Quốc hội Trần Thanh Mẫn đề nghị lực lượng Cảnh sát kinh tế chuyển mạnh từ tư duy phát hiện, xử lý vụ việc là chủ yếu sang kết hợp chặt chẽ giữa phòng ngừa, phát hiện, xử lý và tham mưu hoàn thiện thể chế; từ giải quyết hậu quả sang chủ động nhận diện, ngăn ngừa rủi ro từ sớm, từ xa; từ tư duy quản lý sang phục vụ, kiến tạo và hỗ trợ phát triển.",
+				"language": "vi",
+				"libraryCatalog": "cand.vn"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Dai Bieu Nhan Dan.js
+++ b/Dai Bieu Nhan Dan.js
@@ -1,0 +1,200 @@
+{
+	"translatorID": "6ad14dfd-19a2-4891-a460-7b10a8571e30",
+	"label": "Dai Bieu Nhan Dan",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?daibieunhandan\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:29"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/\d{7,}\.html/i.test(url)
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*=".html"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 20) continue;
+		if (!/daibieunhandan\.vn\/.+\d{7,}\.html/i.test(href)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+function personName(author) {
+	if (!author) return null;
+	if (Array.isArray(author)) {
+		author = author[0];
+	}
+	return author.name || null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Đại biểu Nhân dân';
+		item.language = 'vi';
+
+		let ld = getJSONLD(doc);
+		if (ld) {
+			if (ld.headline) {
+				item.title = ld.headline;
+			}
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+			if (ld.description) {
+				item.abstractNote = ld.description;
+			}
+		}
+
+		if (!item.date) {
+			let published = attr(doc, 'meta[property="article:published_time"]', 'content');
+			if (published) {
+				item.date = ZU.strToISO(published);
+			}
+		}
+
+		item.creators = [];
+		let authorName = personName(ld && ld.author)
+			|| attr(doc, 'meta[property="article:author"]', 'content')
+			|| text(doc, '.block-sc-author, .sc-longform-header-author');
+		if (authorName && authorName !== 'Báo Đại biểu Nhân dân') {
+			item.creators.push({
+				lastName: authorName,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://daibieunhandan.vn/xay-dung-khu-vuc-phong-thu-cap-xa-phuong-vung-manh-toan-dien-10426675.html",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "Thanh Hải",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Khu vực phòng thủ"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Xây dựng khu vực phòng thủ cấp xã, phường vững mạnh toàn diện",
+				"publicationTitle": "Đại biểu Nhân dân",
+				"section": "Thời sự Quốc hội",
+				"date": "2026-08-08",
+				"url": "https://daibieunhandan.vn/xay-dung-khu-vuc-phong-thu-cap-xa-phuong-vung-manh-toan-dien-10426675.html",
+				"abstractNote": "Sáng 8/8, dưới sự chủ trì của Chủ tịch Quốc hội Trần Thanh Mẫn và điều hành của Phó Chủ tịch Quốc hội, Thượng tướng Nguyễn Doãn Anh, Quốc hội làm việc tại Hội trường, thảo luận về dự án Luật sửa đổi, bổ sung một số điều của 9 luật về quân sự, quốc phòng.",
+				"language": "vi",
+				"libraryCatalog": "daibieunhandan.vn"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Dang Cong San.js
+++ b/Dang Cong San.js
@@ -1,0 +1,198 @@
+{
+	"translatorID": "e750b12f-2d54-47a9-9671-5d0b4ed8c798",
+	"label": "Dang Cong San",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?dangcongsan\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:27"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/\.html(?:\?|$)/.test(url)
+			&& (attr(doc, 'meta[property="og:type"]', 'content') === 'article'
+				|| doc.querySelector('h1'))) {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*=".html"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 20) continue;
+		if (!/dangcongsan\.vn\/.+\.html/i.test(href)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Đảng Cộng sản Việt Nam';
+		item.language = 'vi';
+
+		// og:title is often truncated with "..."
+		let h1 = text(doc, 'h1');
+		if (h1) {
+			item.title = h1;
+		}
+		else if (item.title) {
+			item.title = item.title.replace(/\s*\.\.\.\s*$/, '');
+		}
+
+		let published = attr(doc, 'meta[property="article:published_time"]', 'content');
+		if (published) {
+			item.date = ZU.strToISO(published);
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+		else {
+			item.url = url.replace(/\?.*$/, '');
+		}
+
+		// Prefer a real byline over generic staff initials / site name
+		item.creators = [];
+		let byline = text(doc, '.author');
+		let dcCreator = attr(doc, 'meta[name="DC.Creator"]', 'content');
+		let authorName = null;
+		if (byline && !/^(PV|BTV|ĐCSVN)$/i.test(byline)) {
+			authorName = byline;
+		}
+		else if (dcCreator
+				&& dcCreator !== 'Cổng thông tin điện tử Đảng Cộng sản Việt Nam'
+				&& !/^(PV|BTV)$/i.test(dcCreator)) {
+			authorName = dcCreator;
+		}
+		if (authorName) {
+			item.creators.push({
+				lastName: authorName,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+
+		if (item.abstractNote) {
+			item.abstractNote = item.abstractNote.replace(/^\(ĐCSVN\)\s*-\s*/, '');
+		}
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://dangcongsan.vn/tin-hoat-dong/dua-khuon-kho-quan-he-doi-tac-chien-luoc-toan-dien-viet-nam-australia-di-vao-chieu-sau-thuc-chat-hieu-qua.html?categoryId=1902448,1902446",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "Lan Anh",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Tin tức"
+					},
+					{
+						"tag": "Vấn đề quan tâm"
+					},
+					{
+						"tag": "hiệu quả"
+					},
+					{
+						"tag": "thực chất"
+					},
+					{
+						"tag": "Đưa khuôn khổ quan hệ Đối tác Chiến lược Toàn diện Việt Nam - Australia đi vào chiều sâu"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Đưa khuôn khổ quan hệ Đối tác Chiến lược Toàn diện Việt Nam - Australia đi vào chiều sâu, thực chất, hiệu quả",
+				"publicationTitle": "Đảng Cộng sản Việt Nam",
+				"section": "Vấn đề quan tâm, Tin tức",
+				"date": "2026-08-07",
+				"url": "https://dangcongsan.vn/tin-hoat-dong/dua-khuon-kho-quan-he-doi-tac-chien-luoc-toan-dien-viet-nam-australia-di-vao-chieu-sau-thuc-chat-hieu-qua.html",
+				"abstractNote": "Nhận lời mời của Toàn quyền Australia Sam Mostyn, Tổng Bí thư Ban Chấp hành Trung ương Đảng Cộng sản Việt Nam, Chủ tịch nước Cộng hòa xã hội chủ nghĩa Việt Nam Tô Lâm cùng Đoàn đại biểu cấp cao Việt Nam sẽ thăm cấp Nhà nước tới Australia.",
+				"language": "vi",
+				"libraryCatalog": "dangcongsan.vn"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Nhan Dan.js
+++ b/Nhan Dan.js
@@ -1,0 +1,208 @@
+{
+	"translatorID": "682264c8-1028-4a73-9a27-dc9a25722aa1",
+	"label": "Nhan Dan",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?nhandan\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:26"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/post\d+\.html/i.test(url)
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="post"][href$=".html"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 10) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Nhân Dân';
+		item.language = 'vi';
+
+		let ld = getJSONLD(doc);
+		if (ld) {
+			if (ld.headline) {
+				item.title = ld.headline;
+			}
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+			if (ld.description) {
+				item.abstractNote = ld.description;
+			}
+			if (ld.author && ld.author['@type'] === 'Person' && ld.author.name) {
+				item.creators = [{
+					lastName: ld.author.name,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+		else {
+			let published = attr(doc, 'meta[property="article:published_time"]', 'content');
+			if (published) {
+				item.date = ZU.strToISO(published);
+			}
+			let author = text(doc, '.article__author');
+			if (author) {
+				item.creators = [{
+					lastName: author,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+
+		// Site meta author is the newspaper name
+		item.creators = item.creators.filter(c => c.lastName !== 'Báo Nhân Dân điện tử');
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://nhandan.vn/xung-dang-la-thanh-bao-kiem-sac-ben-trong-dau-tranh-phong-chong-toi-pham-post980623.html",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "VĂN CHÚC",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Bảo vệ Tổ quốc"
+					},
+					{
+						"tag": "Chủ tịch Quốc hội"
+					},
+					{
+						"tag": "Cảnh sát kinh tế"
+					},
+					{
+						"tag": "Huân chương Hồ Chí Minh"
+					},
+					{
+						"tag": "Lễ kỷ niệm"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Xứng đáng là “thanh bảo kiếm sắc bén” trong đấu tranh phòng, chống tội phạm",
+				"publicationTitle": "Nhân Dân",
+				"section": "Chính trị,Truyền thống vẻ vang",
+				"date": "2026-08-08",
+				"url": "https://nhandan.vn/xung-dang-la-thanh-bao-kiem-sac-ben-trong-dau-tranh-phong-chong-toi-pham-post980623.html",
+				"abstractNote": "Sáng 8/8, tại Nhà hát Hồ Gươm, Hà Nội, Chủ tịch Quốc hội Trần Thanh Mẫn đến dự Lễ kỷ niệm 70 năm Ngày truyền thống lực lượng Cảnh sát kinh tế (10/8/1956-10/8/2026) và đón nhận Huân chương Hồ Chí Minh.",
+				"language": "vi",
+				"libraryCatalog": "nhandan.vn"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/Quan doi Nhan dan.js
+++ b/Quan doi Nhan dan.js
@@ -1,0 +1,198 @@
+{
+	"translatorID": "ccfddc8a-bb67-44a3-9f05-7cb4e43c0763",
+	"label": "Quan doi Nhan dan",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?qdnd\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:30"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/\/\d{6,}(?:\/|$|\?)/.test(url)
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="qdnd.vn/"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 20) continue;
+		if (!/qdnd\.vn\/.+\/\d{6,}/i.test(href)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'Quân đội nhân dân';
+		item.language = 'vi';
+
+		// og:title is often truncated; h1 is complete
+		let h1 = text(doc, 'h1');
+		if (h1) {
+			item.title = h1;
+		}
+
+		let ld = getJSONLD(doc);
+		if (ld && ld.datePublished) {
+			item.date = ZU.strToISO(ld.datePublished);
+		}
+
+		item.creators = [];
+		// Prefer DOM byline; JSON-LD author may append an office address
+		let author = text(doc, '.author-top, .author');
+		if (!author && ld && ld.author && ld.author.name) {
+			author = ld.author.name.split(/\s+-\s+/)[0].trim();
+		}
+		// Skip photo/graphics credits mistaken for bylines
+		if (author && !/^(Đồ họa|Ảnh|Video|Nguồn|Minh họa)\s*:/i.test(author)) {
+			item.creators.push({
+				lastName: author,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+
+		// Use non-truncated canonical path from the page URL
+		item.url = url.split('?')[0];
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.qdnd.vn/chinh-tri/tin-tuc/dai-tuong-phan-van-giang-tiep-thu-y-kien-dai-bieu-quoc-hoi-ve-du-an-luat-phong-chong-pho-bien-vu-khi-huy-diet-hang-loat-1052548",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "VŨ DUNG",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Kỳ họp không thường lệ"
+					},
+					{
+						"tag": "Quốc hội"
+					},
+					{
+						"tag": "Vũ khí"
+					},
+					{
+						"tag": "hàng loạt"
+					},
+					{
+						"tag": "hủy diệt"
+					},
+					{
+						"tag": "Đại tướng Phan Văn Giang"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Đại tướng Phan Văn Giang tiếp thu ý kiến đại biểu Quốc hội về dự án Luật Phòng, chống phổ biến vũ khí hủy diệt hàng loạt",
+				"publicationTitle": "Quân đội nhân dân",
+				"url": "https://www.qdnd.vn/chinh-tri/tin-tuc/dai-tuong-phan-van-giang-tiep-thu-y-kien-dai-bieu-quoc-hoi-ve-du-an-luat-phong-chong-pho-bien-vu-khi-huy-diet-hang-loat-1052548",
+				"abstractNote": "Đại tướng Phan Văn Giang tiếp thu ý kiến đại biểu Quốc hội về dự án Luật Phòng, chống phổ biến vũ khí hủy diệt hàng loạt",
+				"language": "vi",
+				"libraryCatalog": "www.qdnd.vn",
+				"date": "2026-08-08"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/VietnamPlus.js
+++ b/VietnamPlus.js
@@ -1,0 +1,204 @@
+{
+	"translatorID": "291158d5-151e-48de-911e-8d231489671c",
+	"label": "VietnamPlus",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?vietnamplus\\.vn/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 10:50:28"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/post\d+\.vnp/i.test(url)
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="post"][href$=".vnp"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || title.length < 10) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'VietnamPlus';
+		item.language = 'vi';
+
+		let ld = getJSONLD(doc);
+		if (ld) {
+			if (ld.headline) {
+				item.title = ld.headline;
+			}
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+			if (ld.description) {
+				item.abstractNote = ld.description;
+			}
+			if (ld.author && ld.author['@type'] === 'Person' && ld.author.name) {
+				item.creators = [{
+					lastName: ld.author.name,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+		else {
+			let published = attr(doc, 'meta[property="article:published_time"]', 'content');
+			if (published) {
+				item.date = ZU.strToISO(published);
+			}
+			let author = text(doc, '.article__author');
+			if (author) {
+				item.creators = [{
+					lastName: author,
+					creatorType: 'author',
+					fieldMode: 1
+				}];
+			}
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl.split('#')[0];
+		}
+		else {
+			item.url = url.split('#')[0];
+		}
+
+		item.creators = item.creators.filter(c => !/Vietnam\+/i.test(c.lastName));
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.vietnamplus.vn/giai-quyet-kho-khan-vuong-mac-trong-linh-vuc-thue-va-hai-quan-post1128969.vnp",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [
+					{
+						"lastName": "Tuân-Tùng",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Thủ tục hải quan"
+					},
+					{
+						"tag": "doanh nghiệp siêu nhỏ"
+					},
+					{
+						"tag": "hộ kinh doanh"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Giải quyết khó khăn, vướng mắc trong lĩnh vực thuế và hải quan",
+				"publicationTitle": "VietnamPlus",
+				"section": "Kinh tế",
+				"date": "2026-08-08",
+				"url": "https://www.vietnamplus.vn/giai-quyet-kho-khan-vuong-mac-trong-linh-vuc-thue-va-hai-quan-post1128969.vnp",
+				"abstractNote": "Ngày 8/8, tại trụ sở Chính phủ, Phó Thủ tướng Nguyễn Văn Thắng đã có buổi làm việc với các bộ, ngành, địa phương và doanh nghiệp để giải quyết khó khăn, vướng mắc trong lĩnh vực thuế và hải quan.",
+				"language": "vi",
+				"libraryCatalog": "www.vietnamplus.vn"
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/VnExpress.js
+++ b/VnExpress.js
@@ -1,0 +1,187 @@
+{
+	"translatorID": "6df3da29-3f6e-42d4-b99c-1ca1bc3709bb",
+	"label": "VnExpress",
+	"creator": "letrinhandn",
+	"target": "^https?://(www\\.)?vnexpress\\.net/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-08 11:09:57"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 letrinhandn
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (/\/\d{6,}\.html/.test(url)
+			|| attr(doc, 'meta[name="tt_page_type"]', 'content') === 'article'
+			|| attr(doc, 'meta[property="og:type"]', 'content') === 'article') {
+		return 'newspaperArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('h3.title-news a[href*=".html"], h2.title-news a[href*=".html"], .title-news a[href*=".html"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title || href.includes('#')) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getJSONLD(doc) {
+	let nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (let node of nodes) {
+		try {
+			let data = JSON.parse(node.textContent);
+			if (Array.isArray(data)) {
+				data = data.find(d => d['@type'] === 'NewsArticle') || data[0];
+			}
+			if (data && data['@type'] === 'NewsArticle') {
+				return data;
+			}
+		}
+		catch (e) {}
+	}
+	return null;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.itemType = 'newspaperArticle';
+		item.publicationTitle = 'VnExpress';
+		item.language = 'vi';
+
+		let ld = getJSONLD(doc);
+		if (ld) {
+			if (ld.headline) {
+				item.title = ld.headline;
+			}
+			if (ld.datePublished) {
+				item.date = ZU.strToISO(ld.datePublished);
+			}
+			if (ld.description) {
+				item.abstractNote = ld.description;
+			}
+			// Organization byline is the site name, not a person
+			if (ld.author && ld.author['@type'] === 'Organization') {
+				item.creators = [];
+			}
+		}
+		else {
+			item.title = item.title.replace(/\s*-\s*Báo VnExpress\s*$/i, '');
+			let pubdate = attr(doc, 'meta[name="pubdate"]', 'content')
+				|| attr(doc, 'meta[itemprop="datePublished"]', 'content');
+			if (pubdate) {
+				item.date = ZU.strToISO(pubdate);
+			}
+		}
+
+		let ogUrl = attr(doc, 'meta[property="og:url"]', 'content');
+		if (ogUrl) {
+			item.url = ogUrl;
+		}
+
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	em.itemType = 'newspaperArticle';
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://vnexpress.net/ha-noi-xem-xet-gia-han-thu-tuc-6-du-an-lon-5106755.html",
+		"items": [
+			{
+				"itemType": "newspaperArticle",
+				"creators": [],
+				"notes": [],
+				"tags": [
+					{
+						"tag": "Hà Nội"
+					},
+					{
+						"tag": "Nghị quyết 258 của Quốc hội"
+					},
+					{
+						"tag": "Tin nóng"
+					},
+					{
+						"tag": "đại dự án ở Hà Nội"
+					}
+				],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"title": "Hà Nội xem xét gia hạn thủ tục 6 dự án lớn",
+				"publicationTitle": "VnExpress",
+				"url": "https://vnexpress.net/ha-noi-xem-xet-gia-han-thu-tuc-6-du-an-lon-5106755.html",
+				"abstractNote": "Hà Nội- Sáu dự án đã khởi công nhưng chưa hoàn tất quy hoạch, hồ sơ đầu tư hoặc giải phóng mặt bằng, được đề xuất thêm 6 tháng để đáp ứng đủ điều kiện.",
+				"language": "vi",
+				"libraryCatalog": "vnexpress.net",
+				"date": "2026-08-08"
+			}
+		]
+	}
+]
+/** END TEST CASES **/


### PR DESCRIPTION
## Summary

Adds web translators for eight Vietnamese news sites (`newspaperArticle`), using Embedded Metadata with site-specific cleanup.

| Translator | Domain | CI tests |
|---|---|---|
| `VnExpress.js` | vnexpress.net | 1 article |
| `Nhan Dan.js` | nhandan.vn | 1 article |
| `Dang Cong San.js` | dangcongsan.vn | 1 article |
| `VietnamPlus.js` | vietnamplus.vn | 1 article |
| `Bao Chinh Phu.js` | baochinhphu.vn | 1 article |
| `Dai Bieu Nhan Dan.js` | daibieunhandan.vn | 1 article |
| `Quan doi Nhan dan.js` | qdnd.vn | 1 article |
| `Cong an Nhan dan.js` | cand.com.vn | 1 article |

## Notes for reviewers

- Vietnamese personal bylines use `fieldMode: 1`.
- Common cleanup: strip site/org as author, truncated titles, abstract prefixes, tracking query/`#` fragments.
- **Tạp chí Cộng sản** omitted from this PR: the site returns HTTP 403 to headless Chromium in GitHub Actions, and empty `testCases` make the PR harness report “tests did not run”. Planned as a follow-up (local `--headed` verification).
- Creator: `letrinhandn`.

## Test plan

- [x] `npm run lint` on all eight translators
- [x] Local headless suite
- [ ] Confirm CI `Lint, Check, Test` is green