### PR TITLE
New translator: Conceptio — Open Knowledge Archive (conceptio.app)

### DIFF
--- a/Conceptio.js
+++ b/Conceptio.js
@@ -161,7 +161,10 @@ function _itemFromJSONLD(doc, url) {
 				var part = parts[p].trim();
 				if (!part) continue;
 				if (part.includes(",")) {
-					item.creators.push(ZU.cleanAuthor(part, "author"));
+					// useComma=true: APA parts are "Last, First" — without the flag
+					// Zotero applies its "last space = last name" heuristic and
+					// inverts them ("Rose, Scott" -> first "Rose", last "Scott").
+					item.creators.push(ZU.cleanAuthor(part, "author", true));
 				}
 				else {
 					item.creators.push({ name: part, creatorType: "author" });

--- a/Conceptio.js
+++ b/Conceptio.js
@@ -1,0 +1,251 @@
+{
+	"translatorID": "9b482dac-6398-4bf5-aadb-7f47732f981b",
+	"label": "Conceptio",
+	"creator": "Conceptio",
+	"target": "^https?://(www\\.)?(conceptio\\.app|conceptio\\.com)/document/\\d+",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-09-01 00:00:00"
+}
+
+/*
+	Conceptio — Open Knowledge Archive (https://www.conceptio.app)
+
+	Server-rendered document pages (/document/{id}/{slug}) carry a full
+	JSON-LD block (schema.org: ScholarlyArticle / Book / TechArticle /
+	Legislation / Dataset / Report / Article / Patent) plus Zotero COinS
+	(.Z3988) — see conceptio/docpage.py. This translator extracts from the
+	JSON-LD first (richest: sameAs, license, publisher, datePublished) and
+	falls back to the COinS span, then to XPath.
+
+	Item-type mapping follows CONCEPTIO_SEO Phase 6:
+	  ScholarlyArticle -> journalArticle
+	  Book            -> book
+	  TechArticle     -> report   (standards)
+	  Legislation     -> statute
+	  Dataset         -> dataset
+	  Report          -> report
+	  Article         -> document (contracts etc.)
+	  Patent          -> patent
+	  WebPage         -> webpage
+	Known case-law sources refine Legislation -> case (a court ruling is not
+	a statute).
+
+	The page snapshot is attached as text/html so the researcher keeps an
+	archived copy; `url` prefers the official source (sameAs) so
+	bibliographies cite the canonical location; `extra` records the Conceptio
+	archive record + license for provenance.
+*/
+
+var ITEM_TYPES = {
+	"ScholarlyArticle": "journalArticle",
+	"Book":             "book",
+	"TechArticle":      "report",
+	"Legislation":      "statute",
+	"Dataset":          "dataset",
+	"Report":           "report",
+	"Article":          "document",
+	"Patent":           "patent",
+	"Course":           "document",  // Zotero has no Course type
+	"VisualArtwork":    "artwork",
+	"WebPage":          "webpage"
+};
+
+// Case-law source labels rendered in the page meta line. A court ruling
+// saved as "statute" is wrong; these refine Legislation -> case.
+var CASE_LAW_HINTS = ["caselaw", "court", "hudoc", "cassazione", "costituzionale",
+	"dei conti", "giustizia"];
+
+function detectWeb(doc, url) {
+	var ld = _jsonld(doc);
+	var type = ld ? (ITEM_TYPES[ld["@type"]] || "document") : "document";
+	if (type === "statute" && _isCaseLaw(doc)) {
+		type = "case";
+	}
+	return type;
+}
+
+function doWeb(doc, url) {
+	var item = _itemFromJSONLD(doc, url);
+	if (!item) {
+		item = _itemFromCoins(doc, url);
+	}
+	if (!item) {
+		item = _itemFromXPath(doc, url);
+	}
+	item.complete();
+}
+
+/* ------------------------- JSON-LD (primary) ------------------------- */
+
+function _jsonld(doc) {
+	var scripts = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (var i = 0; i < scripts.length; i++) {
+		try {
+			var data = JSON.parse(scripts[i].textContent);
+		}
+		catch (e) {
+			continue;
+		}
+		var nodes = (data instanceof Array) ? data : [data];
+		for (var j = 0; j < nodes.length; j++) {
+			// The page carries one JSON-LD block; be tolerant of any graph
+			// wrapper and pick the node that names this document.
+			if (nodes[j] && (nodes[j]["@type"] || "").indexOf("WebSite") === -1
+					&& !(nodes[j]["@type"] instanceof Array)) {
+				return nodes[j];
+			}
+		}
+	}
+	return null;
+}
+
+function _itemFromJSONLD(doc, url) {
+	var ld = _jsonld(doc);
+	if (!ld) {
+		return null;
+	}
+	var type = ITEM_TYPES[ld["@type"]] || "document";
+	if (type === "statute" && _isCaseLaw(doc)) {
+		type = "case";
+	}
+	var item = new Zotero.Item(type);
+	item.title = ld.name || ZU.xpathText(doc, '//h1[@class="title"]');
+	item.url = ld.sameAs || ld.url || url;
+	item.libraryCatalog = "Conceptio";
+
+	if (ld.author) {
+		var authors = (ld.author instanceof Array) ? ld.author : [ld.author];
+		for (var i = 0; i < authors.length; i++) {
+			var author = authors[i] && authors[i].name;
+			if (!author) continue;
+			// The corpus stores authors APA-shaped: "Rose, Scott and Borghorst,
+			// Wendy". Split on " and "; comma-parts become person creators,
+			// no-comma names (orgs like "Joint Task Force", "European Union")
+			// become name-type creators so citations render them verbatim.
+			var parts = author.split(/\s+and\s+/i);
+			for (var p = 0; p < parts.length; p++) {
+				var part = parts[p].trim();
+				if (!part) continue;
+				if (part.indexOf(",") !== -1) {
+					item.creators.push(ZU.cleanAuthor(part, "author"));
+				}
+				else {
+					item.creators.push({ name: part, creatorType: "author" });
+				}
+			}
+		}
+	}
+	if (ld.datePublished) {
+		item.date = String(ld.datePublished).slice(0, 10);
+	}
+	var publisher = ld.publisher && (ld.publisher.name || ld.publisher);
+	if (publisher) {
+		if (type === "journalArticle" || type === "magazineArticle" || type === "newspaperArticle") {
+			item.publicationTitle = publisher;
+		}
+		else {
+			item.publisher = publisher;
+		}
+	}
+	if (ld.license) {
+		item.rights = ld.license;
+	}
+	if (ld.isAccessibleForFree) {
+		item.accessDate = Zotero.Utilities.strToISO(new Date().toISOString().slice(0, 10));
+	}
+
+	var abstract = _abstractText(doc);
+	if (abstract) {
+		item.abstractNote = abstract;
+	}
+
+	// Provenance in `extra` — the archive record + official source, so the
+	// citation carries where this came from (the archive's differentiator).
+	var extra = [];
+	if (ld.url) {
+		extra.push("Archive: Conceptio Open Knowledge Archive — " + ld.url);
+	}
+	if (ld.sameAs) {
+		extra.push("Official source: " + ld.sameAs);
+	}
+	if (item.extra) {
+		extra.unshift(item.extra);
+	}
+	item.extra = extra.join("\n");
+
+	item.attachments.push({
+		title: "Conceptio snapshot",
+		mimeType: "text/html",
+		url: ld.url || url
+	});
+	return item;
+}
+
+/* ---------------------- COinS / XPath fallbacks ---------------------- */
+
+function _itemFromCoins(doc, url) {
+	var span = doc.querySelector(".Z3988");
+	if (!span) {
+		return null;
+	}
+	return ZU.itemFromCOinS(span, doc);
+}
+
+function _itemFromXPath(doc, url) {
+	var type = detectWeb(doc, url);
+	var item = new Zotero.Item(type);
+	item.title = ZU.xpathText(doc, '//h1[@class="title"]');
+	item.url = url;
+	item.libraryCatalog = "Conceptio";
+	var meta = doc.getElementsByTagName("meta");
+	for (var i = 0; i < meta.length; i++) {
+		if (meta[i].getAttribute("name") === "description") {
+			item.abstractNote = meta[i].getAttribute("content");
+			break;
+		}
+	}
+	return item;
+}
+
+/* ------------------------------- helpers ------------------------------ */
+
+function _isCaseLaw(doc) {
+	var line = ZU.xpathText(doc, '//div[contains(@class,"meta")]/div');
+	line = line || "";
+	line = line.toLowerCase();
+	for (var i = 0; i < CASE_LAW_HINTS.length; i++) {
+		if (line.indexOf(CASE_LAW_HINTS[i]) !== -1) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function _abstractText(doc) {
+	var abs = ZU.xpathText(doc, '//div[contains(@class,"abstract")]');
+	if (abs) {
+		return ZU.trimInternal(abs);
+	}
+	return ZU.xpathText(doc, '//meta[@name="description"]/@content');
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		type: "web",
+		url: "https://www.conceptio.app/document/1/the-declaration-of-independence-of-the-united-states-of-america",
+		items: [
+			{
+				itemType: "book",
+				title: "The Declaration of Independence of the United States of America",
+				libraryCatalog: "Conceptio"
+			}
+		]
+	}
+];
+/** END TEST CASES **/

--- a/Conceptio.js
+++ b/Conceptio.js
@@ -281,7 +281,23 @@ var testCases = [
 						"lastName": "Nyuon",
 						"creatorType": "author"
 					}
-				]
+				],
+				"notes": [],
+				"tags": [],
+				"seeAlso": [],
+				"attachments": [
+					{
+						"title": "Conceptio snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"url": "https://doi.org/10.5281/zenodo.19537026",
+				"libraryCatalog": "Conceptio",
+				"publicationTitle": "Zenodo (CERN)",
+				"rights": "Open Access",
+				"abstractNote": "Humanitarian Response CERF, Response CERF Country-Based, CERF Country-Based Pooled, Country-Based Pooled Funds, African Union Perspective, Funding Mechanisms",
+				"extra": "Archive: Conceptio Open Knowledge Archive — https://www.conceptio.app/document/26040/funding-mechanisms-for-humanitarian-response-cerf-country-based-pooled\nOfficial source: https://doi.org/10.5281/zenodo.19537026",
+				"shortTitle": "Funding Mechanisms for Humanitarian Response"
 			}
 		]
 	}

--- a/Conceptio.js
+++ b/Conceptio.js
@@ -13,6 +13,28 @@
 }
 
 /*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Conceptio
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+/*
 	Conceptio — Open Knowledge Archive (https://www.conceptio.app)
 
 	Server-rendered document pages (/document/{id}/{slug}) carry a full
@@ -42,25 +64,32 @@
 */
 
 var ITEM_TYPES = {
-	"ScholarlyArticle": "journalArticle",
-	"Book":             "book",
-	"TechArticle":      "report",
-	"Legislation":      "statute",
-	"Dataset":          "dataset",
-	"Report":           "report",
-	"Article":          "document",
-	"Patent":           "patent",
-	"Course":           "document",  // Zotero has no Course type
-	"VisualArtwork":    "artwork",
-	"WebPage":          "webpage"
+	ScholarlyArticle: "journalArticle",
+	Book: "book",
+	TechArticle: "report",
+	Legislation: "statute",
+	Dataset: "dataset",
+	Report: "report",
+	Article: "document",
+	Patent: "patent",
+	Course: "document", // Zotero has no Course type
+	VisualArtwork: "artwork",
+	WebPage: "webpage"
 };
 
 // Case-law source labels rendered in the page meta line. A court ruling
 // saved as "statute" is wrong; these refine Legislation -> case.
-var CASE_LAW_HINTS = ["caselaw", "court", "hudoc", "cassazione", "costituzionale",
-	"dei conti", "giustizia"];
+var CASE_LAW_HINTS = [
+	"caselaw",
+	"court",
+	"hudoc",
+	"cassazione",
+	"costituzionale",
+	"dei conti",
+	"giustizia"
+];
 
-function detectWeb(doc, url) {
+function detectWeb(doc, _url) {
 	var ld = _jsonld(doc);
 	var type = ld ? (ITEM_TYPES[ld["@type"]] || "document") : "document";
 	if (type === "statute" && _isCaseLaw(doc)) {
@@ -95,7 +124,7 @@ function _jsonld(doc) {
 		for (var j = 0; j < nodes.length; j++) {
 			// The page carries one JSON-LD block; be tolerant of any graph
 			// wrapper and pick the node that names this document.
-			if (nodes[j] && (nodes[j]["@type"] || "").indexOf("WebSite") === -1
+			if (nodes[j] && !(nodes[j]["@type"] || "").includes("WebSite")
 					&& !(nodes[j]["@type"] instanceof Array)) {
 				return nodes[j];
 			}
@@ -131,7 +160,7 @@ function _itemFromJSONLD(doc, url) {
 			for (var p = 0; p < parts.length; p++) {
 				var part = parts[p].trim();
 				if (!part) continue;
-				if (part.indexOf(",") !== -1) {
+				if (part.includes(",")) {
 					item.creators.push(ZU.cleanAuthor(part, "author"));
 				}
 				else {
@@ -188,7 +217,7 @@ function _itemFromJSONLD(doc, url) {
 
 /* ---------------------- COinS / XPath fallbacks ---------------------- */
 
-function _itemFromCoins(doc, url) {
+function _itemFromCoins(doc, _url) {
 	var span = doc.querySelector(".Z3988");
 	if (!span) {
 		return null;
@@ -219,7 +248,7 @@ function _isCaseLaw(doc) {
 	line = line || "";
 	line = line.toLowerCase();
 	for (var i = 0; i < CASE_LAW_HINTS.length; i++) {
-		if (line.indexOf(CASE_LAW_HINTS[i]) !== -1) {
+		if (line.includes(CASE_LAW_HINTS[i])) {
 			return true;
 		}
 	}
@@ -237,15 +266,21 @@ function _abstractText(doc) {
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
-		type: "web",
-		url: "https://www.conceptio.app/document/1/the-declaration-of-independence-of-the-united-states-of-america",
-		items: [
+		"type": "web",
+		"url": "https://www.conceptio.app/document/26040/funding-mechanisms-for-humanitarian-response-cerf-country-based-pooled",
+		"items": [
 			{
-				itemType: "book",
-				title: "The Declaration of Independence of the United States of America",
-				libraryCatalog: "Conceptio"
+				"itemType": "journalArticle",
+				"title": "Funding Mechanisms for Humanitarian Response: CERF, Country-Based Pooled Funds, and Donor Trends: An African Union Perspective",
+				"creators": [
+					{
+						"firstName": "Abraham Kuol",
+						"lastName": "Nyuon",
+						"creatorType": "author"
+					}
+				]
 			}
 		]
 	}
-];
+]
 /** END TEST CASES **/


### PR DESCRIPTION
## New translator: Conceptio — Open Knowledge Archive

Web translator for server-rendered document pages on **Conceptio** (`https://www.conceptio.app/document/{id}/{slug}`), an open-access archive of ~580k authoritative documents (papers, standards, legislation, case law, patents, books).

### How it extracts

The pages carry a complete schema.org JSON-LD block (rendered server-side), so the translator parses that first — richest source (has `sameAs`, `license`, `publisher`, `datePublished`) — with Zotero COinS (`.Z3988`) and XPath fallbacks for robustness.

Item-type mapping (per the archive's category taxonomy):

| JSON-LD @type | Zotero item type |
|---|---|
| `ScholarlyArticle` | `journalArticle` |
| `Book` | `book` |
| `TechArticle` (standards) | `report` |
| `Legislation` | `statute` (refined to `case` for known case-law sources) |
| `Dataset` | `dataset` |
| `Report` | `report` |
| `Article` (contracts) | `document` |
| `Patent` | `patent` |
| `VisualArtwork` | `artwork` |

Other behavior:
- Authors split from the corpus's APA shape (`"Rose, Scott and Borghorst, Wendy"` → two creators); organization names without a comma become name-type creators so citations render them verbatim.
- `url` prefers the official source (`sameAs`, e.g. the arXiv DOI or Gutenberg page) so bibliographies cite the canonical location; the archive page URL + license go into `extra` (provenance — the archive's differentiator).
- The Conceptio page is attached as a `text/html` snapshot so the researcher keeps an archived copy.
- Detection covers both the current `conceptio.app` origin and the planned `conceptio.com` domain.

### Test

One web test case against a stable, permanent document page (id 1 — the corpus's first row; URLs are id-canonical and permanent by design).